### PR TITLE
[SPIKE] Extension via portals (a different take)

### DIFF
--- a/packages/venia-concept/src/extensions/ProductRecommendations/ProductRecommendations.css
+++ b/packages/venia-concept/src/extensions/ProductRecommendations/ProductRecommendations.css
@@ -1,0 +1,26 @@
+.root {
+    display: grid;
+    grid-gap: 1rem;
+}
+
+.text {
+    text-align: center;
+    font-weight: bolder;
+    font-size: 1.2rem;
+}
+
+.loadingText {
+    text-align: center;
+}
+
+.tiles {
+    display: grid;
+    grid-gap: 3rem 1rem;
+    grid-template-columns: repeat(auto-fit, 240px);
+    justify-content: center;
+}
+
+.recommendation:hover {
+    box-shadow: 0 0 0 2px rgb(var(--venia-teal-light)),
+        0 0 0.5rem 2px rgba(var(--venia-teal), 0.2);
+}

--- a/packages/venia-concept/src/extensions/ProductRecommendations/ProductRecommendations.js
+++ b/packages/venia-concept/src/extensions/ProductRecommendations/ProductRecommendations.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import classes from './ProductRecommendations.css';
+
+/**
+ * An extension that displays product recommendations
+ */
+export const ProductRecommendations = () => {
+    const [data, setData] = useState(null);
+
+    // Fake a request for some recommendations data.
+    useEffect(() => {
+        setTimeout(() => {
+            setData({});
+        }, 2000);
+    });
+
+    const content = !!data ? (
+        <div className={classes.tiles}>
+            <div className={classes.recommendation}>
+                <img
+                    src="/media/catalog/product/v/d/vd12-rn_main_2.jpg?auto=webp&format=pjpg&width=240&height=300"
+                    alt="product recommendation"
+                />
+            </div>
+            <div className={classes.recommendation}>
+                <img
+                    src="/media/catalog/product/v/a/va12-ts_main.jpg?auto=webp&format=pjpg&width=240&height=300"
+                    alt="product recommendation"
+                />
+            </div>
+            <div className={classes.recommendation}>
+                <img
+                    src="/media/catalog/product/v/t/vt07-rn_main_2.jpg?auto=webp&format=pjpg&width=240&height=300"
+                    alt="product recommendation"
+                />
+            </div>
+        </div>
+    ) : (
+        <div className={classes.loadingText}>Loading...</div>
+    );
+
+    return (
+        <div className={classes.root}>
+            <span className={classes.text}>Product Recommendations</span>
+            {content}
+        </div>
+    );
+};

--- a/packages/venia-concept/src/extensions/WelcomeToast/WelcomeToast.js
+++ b/packages/venia-concept/src/extensions/WelcomeToast/WelcomeToast.js
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+
+import { User as UserIcon } from 'react-feather';
+import Icon from '@magento/venia-ui/lib/components/Icon';
+import { useUserContext } from '@magento/peregrine/lib/context/user';
+import { useToasts } from '@magento/peregrine';
+
+const icon = <Icon src={UserIcon} attrs={{ width: 18 }} />;
+/**
+ * An extension that displays a welcome message when the user signs in.
+ */
+export const WelcomeToast = () => {
+    const [{ currentUser }] = useUserContext();
+    const [, { addToast }] = useToasts();
+    const { firstname, lastname } = currentUser;
+
+    const signedIn = !!firstname;
+    useEffect(() => {
+        if (signedIn) {
+            addToast({
+                type: 'info',
+                icon,
+                message: `Welcome ${firstname} ${lastname}`,
+                timeout: 3000
+            });
+        }
+    }, [addToast, signedIn, firstname, lastname]);
+    return <></>;
+};

--- a/packages/venia-concept/src/extensions/WelcomeToast/WelcomeToast.js
+++ b/packages/venia-concept/src/extensions/WelcomeToast/WelcomeToast.js
@@ -6,6 +6,7 @@ import { useUserContext } from '@magento/peregrine/lib/context/user';
 import { useToasts } from '@magento/peregrine';
 
 const icon = <Icon src={UserIcon} attrs={{ width: 18 }} />;
+
 /**
  * An extension that displays a welcome message when the user signs in.
  */
@@ -25,5 +26,7 @@ export const WelcomeToast = () => {
             });
         }
     }, [addToast, signedIn, firstname, lastname]);
+
+    // Gotta return something or React complains.
     return <></>;
 };

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -10,6 +10,10 @@ import app from '@magento/peregrine/lib/store/actions/app';
 import App, { AppContextProvider } from '@magento/venia-ui/lib/components/App';
 import './index.css';
 
