### PR TITLE
[WIP] V4P5: feat(buildpack): Create CLI wizard to make getting started easier

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -59,3 +59,4 @@ Add any ideas about possible solutions to the problem here.
 - [ ] `pwa-devdocs`
 - [ ] `upward-js`
 - [ ] `upward-spec`
+- [ ] `create-pwa`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -38,3 +38,4 @@ Add any other context or screenshots about the feature request here.
 - [ ] `pwa-devdocs`
 - [ ] `upward-js`
 - [ ] `upward-spec`
+- [ ] `create-pwa`

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,6 +14,7 @@ RUN apk --no-cache --virtual add \
     yarn
 
 # copy just the dependency files and configs needed for install
+COPY packages/create-pwa/package.json ./packages/create-pwa/package.json
 COPY packages/babel-preset-peregrine/package.json ./packages/babel-preset-peregrine/package.json
 COPY packages/graphql-cli-validate-magento-pwa-queries/package.json ./packages/graphql-cli-validate-magento-pwa-queries/package.json
 COPY packages/peregrine/package.json ./packages/peregrine/package.json

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -10,6 +10,7 @@ RUN apk --no-cache --virtual add \
     yarn
 
 # copy just the dependency files and configs needed for install
+COPY packages/create-pwa/package.json ./packages/create-pwa/package.json
 COPY packages/babel-preset-peregrine/package.json ./packages/babel-preset-peregrine/package.json
 COPY packages/graphql-cli-validate-magento-pwa-queries/package.json ./packages/graphql-cli-validate-magento-pwa-queries/package.json
 COPY packages/peregrine/package.json ./packages/peregrine/package.json

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "workspaces": [
     "packages/babel-preset-peregrine",
+    "packages/create-pwa",
     "packages/graphql-cli-validate-magento-pwa-queries",
     "packages/peregrine",
     "packages/pwa-buildpack",

--- a/packages/create-pwa/bin/create-pwa
+++ b/packages/create-pwa/bin/create-pwa
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../')();

--- a/packages/create-pwa/lib/index.js
+++ b/packages/create-pwa/lib/index.js
@@ -1,0 +1,143 @@
+const { basename, resolve } = require('path');
+const os = require('os');
+const changeCase = require('change-case');
+const inquirer = require('inquirer');
+const execa = require('execa');
+const chalk = require('chalk');
+const gitUserInfo = require('git-user-info');
+const isInvalidPath = require('is-invalid-path');
+const isValidNpmName = require('is-valid-npm-name');
+const pkg = require('../package.json');
+const {
+    sampleBackends
+} = require('@magento/pwa-buildpack/lib/cli/create-project');
+
+module.exports = async () => {
+    console.log(chalk.greenBright(`${pkg.name} v${pkg.version}`));
+    console.log(
+        chalk.white(`Creating a ${chalk.whiteBright('venia-concept')} project`)
+    );
+    const userAgent = process.env.npm_config_user_agent || '';
+    const isYarn = userAgent.includes('yarn');
+
+    const questions = [
+        {
+            name: 'directory',
+            message:
+                'Project root directory (will be created if it does not exist)',
+            validate: dir =>
+                !dir
+                    ? 'Please enter a directory path'
+                    : isInvalidPath(dir)
+                    ? 'Invalid directory path; contains illegal characters'
+                    : true
+        },
+        {
+            name: 'name',
+            message:
+                'Short name of the project to put in the package.json "name" field',
+            validate: isValidNpmName,
+            default: ({ directory }) => basename(directory)
+        },
+        {
+            name: 'author',
+            message:
+                'Name of the author to put in the package.json "author" field',
+            default: () => {
+                const userInfo = os.userInfo();
+                let author = userInfo.username;
+                const gitInfo = gitUserInfo({
+                    path: resolve(userInfo.homedir, '.gitconfig')
+                });
+
+                if (gitInfo) {
+                    author = gitInfo.name;
+                    if (gitInfo.email) {
+                        author += ` <${gitInfo.email}>`;
+                    }
+                }
+                return author;
+            }
+        },
+        {
+            name: 'backendUrl',
+            type: 'list',
+            message:
+                'Sample Magento 2.3 instance to use as a backend (will be added to `.env` file)',
+            choices: sampleBackends.environments
+                .map(({ name, description, url }) => ({
+                    name: description,
+                    value: url,
+                    short: name
+                }))
+                .concat([
+                    {
+                        name:
+                            'Other (I will provide my own backing Magento 2.3.1 instance)',
+                        value: false,
+                        short: 'Other'
+                    }
+                ])
+        },
+        {
+            name: 'customBackendUrl',
+            message:
+                'URL of a Magento 2.3 instance to use as a backend (will be added to `.env` file)',
+            default: 'https://magento2.localhost',
+            when: ({ backendUrl }) => !backendUrl
+        },
+        {
+            name: 'npmClient',
+            type: 'list',
+            message: 'NPM package management client to use',
+            choices: ['npm', 'yarn'],
+            default: isYarn ? 'yarn' : 'npm'
+        },
+        {
+            name: 'install',
+            type: 'confirm',
+            message: ({ npmClient }) =>
+                `Install package dependencies with ${npmClient} after creating project`,
+            default: true
+        }
+    ];
+    let answers;
+    try {
+        answers = await inquirer.prompt(questions);
+    } catch (e) {
+        console.error('App creation cancelled.');
+    }
+    answers.backendUrl = answers.backendUrl || answers.customBackendUrl;
+    const args = questions.reduce(
+        (args, q) => {
+            if (q.name === 'customBackendUrl' || q.name === 'directory') {
+                return args;
+            }
+            const answer = answers[q.name];
+            const option = changeCase.paramCase(q.name);
+            if (q.type === 'confirm') {
+                if (answer !== q.default) {
+                    return [...args, answer ? `--${option}` : `--no-${option}`];
+                }
+                return args;
+            }
+            return [...args, `--${option}`, `"${answer}"`];
+        },
+        ['create-project', answers.directory, '--template', '"venia-concept"']
+    );
+
+    const argsString = args.join(' ');
+
+    console.log(
+        '\nRunning command: \n\n' +
+            chalk.whiteBright(`buildpack ${argsString}\n\n`)
+    );
+
+    const buildpackBinLoc = resolve(
+        require.resolve('@magento/pwa-buildpack'),
+        '../../bin/buildpack'
+    );
+    await execa.shell(`${buildpackBinLoc} ${argsString}`, {
+        stdio: 'inherit'
+    });
+};

--- a/packages/create-pwa/package.json
+++ b/packages/create-pwa/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@magento/create-pwa",
+  "version": "1.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Create a PWA Studio app with a single command.",
+  "main": "./lib/index.js",
+  "bin": "./bin/create-pwa",
+  "scripts": {
+    "build": " ",
+    "build:ci": " ",
+    "build:dev": " ",
+    "clean": " ",
+    "test": " "
+  },
+  "repository": "github:magento-research/pwa-studio",
+  "keywords": [
+    "magento",
+    "pwa",
+    "create-pwa",
+    "create-pwa-app",
+    "pwa-studio"
+  ],
+  "author": "Magento Commerce",
+  "license": "(OSL-3.0 OR AFL-3.0)",
+  "bugs": {
+    "url": "https://github.com/magento-research/pwa-studio/issues"
+  },
+  "homepage": "https://github.com/magento-research/pwa-studio/tree/master/packages/create-pwa#readme",
+  "dependencies": {
+    "@magento/pwa-buildpack": "~3.0.0",
+    "chalk": "^2.4.2",
+    "change-case": "^3.1.0",
+    "execa": "^1.0.0",
+    "git-user-info": "^1.0.1",
+    "inquirer": "^6.3.1",
+    "is-invalid-path": "^1.0.2",
+    "is-valid-npm-name": "^0.0.4",
+    "webpack": "^4.29.5"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7997,6 +7997,16 @@ git-url-parse@^11.1.2:
   dependencies:
     git-up "^4.0.0"
 
+git-user-info@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/git-user-info/-/git-user-info-1.0.1.tgz#1f5abcfc77c4e38ca19ffe572e35fbd22dfeff59"
+  integrity sha1-H1q8/HfE44yhn/5XLjX70i3+/1k=
+  dependencies:
+    extend-shallow "^2.0.1"
+    git-config-path "^1.0.1"
+    in-publish "^2.0.0"
+    parse-git-config "^1.1.1"
+
 gitconfiglocal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz#41d045f3851a5ea88f03f24ca1c6178114464b9b"
@@ -8955,6 +8965,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+  integrity sha1-4g/146KvwmkDILbcVSaCqcf631E=
+
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
@@ -9056,7 +9071,7 @@ inquirer@6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^6.2.0, inquirer@^6.2.2:
+inquirer@^6.2.0, inquirer@^6.2.2, inquirer@^6.3.1:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
   integrity sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==
@@ -9313,6 +9328,11 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
+is-invalid-path@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-invalid-path/-/is-invalid-path-1.0.2.tgz#2f84731559f4936abcf1b227632719cf45c5dc0e"
+  integrity sha512-6KLcFrPCEP3AFXMfnWrIFkZpYNBVzZAoBJJDEZKtI3LXkaDjM3uFMJQjxiizUuZTZ9Oh9FNv/soXbx5TcpaDmA==
+
 is-lower-case@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-1.1.3.tgz#7e147be4768dc466db3bfb21cc60b31e6ad69393"
@@ -9494,7 +9514,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-valid-npm-name@~0.0.4:
+is-valid-npm-name@^0.0.4, is-valid-npm-name@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/is-valid-npm-name/-/is-valid-npm-name-0.0.4.tgz#a1b54efb539bd8565188a4b265ceedec9602c9c2"
   integrity sha512-9s0d84feee8/IF9dCzp9q/Tsv2aatPN10UIcM1oDKa+m7HpiUrYE2UvGq+2A0nAOTJyt6BHR7TOty1sPsBxlxw==
@@ -12153,6 +12173,16 @@ parse-diff@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.5.1.tgz#18b3e82a0765ac1c8796e3854e475073a691c4fb"
   integrity sha512-/qXjo9x/pFa5bVk/ZXaJD0yr3Tf3Yp6MWWMr4vnUmumDrE0yoE6YDH2A8vmcCD/Ko3tW2o0X+zGYh2zMLXshsg==
+
+parse-git-config@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/parse-git-config/-/parse-git-config-1.1.1.tgz#d3a9984317132f57398712bba438e129590ddf8c"
+  integrity sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=
+  dependencies:
+    extend-shallow "^2.0.1"
+    fs-exists-sync "^0.1.0"
+    git-config-path "^1.0.1"
+    ini "^1.3.4"
 
 parse-git-config@^2.0.3:
   version "2.0.3"
@@ -16132,7 +16162,7 @@ webpack-sources@^1.0.0, webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.23.1:
+webpack@^4.23.1, webpack@^4.29.5:
   version "4.38.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.38.0.tgz#6d77108404b08883c78f4e7e45a43c4e5c47c931"
   integrity sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==


### PR DESCRIPTION
⚠️ **This PR is merge-based on #1500 and is blocked until that PR is merged.**

## Description

Add an [NPM initializer](https://docs.npmjs.com/cli/init) for creating a PWA Studio project using a friendly questionnaire.

An NPM package whose name begins with `create-` (disregarding `@scope`) can be used as a project generator. It is expected to expose one CLI command that will be run when a developer runs `npm init <package_name_minus_create_prefix>`.

Our initializer is called `@magento/create-pwa`, so the command to use it in NPM is:

```sh
npm init @magento/pwa
```

Or in Yarn:

```sh
yarn create @magento/pwa
```

ℹ️ _Warning: Yarn can't use globally linked modules in its "create", so it's hard to test the Yarn command._


## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. From a fresh clone and install of the repo:
2. `cd packages/create-pwa`
3. `npm link` (this will run a longish install process
4. CD to the root directory for your projects in flight
5. Run `npm init @magento/pwa` and answer the questions

Expected Result: Jubilance and pride.

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [x] minor (e.g 0.x.0 - a backwards compatible addition)
- [ ] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
