### PR TITLE
Removes errant debugger statement in test file

### DIFF
--- a/packages/pwa-buildpack/lib/Utilities/__tests__/loadEnvironment.spec.js
+++ b/packages/pwa-buildpack/lib/Utilities/__tests__/loadEnvironment.spec.js
@@ -357,7 +357,6 @@ test('returns configuration object', () => {
         GEWGAW_ROGUE: 'level 4'
     };
     const config = loadEnvironment({ ...party, NODE_ENV: 'test' });
-    debugger;
     expect(config).toMatchObject({
         isProd: false,
         isProduction: false,


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

There was an errant `debugger` statement left in a code file that would cause `yarn run test:debug` to pause execution when hit.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1555.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->

You can run `yarn run test:debug` and attach a debugger and ensure that it doesn't break, or you can manually verify that I have deleted this `debugger` statement.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