+import { Extension } from '@magento/venia-ui/lib/components/Extension';
+import { WelcomeToast } from './extensions/WelcomeToast/WelcomeToast';
+import { ProductRecommendations } from './extensions/ProductRecommendations/ProductRecommendations';
+
 const { BrowserPersistence } = Util;
 const apiBase = new URL('/graphql', location.origin).toString();
 
@@ -46,6 +50,10 @@ ReactDOM.render(
     <Adapter apiBase={apiBase} apollo={{ link: apolloLink }} store={store}>
         <AppContextProvider>
             <App />
+            <Extension targetId="extension-point-1">
+                <WelcomeToast />
+                <ProductRecommendations />
+            </Extension>
         </AppContextProvider>
     </Adapter>,
     document.getElementById('root')

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -50,9 +50,13 @@ ReactDOM.render(
     <Adapter apiBase={apiBase} apollo={{ link: apolloLink }} store={store}>
         <AppContextProvider>
             <App />
+            {/* Some extensions require a target */}
             <Extension targetId="extension-point-1">
-                <WelcomeToast />
                 <ProductRecommendations />
+            </Extension>
+            {/* Other extensions don't need target (assumes #root at least) */}
+            <Extension>
+                <WelcomeToast />
             </Extension>
         </AppContextProvider>
     </Adapter>,

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -10,7 +10,7 @@ import app from '@magento/peregrine/lib/store/actions/app';
 import App, { AppContextProvider } from '@magento/venia-ui/lib/components/App';
 import './index.css';
 
-import { Extension } from '@magento/venia-ui/lib/components/Extension';
+import { Portal, Extension } from '@magento/venia-ui/lib/components/Extension';
 import { WelcomeToast } from './extensions/WelcomeToast/WelcomeToast';
 import { ProductRecommendations } from './extensions/ProductRecommendations/ProductRecommendations';
 
@@ -49,7 +49,6 @@ const apolloLink = ApolloLink.from([
 ReactDOM.render(
     <Adapter apiBase={apiBase} apollo={{ link: apolloLink }} store={store}>
         <AppContextProvider>
-            <App />
             {/* Some extensions require a target */}
             <Extension targetId="main-ep-before-children">
                 <div style={{ textAlign: 'center' }}>
@@ -69,6 +68,9 @@ ReactDOM.render(
             <Extension>
                 <WelcomeToast />
             </Extension>
+            {/* App/Portals must be rendered _after_ extensions. */}
+            <App />
+            <Portal id="root" />
         </AppContextProvider>
     </Adapter>,
     document.getElementById('root')

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -51,7 +51,18 @@ ReactDOM.render(
         <AppContextProvider>
             <App />
             {/* Some extensions require a target */}
-            <Extension targetId="extension-point-1">
+            <Extension targetId="main-ep-before-children">
+                <div style={{ textAlign: 'center' }}>
+                    I'm not even an extension component, I'm just some DOM!
+                </div>
+            </Extension>
+            <Extension targetId="main-ep-before-children">
+                <div style={{ textAlign: 'center' }}>
+                    I'm an example of an extension trying to overload an
+                    extension point!
+                </div>
+            </Extension>
+            <Extension targetId="main-ep-after-children">
                 <ProductRecommendations />
             </Extension>
             {/* Other extensions don't need target (assumes #root at least) */}

--- a/packages/venia-ui/lib/components/Extension/extension.js
+++ b/packages/venia-ui/lib/components/Extension/extension.js
@@ -1,0 +1,30 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * This extension component renders children into the DOM after React mounts.
+ *
+ * @example
+ * <Extension targetId={'extension-point-1'}>
+ *   <MyExtensionComponent>
+ * </Extension>
+ *
+ * @param {String} props.targetId id of injection target for extension
+ * @param {ReactNode} props.children
+ */
+export const Extension = props => {
+    const { children, targetId } = props;
+    const [isMounted, setMounted] = useState(false);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    const extensionPoint = document.getElementById(targetId);
+
+    // Only render after the initial mount, and only if the extension point has
+    // been found.
+    return isMounted && !!extensionPoint
+        ? createPortal(<Fragment>{children}</Fragment>, extensionPoint)
+        : null;
+};

--- a/packages/venia-ui/lib/components/Extension/extension.js
+++ b/packages/venia-ui/lib/components/Extension/extension.js
@@ -13,7 +13,7 @@ import { createPortal } from 'react-dom';
  * @param {ReactNode} props.children
  */
 export const Extension = props => {
-    const { children, targetId } = props;
+    const { children, targetId = 'root' } = props;
     const [isMounted, setMounted] = useState(false);
 
     useEffect(() => {

--- a/packages/venia-ui/lib/components/Extension/extension.js
+++ b/packages/venia-ui/lib/components/Extension/extension.js
@@ -9,7 +9,7 @@ import { createPortal } from 'react-dom';
  *   <MyExtensionComponent>
  * </Extension>
  *
- * @param {String} props.targetId id of injection target for extension
+ * @param {String} [props.targetId=root] id of injection target for extension
  * @param {ReactNode} props.children
  */
 export const Extension = props => {

--- a/packages/venia-ui/lib/components/Extension/extension.js
+++ b/packages/venia-ui/lib/components/Extension/extension.js
@@ -1,5 +1,15 @@
-import React, { Fragment, useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
+import React, { Fragment } from 'react';
+
+const extensionMap = new Map();
+
+/**
+ * Gets any extensions registered for an id and returns the component.
+ * @param {string} props.id id of the portal within the map
+ */
+export const Portal = ({ id }) => {
+    const components = extensionMap.get(id);
+    return <Fragment>{components}</Fragment>;
+};
 
 /**
  * This extension component renders children into the DOM after React mounts.
@@ -14,17 +24,14 @@ import { createPortal } from 'react-dom';
  */
 export const Extension = props => {
     const { children, targetId = 'root' } = props;
-    const [isMounted, setMounted] = useState(false);
 
-    useEffect(() => {
-        setMounted(true);
-    }, []);
+    // Add new extensions.
+    const existing = extensionMap.get(targetId) || [];
+    existing.push(children);
 
-    const extensionPoint = document.getElementById(targetId);
+    // Store in the map.
+    extensionMap.set(targetId, existing);
 
-    // Only render after the initial mount, and only if the extension point has
-    // been found.
-    return isMounted && !!extensionPoint
-        ? createPortal(<Fragment>{children}</Fragment>, extensionPoint)
-        : null;
+    // Return nothing because rendering happens from the @Portal component.
+    return null;
 };

--- a/packages/venia-ui/lib/components/Extension/index.js
+++ b/packages/venia-ui/lib/components/Extension/index.js
@@ -1,0 +1,1 @@
+export { Extension } from './extension';

--- a/packages/venia-ui/lib/components/Extension/index.js
+++ b/packages/venia-ui/lib/components/Extension/index.js
@@ -1,1 +1,1 @@
-export { Extension } from './extension';
+export { Portal, Extension } from './extension';

--- a/packages/venia-ui/lib/components/Main/main.js
+++ b/packages/venia-ui/lib/components/Main/main.js
@@ -19,7 +19,10 @@ const Main = props => {
     return (
         <main className={rootClass}>
             <Header />
-            <div className={pageClass}>{children}</div>
+            <div className={pageClass}>
+                {children}
+                <div id="extension-point-1" />
+            </div>
             <Footer />
         </main>
     );

--- a/packages/venia-ui/lib/components/Main/main.js
+++ b/packages/venia-ui/lib/components/Main/main.js
@@ -20,8 +20,9 @@ const Main = props => {
         <main className={rootClass}>
             <Header />
             <div className={pageClass}>
+                <div id="main-ep-before-children" />
                 {children}
-                <div id="extension-point-1" />
+                <div id="main-ep-after-children" />
             </div>
             <Footer />
         </main>

--- a/packages/venia-ui/lib/components/Main/main.js
+++ b/packages/venia-ui/lib/components/Main/main.js
@@ -6,6 +6,7 @@ import { mergeClasses } from '../../classify';
 import Footer from '../Footer';
 import Header from '../Header';
 import defaultClasses from './main.css';
+import { Portal } from '@magento/venia-ui/lib/components/Extension';
 
 const Main = props => {
     const { children, isMasked } = props;
@@ -20,9 +21,9 @@ const Main = props => {
         <main className={rootClass}>
             <Header />
             <div className={pageClass}>
-                <div id="main-ep-before-children" />
+                <Portal id="main-ep-before-children" />
                 {children}
-                <div id="main-ep-after-children" />
+                <Portal id="main-ep-after-children" />
             </div>
             <Footer />
         </main>


### PR DESCRIPTION
This branches off the initial spike but is a sort of inverse approach in terms of rendering.

While the initial spike attached `div`s with ids and rendered extensions post-mount, this approach allows components to render `Portal` components with identifiers. Client code doesn't change much, they still use the `Extension` component which registers the JSX within a map and when the UI component calls `<Portal id="some-id" />` it just renders whatever is stored in the map for that identifier.

So in the first spike we have the portals/component code living in the tree at the level where the `Extension` is defined:

[![Image from Gyazo](https://i.gyazo.com/d1f6250d9d799dfab469ed84c6040e58.png)](https://gyazo.com/d1f6250d9d799dfab469ed84c6040e58)

In this spike, the components are more representative of the DOM:

[![Image from Gyazo](https://i.gyazo.com/c7063449147aa40f5b568da13b4c455f.png)](https://gyazo.com/c7063449147aa40f5b568da13b4c455f)