### PR TITLE
Fix allowing "addToCart" on configurable product, with unselected options

### DIFF
--- a/packages/venia-ui/lib/components/ProductOptions/__tests__/option.spec.js
+++ b/packages/venia-ui/lib/components/ProductOptions/__tests__/option.spec.js
@@ -65,11 +65,12 @@ test('calls onSelectionChange function with attribute_id and selection', () => {
         onSelectionChange: onSelectionChangeMock
     };
     const component = testRenderer.create(<Option {...props} />);
+    const set = new Set(['test']);
 
-    component.root.children[0].instance.handleSelectionChange('test');
+    component.root.children[0].instance.handleSelectionChange(set);
     expect(onSelectionChangeMock).toHaveBeenCalledWith(
         defaultProps.attribute_id,
-        'test'
+        set
     );
 
     onSelectionChangeMock.mockReset();

--- a/packages/venia-ui/lib/components/ProductOptions/option.js
+++ b/packages/venia-ui/lib/components/ProductOptions/option.js
@@ -25,9 +25,10 @@ class Option extends Component {
     handleSelectionChange = selection => {
         const { attribute_id, onSelectionChange } = this.props;
 
-        if (onSelectionChange) {
+        typeof onSelectionChange === 'function' &&
+            selection &&
+            selection.size &&
             onSelectionChange(attribute_id, selection);
-        }
     };
 
     get listComponent() {


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Prevent set state on "handleSelectionChange" action in ProductOption component, when selection argument is empty.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1658 

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Go to the ProductConfigurable page with two options.
2. Choose only one option, button "AddToCart" should be disabled. 

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
