### PR TITLE
#1911: fix Button is exported twice

### DIFF
--- a/packages/venia-ui/lib/components/Button/button.js
+++ b/packages/venia-ui/lib/components/Button/button.js
@@ -16,7 +16,7 @@ const getRootClassName = priority => `root_${priority}Priority`;
  *
  * @returns {React.Element} A React component that displays a single button.
  */
-export const Button = props => {
+const Button = props => {
     const {
         children,
         classes: propClasses,


### PR DESCRIPTION
## Description

The `Button` component is exported from the function and as a default export below. This doesn't seem to break anything, but I haven't seen it anywhere else so it's a little weird.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1911.

## Acceptance 

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Build should pass.

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
