### PR TITLE
Add instructions to circumvent self-signed ssl-certificate errors

### DIFF
--- a/pwa-devdocs/src/venia-pwa-concept/setup/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/setup/index.md
@@ -89,6 +89,11 @@ The Venia storefront has been verified to be compatible with the following local
 
 Don't forget to install the [Venia sample data][]!
 
+{: .bs-callout .bs-callout-info}
+In case you connected to a development Magento environment that has a self-signed SSL-certificate, you might run into an `request to [BACKEND_URL] failed, reason: self signed certificate` error when running `yarn run build` or `yarn run watch`.
+This can be circumvented by adding `NODE_TLS_REJECT_UNAUTHORIZED=0` to `packages/venia-concept/.env`.
+Or, alternatively, you could add the variable to the `yarn` command, e.g. `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn build` or `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn build`
+
 ## Step 5. Start the server
 
 ### Build artifacts

--- a/pwa-devdocs/src/venia-pwa-concept/setup/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/setup/index.md
@@ -92,7 +92,7 @@ Don't forget to install the [Venia sample data][]!
 {: .bs-callout .bs-callout-info}
 In case you connected to a development Magento environment that has a self-signed SSL-certificate, you might run into an `request to [BACKEND_URL] failed, reason: self signed certificate` error when running `yarn run build` or `yarn run watch`.
 This can be circumvented by adding `NODE_TLS_REJECT_UNAUTHORIZED=0` to `packages/venia-concept/.env`.
-Or, alternatively, you could add the variable to the `yarn` command, e.g. `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn build` or `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn build`
+Or, alternatively, you could add the variable to the `yarn` command, e.g. `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn run build` or `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn run watch:venia`
 
 ## Step 5. Start the server
 


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Adds instructions to the readme how to circumvent the `request to [MAGENTO_BACKEND_URL] failed, reason: self signed certificate`.
This is particularly useful when developing locally using a invalid/self-signed certificate. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1924, possibly #1443.

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Run a local instance of Magento with a self-signed certificate
2. Run PWA `yarn run build` with this local instance set as backend
3. Observe that the following error is not thrown:  'request to [MAGENTO_BACKEND_URL] failed, reason: self signed certificate'