### PR TITLE
Use eval-source-map instead of cheap-source-map for devtool

### DIFF
--- a/packages/pwa-buildpack/lib/WebpackTools/configureWebpack.js
+++ b/packages/pwa-buildpack/lib/WebpackTools/configureWebpack.js
@@ -269,7 +269,10 @@ async function configureWebpack({ context, vendor = [], special = {}, env }) {
         });
 
         if (isDevServer()) {
-            config.devtool = 'cheap-source-map';
+            // Using eval-source-map shows original source (non-transpiled) as
+            // well as comments.
+            // See https://webpack.js.org/configuration/devtool/
+            config.devtool = 'eval-source-map';
 
             await PWADevServer.configure(
                 {


### PR DESCRIPTION
## Description

Switches us to `eval-source-map`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. `yarn watch:all` and inspect some source code like `minicart.js` it should be non-transpiled and have comments

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
