### PR TITLE
Add field labels

### DIFF
--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/addressForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/addressForm.spec.js.snap
@@ -23,11 +23,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="firstname"
         >
           First Name
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -67,11 +68,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="lastname"
         >
           Last Name
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -111,11 +113,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="email"
         >
           Email
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -155,11 +158,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="street0"
         >
           Street
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -199,11 +203,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="city"
         >
           City
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -243,11 +248,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="region_code"
         >
           State
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -287,11 +293,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="postcode"
         >
           ZIP
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -331,11 +338,12 @@ exports[`renders an AddressForm component 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="telephone"
         >
           Phone
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -423,11 +431,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="firstname"
         >
           First Name
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -467,11 +476,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="lastname"
         >
           Last Name
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -511,11 +521,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="email"
         >
           Email
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -555,11 +566,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="street0"
         >
           Street
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -599,11 +611,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="city"
         >
           City
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -643,11 +656,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="region_code"
         >
           State
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -687,11 +701,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="postcode"
         >
           ZIP
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -731,11 +746,12 @@ exports[`renders validation block with message if address is incorrect 1`] = `
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
+          htmlFor="telephone"
         >
           Phone
-        </span>
+        </label>
         <span
           className="root"
           style={

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
@@ -158,11 +158,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           First Name
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -202,11 +202,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           Last Name
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -246,11 +246,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           Email
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -290,11 +290,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           Street
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -334,11 +334,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           City
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -378,11 +378,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           State
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -422,11 +422,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           ZIP
-        </span>
+        </label>
         <span
           className="root"
           style={
@@ -466,11 +466,11 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <div
         className="root"
       >
-        <span
+        <label
           className="label"
         >
           Phone
-        </span>
+        </label>
         <span
           className="root"
           style={

--- a/packages/venia-ui/lib/components/Checkout/addressForm.js
+++ b/packages/venia-ui/lib/components/Checkout/addressForm.js
@@ -50,7 +50,7 @@ const AddressForm = props => {
                 <h2 className={classes.heading}>Shipping Address</h2>
                 <div className={classes.validationMessage}>{error}</div>
                 <div className={classes.firstname}>
-                    <Field label="First Name">
+                    <Field id={classes.firstname} label="First Name">
                         <TextInput
                             id={classes.firstname}
                             field="firstname"
@@ -59,7 +59,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.lastname}>
-                    <Field label="Last Name">
+                    <Field id={classes.lastname} label="Last Name">
                         <TextInput
                             id={classes.lastname}
                             field="lastname"
@@ -68,7 +68,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.email}>
-                    <Field label="Email">
+                    <Field id={classes.email} label="Email">
                         <TextInput
                             id={classes.email}
                             field="email"
@@ -77,7 +77,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.street0}>
-                    <Field label="Street">
+                    <Field id={classes.street0} label="Street">
                         <TextInput
                             id={classes.street0}
                             field="street[0]"
@@ -86,7 +86,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.city}>
-                    <Field label="City">
+                    <Field id={classes.city} label="City">
                         <TextInput
                             id={classes.city}
                             field="city"
@@ -95,7 +95,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.region_code}>
-                    <Field label="State">
+                    <Field id={classes.region_code} label="State">
                         <TextInput
                             id={classes.region_code}
                             field="region_code"
@@ -108,7 +108,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.postcode}>
-                    <Field label="ZIP">
+                    <Field id={classes.postcode} label="ZIP">
                         <TextInput
                             id={classes.postcode}
                             field="postcode"
@@ -117,7 +117,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.telephone}>
-                    <Field label="Phone">
+                    <Field id={classes.telephone} label="Phone">
                         <TextInput
                             id={classes.telephone}
                             field="telephone"

--- a/packages/venia-ui/lib/components/CreateAccount/__tests__/__snapshots__/createAccount.spec.js.snap
+++ b/packages/venia-ui/lib/components/CreateAccount/__tests__/__snapshots__/createAccount.spec.js.snap
@@ -9,10 +9,10 @@ exports[`renders the correct tree 1`] = `
     Check out faster, use multiple addresses, track orders and more by creating an account!
   </p>
   <div>
-    <span>
+    <label>
       <span />
       First Name
-    </span>
+    </label>
     <span
       style={
         Object {
@@ -36,10 +36,10 @@ exports[`renders the correct tree 1`] = `
     <p />
   </div>
   <div>
-    <span>
+    <label>
       <span />
       Last Name
