### PR TITLE
Removes version checklist from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,6 @@ Closes #ISSUE_NUMBER.
 ## Screenshots / Screen Captures (if appropriate)
 
 ## Checklist
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have updated the documentation accordingly, if necessary.
-- [ ] I have added tests to cover my changes, if necessary.
+<!--- Go over all the following points, and make sure you've done anything necessary -->
+* I have updated the documentation accordingly, if necessary.
+* I have added tests to cover my changes, if necessary.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,15 +30,7 @@ Closes #ISSUE_NUMBER.
 
 ## Screenshots / Screen Captures (if appropriate)
 
-## Proposed Labels for Change Type/Package
-<!--- What type of change level would you suggest for this PR? -->
-<!--- Major, Minor, or Patch? -->
-<!--- See https://pwastudio.io/technologies/versioning/ for help -->
-- [ ] major (e.g x.0.0 - a breaking change)
-- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
-- [ ] patch (e.g 0.0.x - a bug fix)
-
-## Checklist:
+## Checklist
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have updated the documentation accordingly, if necessary.


### PR DESCRIPTION
## Description

Removes the checklists from pr template

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Ensure danger is not complaining about a missing version section IN the PR. It'll still complain if the label is missing.

## Screenshots / Screen Captures (if appropriate)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
