### PR TITLE
#1909: fix invalid “veniaResource” reference in upward.js comments

### DIFF
--- a/packages/venia-ui/upward.yml
+++ b/packages/venia-ui/upward.yml
@@ -88,7 +88,7 @@ veniaProxy:
 # rendered HTML containing the PWA application shell.
 # For SEO purposes, the appropriate meta tags in the HTML head element are also
 # set based on information about the resource.
-# This object uses properties in the top-level 'veniaResource' object to return
+# This object uses properties in the top-level 'veniaResponse' object to return
 # the appropriate response values.
 veniaAppShell:
     resolver: inline


### PR DESCRIPTION
## Description

In `packages/venia-ui/upward.js` there's an incorrect reference to `veniaResource` which should be `veniaResponse`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1909.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
Only affects comments.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
