### PR TITLE
Fixed a bug where the post-install script would suggest to setup a cu…

### DIFF
--- a/scripts/monorepo-introduction.js
+++ b/scripts/monorepo-introduction.js
@@ -33,7 +33,7 @@ async function prepare() {
         'packages',
         'venia-concept'
     );
-    const veniaRelativePath = path.relative(process.cwd(), veniaPath);
+
     try {
         const {
             configureHost,
@@ -44,7 +44,7 @@ async function prepare() {
         if (customOrigin.enabled) {
             const customOriginConfig = await configureHost(
                 Object.assign(customOrigin, {
-                    dir: veniaRelativePath,
+                    dir: veniaPath,
                     interactive: false
                 })
             );
@@ -54,7 +54,7 @@ async function prepare() {
                         'Set up a custom origin for your copy of venia-concept:\n\t'
                     ) +
                         chalk.whiteBright(
-                            `yarn buildpack create-custom-origin ${veniaRelativePath}`
+                            `yarn buildpack create-custom-origin ${veniaPath}`
                         )
                 );
             }


### PR DESCRIPTION
…stom origin when the project was already setup like this (magento#1731)

Closes #1731
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

I changed the relativ path to the project to an absolute path because the hash which is used for comparison would not lead to the expected result. 

Running `yarn install` on an already installed instance will **not** lead to this console output anymore: `Please run Set up a custom origin for your copy of venia-concept:
	yarn buildpack create-custom-origin packages/venia-concept`. )

