### PR TITLE
Provide app state via context

### DIFF
--- a/packages/venia-ui/lib/components/App/container.js
+++ b/packages/venia-ui/lib/components/App/container.js
@@ -1,39 +1,23 @@
-import React, { Component } from 'react';
-import { connect } from '@magento/venia-drivers';
+import React, { useContext } from 'react';
 
-import appActions, { closeDrawer } from '../../actions/app';
 import App from './app';
+import { useErrorBoundary } from './useErrorBoundary';
+import { AppContext } from '../../context/app';
+import { ErrorContext } from '../../context/unhandledErrors';
 
-class AppContainer extends Component {
-    static get initialState() {
-        return {
-            renderError: null
-        };
-    }
+const AppContainer = () => {
+    const ErrorBoundary = useErrorBoundary(App);
+    const [appState, appApi] = useContext(AppContext);
+    const [unhandledErrors, errorApi] = useContext(ErrorContext);
 
-    static getDerivedStateFromError(renderError) {
-        return { renderError };
-    }
-
-    state = AppContainer.initialState;
-
-    render() {
-        const { renderError } = this.state;
-        return <ConnectedApp renderError={renderError} />;
-    }
-}
-
-const mapStateToProps = ({ app, unhandledErrors }) => ({
-    app,
-    unhandledErrors
-});
-
-const { markErrorHandled } = appActions;
-const mapDispatchToProps = { closeDrawer, markErrorHandled };
-
-const ConnectedApp = connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(App);
+    return (
+        <ErrorBoundary
+            unhandledErrors={unhandledErrors}
+            app={appState}
+            {...appApi}
+            {...errorApi}
+        />
+    );
+};
 
 export default AppContainer;

--- a/packages/venia-ui/lib/components/App/contextProvider.js
+++ b/packages/venia-ui/lib/components/App/contextProvider.js
@@ -1,10 +1,12 @@
 import React from 'react';
-
 import {
     PeregrineContextProvider as Peregrine,
     ToastContextProvider,
     WindowSizeContextProvider
 } from '@magento/peregrine';
+
+import AppContextProvider from '../../context/app';
+import ErrorContextProvider from '../../context/unhandledErrors';
 
 /**
  * List of context providers that are required to run Venia
@@ -13,14 +15,16 @@ import {
  */
 const contextProviders = [
     Peregrine,
+    AppContextProvider,
+    ErrorContextProvider,
     WindowSizeContextProvider,
     ToastContextProvider
 ];
 
