### PR TITLE
Fixed issue #1549 Signed in customer access to create account page

### DIFF
--- a/packages/venia-ui/lib/components/CreateAccount/container.js
+++ b/packages/venia-ui/lib/components/CreateAccount/container.js
@@ -2,9 +2,10 @@ import { connect } from '@magento/venia-drivers';
 import CreateAccount from './createAccount';
 
 const mapStateToProps = ({ user }) => {
-    const { createAccountError } = user;
+    const { createAccountError, isSignedIn } = user;
     return {
-        createAccountError
+        createAccountError,
+        isSignedIn
     };
 };
 

--- a/packages/venia-ui/lib/components/CreateAccount/createAccount.js
+++ b/packages/venia-ui/lib/components/CreateAccount/createAccount.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Redirect } from '@magento/venia-drivers';
 import { func, shape, string } from 'prop-types';
 import { Form } from 'informed';
 
@@ -74,7 +75,10 @@ class CreateAccount extends Component {
 
     render() {
         const { errorMessage, handleSubmit, initialValues, props } = this;
-        const { classes } = props;
+        const { classes, isSignedIn } = props;
+        if (isSignedIn) {
+            return <Redirect to="/" />;
+        }
 
         return (
             <Form


### PR DESCRIPTION
Issue #1549 Fixed (Sign in customer access create account page)
## Description

1. Sign in with customer detail .
2. Now open create account page 
3. You are able to access create account page . Which is wrong customer need to redirect on home page or my account section.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Sign in with customer detail .
2. Now open create account page 
3. Now customer redirect to homepage.

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://pwastudio.io/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

Closes #1549