### PR TITLE
replaced rem height and width attribute for the pagination svgs (magento#1737)

### DIFF
--- a/packages/venia-ui/lib/components/Pagination/navButton.js
+++ b/packages/venia-ui/lib/components/Pagination/navButton.js
@@ -17,8 +17,8 @@ const NavIcons = {
 };
 
 const defaultSkipAttributes = {
-    width: '1.2rem',
-    height: '1.2rem'
+    width: '19px',
+    height: '19px'
 };
 
 const activeFill = {


### PR DESCRIPTION
## Description

I changed the with and height value for all svgs used in the pagination. It was changed from 1.2rem to 19px. Rem was leading to the error message `Error: Invalid value for <svg> attribute width="1.2rem"` in the safari browser.

## Related Issue
Closes #1737

## Acceptance 


### Verification Steps
1. Go to the category page with the safari browser
2. Check the console output
3. Check if there is not error message like: `Error: Invalid value for <svg> attribute width="1.2rem"`
4. Check if the pagination still looks good (like in the provided screenshot or the release before)

## Screenshots / Screen Captures (if appropriate)
<img width="759" alt="Expected-Result" src="https://user-images.githubusercontent.com/46490366/65386476-71e32a80-dd3c-11e9-8834-85e1be4759e9.png">
