### PR TITLE
fix test config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,8 +45,7 @@ const testVenia = inPackage => ({
     browser: true,
     moduleNameMapper: {
         // Mock binary files to avoid excess RAM usage.
-        '\\.(jpg|jpeg|png)$':
-            '<rootDir>/packages/venia-ui/__mocks__/fileMock.js',
+        '\\.(jpg|jpeg|png)$': inPackage('__mocks__/fileMock.js'),
         // CSS module classes are dynamically generated, but that makes
         // it hard to test React components using DOM classnames.
         // This mapping forces CSS Modules to return literal identies,

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,8 @@ const testVenia = inPackage => ({
     browser: true,
     moduleNameMapper: {
         // Mock binary files to avoid excess RAM usage.
-        '\\.(jpg|jpeg|png)$': inPackage('__mocks__/fileMock.js'),
+        '\\.(jpg|jpeg|png)$':
+            '<rootDir>/packages/venia-ui/__mocks__/fileMock.js',
         // CSS module classes are dynamically generated, but that makes
         // it hard to test React components using DOM classnames.
         // This mapping forces CSS Modules to return literal identies,

--- a/packages/venia-concept/__mocks__/fileMock.js
+++ b/packages/venia-concept/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';


### PR DESCRIPTION
# Description

OK here's why it's broken.

`jest.config.js` uses `inPackage` to create a path to things in configs. It's a fancy helper for resolving paths. The specific problem is that `__mocks__/fileMock.js` does not exist in `venia-concept`. I _think_ that jest caches some things after running which is why you may or may not see this issue but I assure you it is a problem. If you do a clean checkout into a new directory you should see it happen.

So, we can solve this one of two ways.

1) Any test config using `testVenia` hardcodes a path to `__mocks__/fileMock.js` in `venia-ui`.

2) Create the `__mocks__/fileMock.js` in `venia-concept`.

Personally I don't care what we chose but it _is_ broken and we should fix it.

# Verification

1) `yarn test:dev`/`jest --watch` doesn't break.