-    </span>
+    </label>
     <span
       style={
         Object {
@@ -63,10 +63,10 @@ exports[`renders the correct tree 1`] = `
     <p />
   </div>
   <div>
-    <span>
+    <label>
       <span />
       Email
-    </span>
+    </label>
     <span
       style={
         Object {
@@ -90,10 +90,10 @@ exports[`renders the correct tree 1`] = `
     <p />
   </div>
   <div>
-    <span>
+    <label>
       <span />
       Password
-    </span>
+    </label>
     <span
       style={
         Object {
@@ -118,10 +118,10 @@ exports[`renders the correct tree 1`] = `
     <p />
   </div>
   <div>
-    <span>
+    <label>
       <span />
       Confirm Password
-    </span>
+    </label>
     <span
       style={
         Object {

--- a/packages/venia-ui/lib/components/Field/field.js
+++ b/packages/venia-ui/lib/components/Field/field.js
@@ -5,7 +5,7 @@ import { mergeClasses } from '../../classify';
 import defaultClasses from './field.css';
 
 const Field = props => {
-    const { children, label, required } = props;
+    const { children, id, label, required } = props;
     const classes = mergeClasses(defaultClasses, props.classes);
     const requiredSymbol = required ? (
         <span className={classes.requiredSymbol} />
@@ -13,10 +13,10 @@ const Field = props => {
 
     return (
         <div className={classes.root}>
-            <span className={classes.label}>
+            <label className={classes.label} htmlFor={id}>
                 {requiredSymbol}
                 {label}
-            </span>
+            </label>
             {children}
         </div>
     );
@@ -28,6 +28,7 @@ Field.propTypes = {
         label: string,
         root: string
     }),
+    id: string,
     label: node,
     required: bool
 };

--- a/packages/venia-ui/lib/components/ForgotPassword/ForgotPasswordForm/__tests__/__snapshots__/forgotPasswordForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/ForgotPassword/ForgotPasswordForm/__tests__/__snapshots__/forgotPasswordForm.spec.js.snap
@@ -6,10 +6,10 @@ exports[`renders correctly 1`] = `
   onSubmit={[Function]}
 >
   <div>
-    <span>
+    <label>
       <span />
       Email Address
-    </span>
+    </label>
     <span
       style={
         Object {

--- a/packages/venia-ui/lib/components/SignIn/__tests__/__snapshots__/signIn.spec.js.snap
+++ b/packages/venia-ui/lib/components/SignIn/__tests__/__snapshots__/signIn.spec.js.snap
@@ -12,14 +12,14 @@ exports[`displays an error message if there is a sign in error 1`] = `
     <div
       className="root"
     >
-      <span
+      <label
         className="label"
       >
         <span
           className="requiredSymbol"
         />
         Email
-      </span>
+      </label>
       <span
         className="root"
         style={
@@ -55,14 +55,14 @@ exports[`displays an error message if there is a sign in error 1`] = `
     <div
       className="root"
     >
-      <span
+      <label
         className="label"
       >
         <span
           className="requiredSymbol"
         />
         Password
-      </span>
+      </label>
       <span
         className="root"
         style={
@@ -135,14 +135,14 @@ exports[`renders correctly 1`] = `
     <div
       className="root"
     >
-      <span
+      <label
         className="label"
       >
         <span
           className="requiredSymbol"
         />
         Email
-      </span>
+      </label>
       <span
         className="root"
         style={
@@ -178,14 +178,14 @@ exports[`renders correctly 1`] = `
     <div
       className="root"
     >
-      <span
+      <label
         className="label"
       >
         <span
           className="requiredSymbol"
         />
         Password
-      </span>
+      </label>
       <span
         className="root"
         style={


### PR DESCRIPTION
## Description

As I noted in #1844, the `<Field>` component, used in checkout and account forms, outputs the text label in a `<span>` instead of a `<label>` that's properly associated with the input. In this PR, I've updated `<Field>` to output a `<label>` for the label and — given an `id` prop — include an `htmlFor` to associate it with the input. There is no visual change as a result of this change, and the `id` prop is optional. 

I've updated Checkout/addressForm to pass in the `id` values for all labels. The same change (64a1b54) needs to be made for other forms that utilize `<Field>` in future PRs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1844 .

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Add a product to cart.
2. Expand the cart and proceed to checkout.
3. Within the checkout shipping address form, inspect or click an input label.

## Screenshots / Screen Captures (if appropriate)

<details>
<summary>With the fix</summary>
<img width="1232" alt="image" src="https://user-images.githubusercontent.com/4383327/66216215-12b5dc00-e693-11e9-9be0-eb6fde8f02fd.png">
</details>

<details>
<summary>Before the fix</summary>
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/4383327/66216023-b05cdb80-e692-11e9-866e-16ff16f5ea01.png">
</details>