-const AppContextProvider = ({ children }) => {
+const ContextProvider = ({ children }) => {
     return contextProviders.reduceRight((memo, ContextProvider) => {
         return <ContextProvider>{memo}</ContextProvider>;
     }, children);
 };
 
-export default AppContextProvider;
+export default ContextProvider;

--- a/packages/venia-ui/lib/components/App/contextProvider.js
+++ b/packages/venia-ui/lib/components/App/contextProvider.js
@@ -6,7 +6,9 @@ import {
 } from '@magento/peregrine';
 
 import AppContextProvider from '../../context/app';
+import CatalogContextProvider from '../../context/catalog';
 import ErrorContextProvider from '../../context/unhandledErrors';
+import UserContextProvider from '../../context/user';
 
 /**
  * List of context providers that are required to run Venia
@@ -16,6 +18,8 @@ import ErrorContextProvider from '../../context/unhandledErrors';
 const contextProviders = [
     Peregrine,
     AppContextProvider,
+    UserContextProvider,
+    CatalogContextProvider,
     ErrorContextProvider,
     WindowSizeContextProvider,
     ToastContextProvider

--- a/packages/venia-ui/lib/components/App/contextProvider.js
+++ b/packages/venia-ui/lib/components/App/contextProvider.js
@@ -6,7 +6,9 @@ import {
 } from '@magento/peregrine';
 
 import AppContextProvider from '../../context/app';
+import CartContextProvider from '../../context/cart';
 import CatalogContextProvider from '../../context/catalog';
+import CheckoutContextProvider from '../../context/checkout';
 import ErrorContextProvider from '../../context/unhandledErrors';
 import UserContextProvider from '../../context/user';
 
@@ -17,10 +19,12 @@ import UserContextProvider from '../../context/user';
  */
 const contextProviders = [
     Peregrine,
+    ErrorContextProvider,
     AppContextProvider,
     UserContextProvider,
     CatalogContextProvider,
-    ErrorContextProvider,
+    CartContextProvider,
+    CheckoutContextProvider,
     WindowSizeContextProvider,
     ToastContextProvider
 ];

--- a/packages/venia-ui/lib/components/App/useErrorBoundary.js
+++ b/packages/venia-ui/lib/components/App/useErrorBoundary.js
@@ -1,0 +1,30 @@
+import React, { Component, useMemo } from 'react';
+
+export const useErrorBoundary = WrappedComponent =>
+    useMemo(
+        () =>
+            class ErrorBoundary extends Component {
+                constructor(props) {
+                    super(props);
+
+                    this.state = { renderError: null };
+                }
+
+                static getDerivedStateFromError(renderError) {
+                    return { renderError };
+                }
+
+                render() {
+                    const { props, state } = this;
+                    const { renderError } = state;
+
+                    return (
+                        <WrappedComponent
+                            {...props}
+                            renderError={renderError}
+                        />
+                    );
+                }
+            },
+        []
+    );

--- a/packages/venia-ui/lib/components/AuthBar/authBar.js
+++ b/packages/venia-ui/lib/components/AuthBar/authBar.js
@@ -2,8 +2,8 @@ import React, { useCallback, useContext } from 'react';
 import { bool, func, shape, string } from 'prop-types';
 
 import { mergeClasses } from '../../classify';
+import { UserContext } from '../../context/user';
 import Button from '../Button';
-import { UserContext } from '../Navigation';
 import UserChip from './userChip';
 import defaultClasses from './authBar.css';
 

--- a/packages/venia-ui/lib/components/AuthModal/authModal.js
+++ b/packages/venia-ui/lib/components/AuthModal/authModal.js
@@ -2,11 +2,11 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { func, shape, string } from 'prop-types';
 
 import { mergeClasses } from '../../classify';
+import { UserContext } from '../../context/user';
 import CreateAccount from '../CreateAccount';
 import ForgotPassword from '../ForgotPassword';
 import MyAccount from '../MyAccount';
 import SignIn from '../SignIn';
-import { UserContext } from '../Navigation';
 import defaultClasses from './authModal.css';
 
 const UNAUTHED_ONLY = ['CREATE_ACCOUNT', 'FORGOT_PASSWORD', 'SIGN_IN'];

--- a/packages/venia-ui/lib/components/Navigation/__tests__/navigation.spec.js
+++ b/packages/venia-ui/lib/components/Navigation/__tests__/navigation.spec.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { act } from 'react-test-renderer';
 import { createTestInstance } from '@magento/peregrine';
 
+import { AppContext } from '../../../context/app';
+import { CatalogContext } from '../../../context/catalog';
+import { UserContext } from '../../../context/user';
 import AuthModal from '../../AuthModal';
 import CategoryTree from '../../CategoryTree';
-import { AppContext, CatalogContext, UserContext } from '../container';
 import NavHeader from '../navHeader';
 import Navigation from '../navigation';
 
@@ -13,6 +15,19 @@ jest.mock('../../AuthBar', () => () => <i />);
 jest.mock('../../AuthModal', () => () => <i />);
 jest.mock('../../CategoryTree', () => () => <i />);
 jest.mock('../navHeader', () => () => <i />);
+
+jest.mock('../../../context/app', () => {
+    const { createContext } = require('react');
+    return { AppContext: createContext() };
+});
+jest.mock('../../../context/catalog', () => {
+    const { createContext } = require('react');
+    return { CatalogContext: createContext() };
+});
+jest.mock('../../../context/user', () => {
+    const { createContext } = require('react');
+    return { UserContext: createContext() };
+});
 
 const mockAppContext = [{ drawer: 'nav' }, { closeDrawer: jest.fn() }];
 
@@ -28,16 +43,6 @@ const mockCatalogContext = [
 ];
 
 const mockUserContext = [{}, { getUserDetails: jest.fn() }];
-
-jest.mock('../container', () => {
-    const { createContext } = require('react');
-
-    return {
-        AppContext: createContext(),
-        CatalogContext: createContext(),
-        UserContext: createContext()
-    };
-});
 
 const MockContext = props => (
     <AppContext.Provider value={mockAppContext}>

--- a/packages/venia-ui/lib/components/Navigation/index.js
+++ b/packages/venia-ui/lib/components/Navigation/index.js
@@ -1,3 +1,2 @@
-export { default, AppContext, CatalogContext, UserContext } from './container';
+export { default } from './navigation';
 export { default as NavHeader } from './navHeader';
-export { default as Navigation } from './navigation';

--- a/packages/venia-ui/lib/components/Navigation/navigation.js
+++ b/packages/venia-ui/lib/components/Navigation/navigation.js
@@ -22,7 +22,9 @@ const ancestors = {
 const Navigation = props => {
     // retrieve app state from context
     const [appState, { closeDrawer }] = useContext(AppContext);
-    const [catalogState, { updateCategories }] = useContext(CatalogContext);
+    const [catalogState, { actions: catalogActions }] = useContext(
+        CatalogContext
+    );
     const [, { getUserDetails }] = useContext(UserContext);
 
     // request data from server
@@ -94,7 +96,7 @@ const Navigation = props => {
                     categories={categories}
                     onNavigate={closeDrawer}
                     setCategoryId={setCategoryId}
-                    updateCategories={updateCategories}
+                    updateCategories={catalogActions.updateCategories}
                 />
             </div>
             <div className={classes.footer}>

--- a/packages/venia-ui/lib/components/Navigation/navigation.js
+++ b/packages/venia-ui/lib/components/Navigation/navigation.js
@@ -2,10 +2,12 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { shape, string } from 'prop-types';
 
 import { mergeClasses } from '../../classify';
+import { AppContext } from '../../context/app';
+import { CatalogContext } from '../../context/catalog';
+import { UserContext } from '../../context/user';
 import AuthBar from '../AuthBar';
 import AuthModal from '../AuthModal';
 import CategoryTree from '../CategoryTree';
-import { AppContext, CatalogContext, UserContext } from './container';
 import NavHeader from './navHeader';
 import defaultClasses from './navigation.css';
 

--- a/packages/venia-ui/lib/context/__tests__/app.spec.js
+++ b/packages/venia-ui/lib/context/__tests__/app.spec.js
@@ -1,0 +1,77 @@
+import React, { useContext, useEffect } from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import AppContextProvider, { AppContext } from '../app';
+
+jest.mock('@magento/venia-drivers', () => ({
+    connect: jest.fn((mapStateToProps, mapDispatchToProps) =>
+        jest.fn(Component => ({
+            Component: jest.fn(Component),
+            mapDispatchToProps,
+            mapStateToProps
+        }))
+    )
+}));
+
+const log = jest.fn();
+const Consumer = jest.fn(() => {
+    const contextValue = useContext(AppContext);
+
+    useEffect(() => {
+        log(contextValue);
+    }, [contextValue]);
+
+    return <i />;
+});
+
+test('returns a connected component', () => {
+    const { mapDispatchToProps, mapStateToProps } = AppContextProvider;
+
+    expect(mapStateToProps).toBeInstanceOf(Function);
+    expect(mapDispatchToProps).toEqual({
+        closeDrawer: expect.any(Function)
+    });
+});
+
+test('mapStateToProps maps state to props', () => {
+    const { mapStateToProps } = AppContextProvider;
+    const include = { app: 'a' };
+    const exclude = { foo: 'b' };
+    const state = { ...include, ...exclude };
+
+    expect(mapStateToProps(state)).toEqual(include);
+});
+
+test('renders children', () => {
+    const { Component } = AppContextProvider;
+    const symbol = Symbol();
+    const { root } = createTestInstance(
+        <Component>
+            <i symbol={symbol} />
+        </Component>
+    );
+
+    expect(root.findByProps({ symbol })).toBeTruthy();
+});
+
+test('provides state and actions via context', () => {
+    const { Component } = AppContextProvider;
+    const props = {
+        app: 'app',
+        closeDrawer: jest.fn()
+    };
+
+    createTestInstance(
+        <Component {...props}>
+            <Consumer />
+        </Component>
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenNthCalledWith(1, [
+        props.app,
+        expect.objectContaining({
+            closeDrawer: props.closeDrawer
+        })
+    ]);
+});

--- a/packages/venia-ui/lib/context/__tests__/cart.spec.js
+++ b/packages/venia-ui/lib/context/__tests__/cart.spec.js
@@ -1,0 +1,95 @@
+import React, { useContext, useEffect } from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import CartContextProvider, { CartContext } from '../cart';
+
+jest.mock('@magento/venia-drivers', () => ({
+    connect: jest.fn((mapStateToProps, mapDispatchToProps) =>
+        jest.fn(Component => ({
+            Component: jest.fn(Component),
+            mapDispatchToProps,
+            mapStateToProps
+        }))
+    )
+}));
+
+const log = jest.fn();
+const Consumer = jest.fn(() => {
+    const contextValue = useContext(CartContext);
+
+    useEffect(() => {
+        log(contextValue);
+    }, [contextValue]);
+
+    return <i />;
+});
+
+test('returns a connected component', () => {
+    const { mapDispatchToProps, mapStateToProps } = CartContextProvider;
+
+    expect(mapStateToProps).toBeInstanceOf(Function);
+    expect(mapDispatchToProps).toEqual({
+        addItemToCart: expect.any(Function),
+        beginEditItem: expect.any(Function),
+        createCart: expect.any(Function),
+        endEditItem: expect.any(Function),
+        getCartDetails: expect.any(Function),
+        removeItemFromCart: expect.any(Function),
+        updateItemInCart: expect.any(Function)
+    });
+});
+
+test('mapStateToProps maps state to props', () => {
+    const { mapStateToProps } = CartContextProvider;
+    const include = { cart: 'a' };
+    const exclude = { foo: 'b' };
+    const state = { ...include, ...exclude };
+
+    expect(mapStateToProps(state)).toEqual(include);
+});
+
+test('renders children', () => {
+    const { Component } = CartContextProvider;
+    const symbol = Symbol();
+    const { root } = createTestInstance(
+        <Component>
+            <i symbol={symbol} />
+        </Component>
+    );
+
+    expect(root.findByProps({ symbol })).toBeTruthy();
+});
+
+test('provides state and actions via context', () => {
+    const { Component } = CartContextProvider;
+    const props = {
+        cart: 'cart',
+        addItemToCart: jest.fn(),
+        beginEditItem: jest.fn(),
+        createCart: jest.fn(),
+        endEditItem: jest.fn(),
+        getCartDetails: jest.fn(),
+        removeItemFromCart: jest.fn(),
+        updateItemInCart: jest.fn()
+    };
+
+    createTestInstance(
+        <Component {...props}>
+            <Consumer />
+        </Component>
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenNthCalledWith(1, [
+        props.cart,
+        expect.objectContaining({
+            addItemToCart: props.addItemToCart,
+            beginEditItem: props.beginEditItem,
+            createCart: props.createCart,
+            endEditItem: props.endEditItem,
+            getCartDetails: props.getCartDetails,
+            removeItemFromCart: props.removeItemFromCart,
+            updateItemInCart: props.updateItemInCart
+        })
+    ]);
+});

--- a/packages/venia-ui/lib/context/__tests__/catalog.spec.js
+++ b/packages/venia-ui/lib/context/__tests__/catalog.spec.js
@@ -1,0 +1,77 @@
+import React, { useContext, useEffect } from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import CatalogContextProvider, { CatalogContext } from '../catalog';
+
+jest.mock('@magento/venia-drivers', () => ({
+    connect: jest.fn((mapStateToProps, mapDispatchToProps) =>
+        jest.fn(Component => ({
+            Component: jest.fn(Component),
+            mapDispatchToProps,
+            mapStateToProps
+        }))
+    )
+}));
+
+const log = jest.fn();
+const Consumer = jest.fn(() => {
+    const contextValue = useContext(CatalogContext);
+
+    useEffect(() => {
+        log(contextValue);
+    }, [contextValue]);
+
+    return <i />;
+});
+
+test('returns a connected component', () => {
+    const { mapDispatchToProps, mapStateToProps } = CatalogContextProvider;
+
+    expect(mapStateToProps).toBeInstanceOf(Function);
+    expect(mapDispatchToProps).toEqual({
+        updateCategories: expect.any(Function)
+    });
+});
+
+test('mapStateToProps maps state to props', () => {
+    const { mapStateToProps } = CatalogContextProvider;
+    const include = { catalog: 'a' };
+    const exclude = { foo: 'b' };
+    const state = { ...include, ...exclude };
+
+    expect(mapStateToProps(state)).toEqual(include);
+});
+
+test('renders children', () => {
+    const { Component } = CatalogContextProvider;
+    const symbol = Symbol();
+    const { root } = createTestInstance(
+        <Component>
+            <i symbol={symbol} />
+        </Component>
+    );
+
+    expect(root.findByProps({ symbol })).toBeTruthy();
+});
+
+test('provides state and actions via context', () => {
+    const { Component } = CatalogContextProvider;
+    const props = {
+        catalog: 'catalog',
+        updateCategories: jest.fn()
+    };
+
+    createTestInstance(
+        <Component {...props}>
+            <Consumer />
+        </Component>
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenNthCalledWith(1, [
+        props.catalog,
+        expect.objectContaining({
+            updateCategories: props.updateCategories
+        })
+    ]);
+});

--- a/packages/venia-ui/lib/context/__tests__/checkout.spec.js
+++ b/packages/venia-ui/lib/context/__tests__/checkout.spec.js
@@ -1,0 +1,102 @@
+import React, { useContext, useEffect } from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import CheckoutContextProvider, { CheckoutContext } from '../checkout';
+
+jest.mock('@magento/venia-drivers', () => ({
+    connect: jest.fn((mapStateToProps, mapDispatchToProps) =>
+        jest.fn(Component => ({
+            Component: jest.fn(Component),
+            mapDispatchToProps,
+            mapStateToProps
+        }))
+    )
+}));
+
+const log = jest.fn();
+const Consumer = jest.fn(() => {
+    const contextValue = useContext(CheckoutContext);
+
+    useEffect(() => {
+        log(contextValue);
+    }, [contextValue]);
+
+    return <i />;
+});
+
+const fromEntries = array => {
+    const object = {};
+
+    for (const [key, value] of array) {
+        object[key] = value;
+    }
+
+    return object;
+};
+
+const actionCreators = [
+    'beginCheckout',
+    'cancelCheckout',
+    'getShippingMethods',
+    'resetCheckout',
+    'submitBillingAddress',
+    'submitOrder',
+    'submitPaymentMethod',
+    'submitPaymentMethodAndBillingAddress',
+    'submitShippingAddress',
+    'submitShippingMethod'
+];
+
+test('returns a connected component', () => {
+    const { mapDispatchToProps, mapStateToProps } = CheckoutContextProvider;
+    const expectedApi = fromEntries(
+        actionCreators.map(key => [key, expect.any(Function)])
+    );
+
+    expect(mapStateToProps).toBeInstanceOf(Function);
+    expect(mapDispatchToProps).toEqual(expectedApi);
+});
+
+test('mapStateToProps maps state to props', () => {
+    const { mapStateToProps } = CheckoutContextProvider;
+    const include = { checkout: 'a' };
+    const exclude = { foo: 'b' };
+    const state = { ...include, ...exclude };
+
+    expect(mapStateToProps(state)).toEqual(include);
+});
+
+test('renders children', () => {
+    const { Component } = CheckoutContextProvider;
+    const symbol = Symbol();
+    const { root } = createTestInstance(
+        <Component>
+            <i symbol={symbol} />
+        </Component>
+    );
+
+    expect(root.findByProps({ symbol })).toBeTruthy();
+});
+
+test('provides state and actions via context', () => {
+    const { Component } = CheckoutContextProvider;
+    const expectedApi = fromEntries(
+        actionCreators.map(key => [key, jest.fn()])
+    );
+    const props = {
+        checkout: 'checkout',
+        ...expectedApi
+    };
+
+    createTestInstance(
+        <Component {...props}>
+            <Consumer />
+        </Component>
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenNthCalledWith(1, [
+        props.checkout,
+        expect.objectContaining(expectedApi)
+    ]);
+});

--- a/packages/venia-ui/lib/context/__tests__/unhandledErrors.spec.js
+++ b/packages/venia-ui/lib/context/__tests__/unhandledErrors.spec.js
@@ -1,0 +1,77 @@
+import React, { useContext, useEffect } from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import ErrorContextProvider, { ErrorContext } from '../unhandledErrors';
+
+jest.mock('@magento/venia-drivers', () => ({
+    connect: jest.fn((mapStateToProps, mapDispatchToProps) =>
+        jest.fn(Component => ({
+            Component: jest.fn(Component),
+            mapDispatchToProps,
+            mapStateToProps
+        }))
+    )
+}));
+
+const log = jest.fn();
+const Consumer = jest.fn(() => {
+    const contextValue = useContext(ErrorContext);
+
+    useEffect(() => {
+        log(contextValue);
+    }, [contextValue]);
+
+    return <i />;
+});
+
+test('returns a connected component', () => {
+    const { mapDispatchToProps, mapStateToProps } = ErrorContextProvider;
+
+    expect(mapStateToProps).toBeInstanceOf(Function);
+    expect(mapDispatchToProps).toEqual({
+        markErrorHandled: expect.any(Function)
+    });
+});
+
+test('mapStateToProps maps state to props', () => {
+    const { mapStateToProps } = ErrorContextProvider;
+    const include = { unhandledErrors: 'a' };
+    const exclude = { foo: 'b' };
+    const state = { ...include, ...exclude };
+
+    expect(mapStateToProps(state)).toEqual(include);
+});
+
+test('renders children', () => {
+    const { Component } = ErrorContextProvider;
+    const symbol = Symbol();
+    const { root } = createTestInstance(
+        <Component>
+            <i symbol={symbol} />
+        </Component>
+    );
+
+    expect(root.findByProps({ symbol })).toBeTruthy();
+});
+
+test('provides state and actions via context', () => {
+    const { Component } = ErrorContextProvider;
+    const props = {
+        unhandledErrors: 'unhandledErrors',
+        markErrorHandled: jest.fn()
+    };
+
+    createTestInstance(
+        <Component {...props}>
+            <Consumer />
+        </Component>
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenNthCalledWith(1, [
+        props.unhandledErrors,
+        expect.objectContaining({
+            markErrorHandled: props.markErrorHandled
+        })
+    ]);
+});

--- a/packages/venia-ui/lib/context/__tests__/user.spec.js
+++ b/packages/venia-ui/lib/context/__tests__/user.spec.js
@@ -1,0 +1,86 @@
+import React, { useContext, useEffect } from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import UserContextProvider, { UserContext } from '../user';
+
+jest.mock('@magento/venia-drivers', () => ({
+    connect: jest.fn((mapStateToProps, mapDispatchToProps) =>
+        jest.fn(Component => ({
+            Component: jest.fn(Component),
+            mapDispatchToProps,
+            mapStateToProps
+        }))
+    )
+}));
+
+const log = jest.fn();
+const Consumer = jest.fn(() => {
+    const contextValue = useContext(UserContext);
+
+    useEffect(() => {
+        log(contextValue);
+    }, [contextValue]);
+
+    return <i />;
+});
+
+test('returns a connected component', () => {
+    const { mapDispatchToProps, mapStateToProps } = UserContextProvider;
+
+    expect(mapStateToProps).toBeInstanceOf(Function);
+    expect(mapDispatchToProps).toEqual({
+        createAccount: expect.any(Function),
+        getUserDetails: expect.any(Function),
+        signIn: expect.any(Function),
+        signOut: expect.any(Function)
+    });
+});
+
+test('mapStateToProps maps state to props', () => {
+    const { mapStateToProps } = UserContextProvider;
+    const include = { user: 'a' };
+    const exclude = { foo: 'b' };
+    const state = { ...include, ...exclude };
+
+    expect(mapStateToProps(state)).toEqual(include);
+});
+
+test('renders children', () => {
+    const { Component } = UserContextProvider;
+    const symbol = Symbol();
+    const { root } = createTestInstance(
+        <Component>
+            <i symbol={symbol} />
+        </Component>
+    );
+
+    expect(root.findByProps({ symbol })).toBeTruthy();
+});
+
+test('provides state and actions via context', () => {
+    const { Component } = UserContextProvider;
+    const props = {
+        user: 'user',
+        createAccount: jest.fn(),
+        getUserDetails: jest.fn(),
+        signIn: jest.fn(),
+        signOut: jest.fn()
+    };
+
+    createTestInstance(
+        <Component {...props}>
+            <Consumer />
+        </Component>
+    );
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenNthCalledWith(1, [
+        props.user,
+        expect.objectContaining({
+            createAccount: props.createAccount,
+            getUserDetails: props.getUserDetails,
+            signIn: props.signIn,
+            signOut: props.signOut
+        })
+    ]);
+});

--- a/packages/venia-ui/lib/context/app.js
+++ b/packages/venia-ui/lib/context/app.js
@@ -1,0 +1,34 @@
+import React, { createContext, useMemo } from 'react';
+
+import { closeDrawer } from '../actions/app';
+import { connect } from '../drivers';
+
+export const AppContext = createContext();
+
+const AppContextProvider = props => {
+    const { app: appState, children, closeDrawer } = props;
+
+    const appApi = useMemo(
+        () => ({
+            closeDrawer
+        }),
+        [closeDrawer]
+    );
+
+    const contextValue = useMemo(() => [appState, appApi], [appApi, appState]);
+
+    return (
+        <AppContext.Provider value={contextValue}>
+            {children}
+        </AppContext.Provider>
+    );
+};
+
+const mapStateToProps = ({ app }) => ({ app });
+
+const mapDispatchToProps = { closeDrawer };
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(AppContextProvider);

--- a/packages/venia-ui/lib/context/app.js
+++ b/packages/venia-ui/lib/context/app.js
@@ -1,18 +1,21 @@
 import React, { createContext, useMemo } from 'react';
+import { bindActionCreators } from 'redux';
 
-import { closeDrawer } from '../actions/app';
+import actions from '../actions/app/actions';
+import * as asyncActions from '../actions/app/asyncActions';
 import { connect } from '../drivers';
 
 export const AppContext = createContext();
 
 const AppContextProvider = props => {
-    const { app: appState, children, closeDrawer } = props;
+    const { actions, appState, asyncActions, children } = props;
 
     const appApi = useMemo(
         () => ({
-            closeDrawer
+            actions,
+            ...asyncActions
         }),
-        [closeDrawer]
+        [actions, asyncActions]
     );
 
     const contextValue = useMemo(() => [appState, appApi], [appApi, appState]);
@@ -24,9 +27,12 @@ const AppContextProvider = props => {
     );
 };
 
-const mapStateToProps = ({ app }) => ({ app });
+const mapStateToProps = ({ app }) => ({ appState: app });
 
-const mapDispatchToProps = { closeDrawer };
+const mapDispatchToProps = dispatch => ({
+    actions: bindActionCreators(actions, dispatch),
+    asyncActions: bindActionCreators(asyncActions, dispatch)
+});
 
 export default connect(
     mapStateToProps,

--- a/packages/venia-ui/lib/context/cart.js
+++ b/packages/venia-ui/lib/context/cart.js
@@ -1,0 +1,77 @@
+import React, { createContext, useMemo } from 'react';
+
+import {
+    addItemToCart,
+    beginEditItem,
+    createCart,
+    endEditItem,
+    getCartDetails,
+    removeItemFromCart,
+    updateItemInCart
+} from '../actions/cart';
+import { connect } from '../drivers';
+
+export const CartContext = createContext();
+
+const CartContextProvider = props => {
+    const {
+        addItemToCart,
+        beginEditItem,
+        cart: cartState,
+        children,
+        createCart,
+        endEditItem,
+        getCartDetails,
+        removeItemFromCart,
+        updateItemInCart
+    } = props;
+
+    const cartApi = useMemo(
+        () => ({
+            addItemToCart,
+            beginEditItem,
+            createCart,
+            endEditItem,
+            getCartDetails,
+            removeItemFromCart,
+            updateItemInCart
+        }),
+        [
+            addItemToCart,
+            beginEditItem,
+            createCart,
+            endEditItem,
+            getCartDetails,
+            removeItemFromCart,
+            updateItemInCart
+        ]
+    );
+
+    const contextValue = useMemo(() => [cartState, cartApi], [
+        cartApi,
+        cartState
+    ]);
+
+    return (
+        <CartContext.Provider value={contextValue}>
+            {children}
+        </CartContext.Provider>
+    );
+};
+
+const mapStateToProps = ({ cart }) => ({ cart });
+
+const mapDispatchToProps = {
+    addItemToCart,
+    beginEditItem,
+    createCart,
+    endEditItem,
+    getCartDetails,
+    removeItemFromCart,
+    updateItemInCart
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(CartContextProvider);

--- a/packages/venia-ui/lib/context/cart.js
+++ b/packages/venia-ui/lib/context/cart.js
@@ -1,50 +1,21 @@
 import React, { createContext, useMemo } from 'react';
+import { bindActionCreators } from 'redux';
 
-import {
-    addItemToCart,
-    beginEditItem,
-    createCart,
-    endEditItem,
-    getCartDetails,
-    removeItemFromCart,
-    updateItemInCart
-} from '../actions/cart';
+import actions from '../actions/cart/actions';
+import * as asyncActions from '../actions/cart/asyncActions';
 import { connect } from '../drivers';
 
 export const CartContext = createContext();
 
 const CartContextProvider = props => {
-    const {
-        addItemToCart,
-        beginEditItem,
-        cart: cartState,
-        children,
-        createCart,
-        endEditItem,
-        getCartDetails,
-        removeItemFromCart,
-        updateItemInCart
-    } = props;
+    const { actions, asyncActions, cartState, children } = props;
 
     const cartApi = useMemo(
         () => ({
-            addItemToCart,
-            beginEditItem,
-            createCart,
-            endEditItem,
-            getCartDetails,
-            removeItemFromCart,
-            updateItemInCart
+            actions,
+            ...asyncActions
         }),
-        [
-            addItemToCart,
-            beginEditItem,
-            createCart,
-            endEditItem,
-            getCartDetails,
-            removeItemFromCart,
-            updateItemInCart
-        ]
+        [actions, asyncActions]
     );
 
     const contextValue = useMemo(() => [cartState, cartApi], [
@@ -59,17 +30,12 @@ const CartContextProvider = props => {
     );
 };
 
-const mapStateToProps = ({ cart }) => ({ cart });
+const mapStateToProps = ({ cart }) => ({ cartState: cart });
 
-const mapDispatchToProps = {
-    addItemToCart,
-    beginEditItem,
-    createCart,
-    endEditItem,
-    getCartDetails,
-    removeItemFromCart,
-    updateItemInCart
-};
+const mapDispatchToProps = dispatch => ({
+    actions: bindActionCreators(actions, dispatch),
+    asyncActions: bindActionCreators(asyncActions, dispatch)
+});
 
 export default connect(
     mapStateToProps,

--- a/packages/venia-ui/lib/context/catalog.js
+++ b/packages/venia-ui/lib/context/catalog.js
@@ -1,0 +1,39 @@
+import React, { createContext, useMemo } from 'react';
+
+import catalogActions from '../actions/catalog';
+import { connect } from '../drivers';
+
+export const CatalogContext = createContext();
+
+const CatalogContextProvider = props => {
+    const { catalog: catalogState, children, updateCategories } = props;
+
+    const catalogApi = useMemo(
+        () => ({
+            updateCategories
+        }),
+        [updateCategories]
+    );
+
+    const contextValue = useMemo(() => [catalogState, catalogApi], [
+        catalogApi,
+        catalogState
+    ]);
+
+    return (
+        <CatalogContext.Provider value={contextValue}>
+            {children}
+        </CatalogContext.Provider>
+    );
+};
+
+const mapStateToProps = ({ catalog }) => ({ catalog });
+
+const mapDispatchToProps = {
+    updateCategories: catalogActions.updateCategories
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(CatalogContextProvider);

--- a/packages/venia-ui/lib/context/catalog.js
+++ b/packages/venia-ui/lib/context/catalog.js
@@ -1,18 +1,21 @@
 import React, { createContext, useMemo } from 'react';
+import { bindActionCreators } from 'redux';
 
-import catalogActions from '../actions/catalog';
+import actions from '../actions/catalog/actions';
+import * as asyncActions from '../actions/catalog/asyncActions';
 import { connect } from '../drivers';
 
 export const CatalogContext = createContext();
 
 const CatalogContextProvider = props => {
-    const { catalog: catalogState, children, updateCategories } = props;
+    const { actions, asyncActions, catalogState, children } = props;
 
     const catalogApi = useMemo(
         () => ({
-            updateCategories
+            actions,
+            ...asyncActions
         }),
-        [updateCategories]
+        [actions, asyncActions]
     );
 
     const contextValue = useMemo(() => [catalogState, catalogApi], [
@@ -27,11 +30,12 @@ const CatalogContextProvider = props => {
     );
 };
 
-const mapStateToProps = ({ catalog }) => ({ catalog });
+const mapStateToProps = ({ catalog }) => ({ catalogState: catalog });
 
-const mapDispatchToProps = {
-    updateCategories: catalogActions.updateCategories
-};
+const mapDispatchToProps = dispatch => ({
+    actions: bindActionCreators(actions, dispatch),
+    asyncActions: bindActionCreators(asyncActions, dispatch)
+});
 
 export default connect(
     mapStateToProps,

--- a/packages/venia-ui/lib/context/checkout.js
+++ b/packages/venia-ui/lib/context/checkout.js
@@ -1,62 +1,21 @@
 import React, { createContext, useMemo } from 'react';
+import { bindActionCreators } from 'redux';
 
-import {
-    beginCheckout,
-    cancelCheckout,
-    getShippingMethods,
-    resetCheckout,
-    submitBillingAddress,
-    submitOrder,
-    submitPaymentMethod,
-    submitPaymentMethodAndBillingAddress,
-    submitShippingAddress,
-    submitShippingMethod
-} from '../actions/checkout';
+import actions from '../actions/checkout/actions';
+import * as asyncActions from '../actions/checkout/asyncActions';
 import { connect } from '../drivers';
 
 export const CheckoutContext = createContext();
 
 const CheckoutContextProvider = props => {
-    const {
-        beginCheckout,
-        cancelCheckout,
-        checkout: checkoutState,
-        children,
-        getShippingMethods,
-        resetCheckout,
-        submitBillingAddress,
-        submitOrder,
-        submitPaymentMethod,
-        submitPaymentMethodAndBillingAddress,
-        submitShippingAddress,
-        submitShippingMethod
-    } = props;
+    const { actions, asyncActions, checkoutState, children } = props;
 
     const checkoutApi = useMemo(
         () => ({
-            beginCheckout,
-            cancelCheckout,
-            getShippingMethods,
-            resetCheckout,
-            submitBillingAddress,
-            submitOrder,
-            submitPaymentMethod,
-            submitPaymentMethodAndBillingAddress,
-            submitShippingAddress,
-            submitShippingMethod
+            actions,
+            ...asyncActions
         }),
-        [
-            beginCheckout,
-            cancelCheckout,
-            getShippingMethods,
-            resetCheckout,
-            submitBillingAddress,
-            submitOrder,
-            submitPaymentMethod,
-            submitPaymentMethodAndBillingAddress,
-            submitShippingAddress,
-            submitShippingMethod
-        ]
+        [actions, asyncActions]
     );
 
     const contextValue = useMemo(() => [checkoutState, checkoutApi], [
@@ -71,20 +30,12 @@ const CheckoutContextProvider = props => {
     );
 };
 
-const mapStateToProps = ({ checkout }) => ({ checkout });
+const mapStateToProps = ({ checkout }) => ({ checkoutState: checkout });
 
-const mapDispatchToProps = {
-    beginCheckout,
-    cancelCheckout,
-    getShippingMethods,
-    resetCheckout,
-    submitBillingAddress,
-    submitOrder,
-    submitPaymentMethod,
-    submitPaymentMethodAndBillingAddress,
-    submitShippingAddress,
-    submitShippingMethod
-};
+const mapDispatchToProps = dispatch => ({
+    actions: bindActionCreators(actions, dispatch),
+    asyncActions: bindActionCreators(asyncActions, dispatch)
+});
 
 export default connect(
     mapStateToProps,

--- a/packages/venia-ui/lib/context/checkout.js
+++ b/packages/venia-ui/lib/context/checkout.js
@@ -1,0 +1,92 @@
+import React, { createContext, useMemo } from 'react';
+
+import {
+    beginCheckout,
+    cancelCheckout,
+    getShippingMethods,
+    resetCheckout,
+    submitBillingAddress,
+    submitOrder,
+    submitPaymentMethod,
+    submitPaymentMethodAndBillingAddress,
+    submitShippingAddress,
+    submitShippingMethod
+} from '../actions/checkout';
+import { connect } from '../drivers';
+
+export const CheckoutContext = createContext();
+
+const CheckoutContextProvider = props => {
+    const {
+        beginCheckout,
+        cancelCheckout,
+        checkout: checkoutState,
+        children,
+        getShippingMethods,
+        resetCheckout,
+        submitBillingAddress,
+        submitOrder,
+        submitPaymentMethod,
+        submitPaymentMethodAndBillingAddress,
+        submitShippingAddress,
+        submitShippingMethod
+    } = props;
+
+    const checkoutApi = useMemo(
+        () => ({
+            beginCheckout,
+            cancelCheckout,
+            getShippingMethods,
+            resetCheckout,
+            submitBillingAddress,
+            submitOrder,
+            submitPaymentMethod,
+            submitPaymentMethodAndBillingAddress,
+            submitShippingAddress,
+            submitShippingMethod
+        }),
+        [
+            beginCheckout,
+            cancelCheckout,
+            getShippingMethods,
+            resetCheckout,
+            submitBillingAddress,
+            submitOrder,
+            submitPaymentMethod,
+            submitPaymentMethodAndBillingAddress,
+            submitShippingAddress,
+            submitShippingMethod
+        ]
+    );
+
+    const contextValue = useMemo(() => [checkoutState, checkoutApi], [
+        checkoutApi,
+        checkoutState
+    ]);
+
+    return (
+        <CheckoutContext.Provider value={contextValue}>
+            {children}
+        </CheckoutContext.Provider>
+    );
+};
+
+const mapStateToProps = ({ checkout }) => ({ checkout });
+
+const mapDispatchToProps = {
+    beginCheckout,
+    cancelCheckout,
+    getShippingMethods,
+    resetCheckout,
+    submitBillingAddress,
+    submitOrder,
+    submitPaymentMethod,
+    submitPaymentMethodAndBillingAddress,
+    submitShippingAddress,
+    submitShippingMethod
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(CheckoutContextProvider);

--- a/packages/venia-ui/lib/context/unhandledErrors.js
+++ b/packages/venia-ui/lib/context/unhandledErrors.js
@@ -1,0 +1,39 @@
+import React, { createContext, useMemo } from 'react';
+
+import appActions from '../actions/app';
+import { connect } from '../drivers';
+
+export const ErrorContext = createContext();
+
+const ErrorContextProvider = props => {
+    const { children, markErrorHandled, unhandledErrors } = props;
+
+    const errorApi = useMemo(
+        () => ({
+            markErrorHandled
+        }),
+        [markErrorHandled]
+    );
+
+    const contextValue = useMemo(() => [unhandledErrors, errorApi], [
+        errorApi,
+        unhandledErrors
+    ]);
+
+    return (
+        <ErrorContext.Provider value={contextValue}>
+            {children}
+        </ErrorContext.Provider>
+    );
+};
+
+const mapStateToProps = ({ unhandledErrors }) => ({ unhandledErrors });
+
+const mapDispatchToProps = {
+    markErrorHandled: appActions.markErrorHandled
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ErrorContextProvider);

--- a/packages/venia-ui/lib/context/user.js
+++ b/packages/venia-ui/lib/context/user.js
@@ -1,33 +1,21 @@
 import React, { createContext, useMemo } from 'react';
+import { bindActionCreators } from 'redux';
 
-import {
-    createAccount,
-    getUserDetails,
-    signIn,
-    signOut
-} from '../actions/user';
+import actions from '../actions/user/actions';
+import * as asyncActions from '../actions/user/asyncActions';
 import { connect } from '../drivers';
 
 export const UserContext = createContext();
 
 const UserContextProvider = props => {
-    const {
-        children,
-        createAccount,
-        getUserDetails,
-        signIn,
-        signOut,
-        user: userState
-    } = props;
+    const { actions, asyncActions, children, userState } = props;
 
     const userApi = useMemo(
         () => ({
-            createAccount,
-            getUserDetails,
-            signIn,
-            signOut
+            actions,
+            ...asyncActions
         }),
-        [createAccount, getUserDetails, signIn, signOut]
+        [actions, asyncActions]
     );
 
     const contextValue = useMemo(() => [userState, userApi], [
@@ -42,14 +30,12 @@ const UserContextProvider = props => {
     );
 };
 
-const mapStateToProps = ({ user }) => ({ user });
+const mapStateToProps = ({ user }) => ({ userState: user });
 
-const mapDispatchToProps = {
-    createAccount,
-    getUserDetails,
-    signIn,
-    signOut
-};
+const mapDispatchToProps = dispatch => ({
+    actions: bindActionCreators(actions, dispatch),
+    asyncActions: bindActionCreators(asyncActions, dispatch)
+});
 
 export default connect(
     mapStateToProps,

--- a/packages/venia-ui/lib/context/user.js
+++ b/packages/venia-ui/lib/context/user.js
@@ -1,0 +1,57 @@
+import React, { createContext, useMemo } from 'react';
+
+import {
+    createAccount,
+    getUserDetails,
+    signIn,
+    signOut
+} from '../actions/user';
+import { connect } from '../drivers';
+
+export const UserContext = createContext();
+
+const UserContextProvider = props => {
+    const {
+        children,
+        createAccount,
+        getUserDetails,
+        signIn,
+        signOut,
+        user: userState
+    } = props;
+
+    const userApi = useMemo(
+        () => ({
+            createAccount,
+            getUserDetails,
+            signIn,
+            signOut
+        }),
+        [createAccount, getUserDetails, signIn, signOut]
+    );
+
+    const contextValue = useMemo(() => [userState, userApi], [
+        userApi,
+        userState
+    ]);
+
+    return (
+        <UserContext.Provider value={contextValue}>
+            {children}
+        </UserContext.Provider>
+    );
+};
+
+const mapStateToProps = ({ user }) => ({ user });
+
+const mapDispatchToProps = {
+    createAccount,
+    getUserDetails,
+    signIn,
+    signOut
+};
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(UserContextProvider);


### PR DESCRIPTION
## Description

As demonstrated in #1552, provide slices of app state via context. Each provider should provide state and bound action creators for a single slice, following our usual signature.

```es6
const [state, api] = useContext(SliceContext)
```

Consuming these contexts is not in scope for this issue, so it will be handled in a subsequent PR.

## Related Issue

Closes #1601.

## Verification Steps
1. Smoke test the app.

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
