### PR TITLE
Fix version number for babel-preset-peregrine

### DIFF
--- a/packages/babel-preset-peregrine/package.json
+++ b/packages/babel-preset-peregrine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magento/babel-preset-peregrine",
-  "version": "2.1.0",
+  "version": "1.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -49,7 +49,7 @@
     "@babel/plugin-transform-runtime": "~7.4.4",
     "@babel/preset-env": "~7.3.4",
     "@babel/runtime": "~7.4.2",
-    "@magento/babel-preset-peregrine": "~2.1.0",
+    "@magento/babel-preset-peregrine": "~1.0.0",
     "@magento/eslint-config": "~1.4.0",
     "@magento/peregrine": "~3.0.0",
     "@magento/pwa-buildpack": "~3.0.0",

--- a/packages/venia-ui/package.json
+++ b/packages/venia-ui/package.json
@@ -69,7 +69,7 @@
     "redux": "~4.0.1"
   },
   "peerDependencies": {
-    "@magento/babel-preset-peregrine": "~2.1.0",
+    "@magento/babel-preset-peregrine": "~1.0.0",
     "@magento/peregrine": "~3.0.0",
     "apollo-cache-inmemory": "~1.4.3",
     "apollo-cache-persist": "~0.1.1",


### PR DESCRIPTION
## Description
babel-preset-peregrine` has incorrect version number.

## Related Issue
Closes #1649 

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Run venia regression 

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
