### PR TITLE
Add publishConfig keys to upward-spec and upward-js

### DIFF
--- a/packages/upward-js/package.json
+++ b/packages/upward-js/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@magento/upward-js",
   "version": "2.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Implementation of the UPWARD spec as a NodeJS server",
   "main": "./lib/index.js",
   "bin": {

--- a/packages/upward-spec/package.json
+++ b/packages/upward-spec/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@magento/upward-spec",
   "version": "2.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "UPWARD specification, guide, and test suite.",
   "main": "./suite/index.js",
   "bin": {


### PR DESCRIPTION
## Description
Add missing publishConfig key in package.json for upward-spec and upward-js packages

## Related Issue
Closes #1543 

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Run regression scripts

## Screenshots / Screen Captures (if appropriate)

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://pwastudio.io/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.
