### PR TITLE
feat: ServiceWorker uses existing versions of resized images

### DIFF
--- a/packages/venia-concept/src/sw.js
+++ b/packages/venia-concept/src/sw.js
@@ -17,17 +17,92 @@ workbox.routing.registerRoute(
     new workbox.strategies.StaleWhileRevalidate()
 );
 
+const catalogCacheName = 'catalog';
+
+const getWidth = url => Number(new URLSearchParams(url.search).get('width'));
+
+const isCatalogImage = ({ url }) => url.pathname.startsWith('/media/catalog');
+
+const isResizedCatalogImage = ({ url }) =>
+    isCatalogImage({ url }) && !isNaN(getWidth(url));
+
+const catalogCacheHandler = new workbox.strategies.StaleWhileRevalidate({
+    cacheName: catalogCacheName,
+    plugins: [
+        new workbox.expiration.Plugin({
+            maxEntries: 60,
+            maxAgeSeconds: thirtyDays // 30 Days
+        }),
+        new workbox.cacheableResponse.Plugin({
+            statuses: [0, 200]
+        })
+    ]
+});
+
+const findSameOrLargerImage = async (url, request) => {
+    const requestedWidth = getWidth(url);
+
+    const cache = await caches.open(catalogCacheName);
+    const cachedSources = await cache.matchAll(request, {
+        ignoreSearch: true
+    });
+
+    // Find the cached version of this image that is closest to the requested
+    // width without going under it.
+    let best = { difference: Infinity, candidate: null };
+    for (const candidate of cachedSources) {
+        const width = getWidth(new URL(candidate.url));
+        if (isNaN(width)) {
+            // cached image has no resize param, so we can't safely use it
+            continue;
+        }
+
+        const difference = width - requestedWidth;
+
+        if (difference < 0) {
+            // cached image is smaller than requested, so we can't safely use it
+            continue;
+        }
+
+        if (difference === 0) {
+            // cached image is exactly what we want, so shortcut to this one
+            return candidate;
+        }
+
+        // we now know the cached image is larger than requested, but we don't
+        // want to serve an unnecessarily large image if a smaller one is
+        // available, to save device processing power and memory
+        if (difference < best.difference) {
+            // cached image is larger than requested, but smaller than the
+            // previous existing match
+            best = {
+                difference,
+                candidate
+            };
+        }
+    }
+    if (best.candidate) {
+        console.log(
+            `ServiceWorker responding to GET ${
+                url.pathname
+            } at ${requestedWidth}w with cached version ${
+                best.difference
+            }px larger: ${best.candidate.url}`
+        );
+        return best.candidate;
+    }
+};
+
 workbox.routing.registerRoute(
-    /\/media\/catalog.*\.(?:png|gif|jpg|jpeg|svg)$/,
-    new workbox.strategies.StaleWhileRevalidate({
-        cacheName: 'catalog',
-        plugins: [
-            new workbox.expiration.Plugin({
-                maxEntries: 60,
-                maxAgeSeconds: thirtyDays // 30 Days
-            })
-        ]
-    })
+    isResizedCatalogImage,
+    ({ url, request, event }) => {
+        const sameOrLargerImagePromise = findSameOrLargerImage(url, request);
+        event.waitUntil(sameOrLargerImagePromise);
+        return sameOrLargerImagePromise.then(
+            response =>
+                response || catalogCacheHandler.handle({ request, event })
+        );
+    }
 );
 
 workbox.routing.registerRoute(


### PR DESCRIPTION
## Description

Now that #1584 is going to be merged and we're using a consistent pattern of responsive images everywhere, we can teach the ServiceWorker to understand that it may have already cached a larger version of a requested image! This larger version could be used anywhere that the smaller one is used. This prevents repetitive caching of many sizes of the same image.

I opened this issue against #1584 because I began this experiment against that PR. I thought it would be interesting for @revanth0212 to review and merge into his own PR if he wants to.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Clear all caches. Build a production build and stage it with `yarn stage:venia` so the ServiceWorker installs. Load the homepage and refresh twice to make sure the ServiceWorker is installed.
2. Size your browser window narrow enough that thumbnails do not appear on a product page.
3. Navigate to a product page.
4. Open the browser console.
5. Resize the window until the thumbnails appear.
6. Check the console: you should see a notice that the large main image was used in place of one of the thumbnails.