### PR TITLE
#1915: remove redux.compose() where not needed

### DIFF
--- a/packages/venia-ui/lib/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-ui/lib/components/Checkout/Receipt/receipt.js
@@ -1,5 +1,4 @@
 import React, { Fragment } from 'react';
-import { compose } from 'redux';
 import { func, shape, string } from 'prop-types';
 
 import { mergeClasses } from '../../../classify';
@@ -79,4 +78,4 @@ Receipt.defaultProps = {
     order: {}
 };
 
-export default compose(withRouter)(Receipt);
+export default withRouter(Receipt);

--- a/packages/venia-ui/lib/components/CreateAccountPage/createAccountPage.js
+++ b/packages/venia-ui/lib/components/CreateAccountPage/createAccountPage.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shape } from 'prop-types';
 import { withRouter } from '@magento/venia-drivers';
-import { compose } from 'redux';
 import CreateAccountForm from '../CreateAccount';
 import { mergeClasses } from '../../classify';
 import defaultClasses from './createAccountPage.css';
@@ -30,4 +29,4 @@ CreateAccountPage.propTypes = {
     history: shape({})
 };
 
-export default compose(withRouter)(CreateAccountPage);
+export default withRouter(CreateAccountPage);

--- a/packages/venia-ui/lib/components/FilterModal/FilterFooter/filterFooter.js
+++ b/packages/venia-ui/lib/components/FilterModal/FilterFooter/filterFooter.js
@@ -3,7 +3,6 @@ import { object, shape, string } from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { mergeClasses } from '../../../classify';
 import defaultClasses from './filterFooter.css';
-import { compose } from 'redux';
 import isObjectEmpty from '../../../util/isObjectEmpty';
 import { preserveQueryParams } from '@magento/peregrine/lib/util/preserveQueryParams';
 import { useCatalogContext } from '@magento/peregrine/lib/context/catalog';
@@ -78,4 +77,4 @@ FilterFooter.propTypes = {
     location: object
 };
 
-export default compose(withRouter)(FilterFooter);
+export default withRouter(FilterFooter);

--- a/packages/venia-ui/lib/components/FilterModal/FiltersCurrent/filtersCurrent.js
+++ b/packages/venia-ui/lib/components/FilterModal/FiltersCurrent/filtersCurrent.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import { object, shape, string } from 'prop-types';
-import { compose } from 'redux';
 import Icon from '../../Icon';
 import { X as Remove } from 'react-feather';
 import { mergeClasses } from '../../../classify';
@@ -77,4 +76,4 @@ FiltersCurrent.propTypes = {
     location: object
 };
 
-export default compose(withRouter)(FiltersCurrent);
+export default withRouter(FiltersCurrent);

--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Banner/banner.js
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Banner/banner.js
@@ -5,7 +5,6 @@ import { arrayOf, bool, object, oneOf, shape, string } from 'prop-types';
 import Button from '../../../../Button/button';
 import resolveLinkProps from '../../resolveLinkProps';
 import { Link, withRouter, resourceUrl } from '@magento/venia-drivers';
-import { compose } from 'redux';
 
 const toHTML = str => ({ __html: str });
 
@@ -308,4 +307,4 @@ Banner.propTypes = {
     history: object
 };
 
-export default compose(withRouter)(Banner);
+export default withRouter(Banner);

--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/ButtonItem/buttonItem.js
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/ButtonItem/buttonItem.js
@@ -3,7 +3,6 @@ import Button from '../../../../Button/button';
 import { arrayOf, oneOf, string, bool, object } from 'prop-types';
 import { withRouter } from '@magento/venia-drivers';
 import resolveLinkProps from '../../resolveLinkProps';
-import { compose } from 'redux';
 
 /**
  * Page Builder ButtonItem component.
@@ -156,4 +155,4 @@ ButtonItem.propTypes = {
     history: object
 };
 
-export default compose(withRouter)(ButtonItem);
+export default withRouter(ButtonItem);


### PR DESCRIPTION


## Description

Removes `redux.compose()` where it's not being used to compose multiple functions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1915

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Should pass build.

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
