### PR TITLE
1917 avoid js string on text nodes in jsx

### DIFF
--- a/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
+++ b/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
@@ -35,7 +35,7 @@ const CategoryContent = props => {
                 onClick={handleOpenFilters}
                 type="button"
             >
-                {'Filter'}
+                Filter
             </button>
         </div>
     ) : null;

--- a/packages/venia-ui/lib/components/AuthBar/authBar.js
+++ b/packages/venia-ui/lib/components/AuthBar/authBar.js
@@ -26,7 +26,7 @@ const AuthBar = props => {
             priority="high"
             onClick={handleSignIn}
         >
-            {'Sign In'}
+            Sign In
         </Button>
     );
 

--- a/packages/venia-ui/lib/components/CreateAccount/createAccount.js
+++ b/packages/venia-ui/lib/components/CreateAccount/createAccount.js
@@ -100,7 +100,7 @@ const CreateAccount = props => {
             <div className={classes.error}>{errorMessage}</div>
             <div className={classes.actions}>
                 <Button disabled={isDisabled} type="submit" priority="high">
-                    {'Submit'}
+                    Submit
                 </Button>
             </div>
         </Form>

--- a/packages/venia-ui/lib/components/LoadingIndicator/static.js
+++ b/packages/venia-ui/lib/components/LoadingIndicator/static.js
@@ -3,9 +3,7 @@ import React from 'react';
 import LoadingIndicator from './indicator';
 
 const staticIndicator = (
-    <LoadingIndicator global={true}>
-        Fetching Data...
-    </LoadingIndicator>
+    <LoadingIndicator global={true}>Fetching Data...</LoadingIndicator>
 );
 
 export default staticIndicator;

--- a/packages/venia-ui/lib/components/LoadingIndicator/static.js
+++ b/packages/venia-ui/lib/components/LoadingIndicator/static.js
@@ -3,7 +3,9 @@ import React from 'react';
 import LoadingIndicator from './indicator';
 
 const staticIndicator = (
-    <LoadingIndicator global={true}>{'Fetching Data...'}</LoadingIndicator>
+    <LoadingIndicator global={true}>
+        Fetching Data...
+    </LoadingIndicator>
 );
 
 export default staticIndicator;

--- a/packages/venia-ui/lib/components/MiniCart/cartOptions.js
+++ b/packages/venia-ui/lib/components/MiniCart/cartOptions.js
@@ -17,7 +17,7 @@ const Options = React.lazy(() => import('../ProductOptions'));
 
 const loadingIndicator = (
     <LoadingIndicator>
-        <span>{'Fetching Options...'}</span>
+        <span>Fetching Options...</span>
     </LoadingIndicator>
 );
 

--- a/packages/venia-ui/lib/components/MiniCart/product.js
+++ b/packages/venia-ui/lib/components/MiniCart/product.js
@@ -71,7 +71,7 @@ const Product = props => {
             <div className={classes.quantity}>
                 <div className={classes.quantityRow}>
                     <span>{productQuantity}</span>
-                    <span className={classes.quantityOperator}>{'×'}</span>
+                    <span className={classes.quantityOperator}>×</span>
                     <span className={classes.price}>
                         <Price
                             currencyCode={currencyCode}

--- a/packages/venia-ui/lib/components/MiniCart/totalsSummary.js
+++ b/packages/venia-ui/lib/components/MiniCart/totalsSummary.js
@@ -22,8 +22,7 @@ const TotalsSummary = props => {
                 <dl className={classes.totals}>
                     <dt className={classes.subtotalLabel}>
                         <span>
-                            Cart Total:
-                            {' '}
+                            Cart Total:{' '}
                             <Price
                                 currencyCode={currencyCode}
                                 value={subtotal}

--- a/packages/venia-ui/lib/components/MiniCart/totalsSummary.js
+++ b/packages/venia-ui/lib/components/MiniCart/totalsSummary.js
@@ -22,7 +22,8 @@ const TotalsSummary = props => {
                 <dl className={classes.totals}>
                     <dt className={classes.subtotalLabel}>
                         <span>
-                            {'Cart Total : '}
+                            Cart Total:
+                            {' '}
                             <Price
                                 currencyCode={currencyCode}
                                 value={subtotal}

--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/products.js
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/products.js
@@ -81,9 +81,7 @@ const Products = props => {
                 style={dynamicStyles}
                 className={[classes.root, ...cssClasses].join(' ')}
             >
-                <div className={classes.error}>
-                    No products to display
-                </div>
+                <div className={classes.error}>No products to display</div>
             </div>
         );
     }

--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/products.js
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/products.js
@@ -81,7 +81,9 @@ const Products = props => {
                 style={dynamicStyles}
                 className={[classes.root, ...cssClasses].join(' ')}
             >
-                <div className={classes.error}>{'No products to display'}</div>
+                <div className={classes.error}>
+                    No products to display
+                </div>
             </div>
         );
     }

--- a/packages/venia-ui/lib/components/SearchBar/suggestions.js
+++ b/packages/venia-ui/lib/components/SearchBar/suggestions.js
@@ -29,7 +29,7 @@ const Suggestions = props => {
                 value={searchValue}
             />
             <h2 className={classes.heading}>
-                <span>{'Product Suggestions'}</span>
+                <span>Product Suggestions</span>
             </h2>
             <SuggestedProducts onNavigate={onNavigate} products={items} />
         </Fragment>

--- a/packages/venia-ui/lib/components/SignIn/signIn.js
+++ b/packages/venia-ui/lib/components/SignIn/signIn.js
@@ -27,7 +27,7 @@ const SignIn = props => {
     if (isBusy) {
         return (
             <div className={classes.modal_active}>
-                <LoadingIndicator>{'Signing In'}</LoadingIndicator>
+                <LoadingIndicator>Signing In</LoadingIndicator>
             </div>
         );
     }
@@ -57,7 +57,7 @@ const SignIn = props => {
                 <div className={classes.signInError}>{errorMessage}</div>
                 <div className={classes.signInButton}>
                     <Button priority="high" type="submit">
-                        {'Sign In'}
+                        Sign In
                     </Button>
                 </div>
             </Form>
@@ -70,7 +70,7 @@ const SignIn = props => {
                         root_lowPriority: classes.forgotPasswordButtonRoot
                     }}
                 >
-                    {'Forgot Password?'}
+                    Forgot Password?
                 </Button>
             </div>
             <div className={classes.signInDivider} />
@@ -80,7 +80,7 @@ const SignIn = props => {
                     type="button"
                     onClick={handleCreateAccount}
                 >
-                    {'Create an Account'}
+                    Create an Account
                 </Button>
             </div>
         </div>


### PR DESCRIPTION


## Description

In JSX, some plain text nodes in components are wrapped in JS curlies to parse a string like `{'thing'}`.

This looks like clutter, and I'm not sure if it serves a purpose.

Note: I did not touch attribute values using this technique because I'm guessing React escapes that.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1917

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Should be none. All strings will render as strings without being parsed as JS.

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
