### PR TITLE
removed sticky attribute from the pagination (magento#1723)

### DIFF
--- a/packages/venia-ui/lib/RootComponents/Category/category.css
+++ b/packages/venia-ui/lib/RootComponents/Category/category.css
@@ -9,7 +9,6 @@
 }
 
 .pagination {
-    position: sticky;
     bottom: 0;
 }
 

--- a/packages/venia-ui/lib/RootComponents/Category/category.css
+++ b/packages/venia-ui/lib/RootComponents/Category/category.css
@@ -9,6 +9,7 @@
 }
 
 .pagination {
+    position: relative;
     bottom: 0;
 }
 

--- a/packages/venia-ui/lib/components/Pagination/tile.css
+++ b/packages/venia-ui/lib/components/Pagination/tile.css
@@ -1,14 +1,14 @@
 .button {
     grid-row-start: 1;
     outline: none;
+    position: relative;
 }
 
 .marker {
     position: absolute;
-    width: 1.75rem;
-    height: 1.75rem;
+    width: 100%;
+    height: 100%;
     border: 1px solid;
     border-radius: 2px;
-    bottom: 0.75rem;
-    margin-bottom: 2px;
+    bottom: 0;
 }


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

With this codechange the pagination on the category-pages will not be sticky anymore.

Closes #1723 

## Additional Information
1. I have tested this ticket in these browsers in different sizes:
    - Firefox
    - Chrome
    - Safari
2. Fixed bug where the border for the currently selected page will not be displayed properly among all browser. The problem was the overall size of some elements in the pagination differ in different browsers. I didn't fix the issue with this. Instead I made the border-elements' size relativ to his parent. As a result there won't be any issues with this in different browsers.

## Behaviour after my codechange:
![pagination](https://user-images.githubusercontent.com/46490366/65377128-78c05d80-dca8-11e9-83db-d1d32a3025c6.gif)

