### PR TITLE
Remove unused parameters

### DIFF
--- a/packages/pwa-buildpack/lib/Utilities/createProject.js
+++ b/packages/pwa-buildpack/lib/Utilities/createProject.js
@@ -108,7 +108,7 @@ async function createProject(options) {
         ignores = getIgnores(packageRoot)
     } = instructions.create({
         fs: fse,
-        tasks: makeCommonTasks(fse, options),
+        tasks: makeCommonTasks(fse),
         options
     });
 

--- a/packages/venia-concept/_buildpack/__tests__/create.spec.js
+++ b/packages/venia-concept/_buildpack/__tests__/create.spec.js
@@ -45,7 +45,7 @@ const mockFs = data => {
 const runCreate = (fs, options) => {
     const { visitor } = createVenia({
         fs,
-        tasks: makeCommonTasks(fs, options),
+        tasks: makeCommonTasks(fs),
         options
     });
     return makeCopyStream({


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

This PR removes unused parameters from `makeCommonTasks` invocations.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #<issue_number>

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* [ ] I have updated the documentation accordingly, if necessary.
* [ ] I have added tests to cover my changes, if necessary.
