### PR TITLE
Changed prop type of uniqueID for Item component.

### DIFF
--- a/packages/peregrine/lib/List/item.js
+++ b/packages/peregrine/lib/List/item.js
@@ -54,7 +54,8 @@ Item.propTypes = {
     item: PropTypes.any.isRequired,
     itemIndex: PropTypes.number.isRequired,
     render: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired,
-    uniqueID: PropTypes.number
+    uniqueID: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+        .isRequired
 };
 
 Item.defaultProps = {


### PR DESCRIPTION
## Description

uniqueID prop check was failing since it was mentioned that uniqueID will be a number but in case of `category` component which internally uses `item`, it can be a string as well.

So no more errors like this:

![image](https://user-images.githubusercontent.com/35203638/63462253-1b728b80-c420-11e9-9785-a63df8369ff8.png)

## Related Issue
None. No issue for this. It is just a dev fix.
Closes nothing.

## Verification Steps
No more console errors related to prop types.

## Checklist
Check the console for prop types errors in category and product pages.