### PR TITLE
[doc] Add venia ui component docs

### DIFF
--- a/packages/venia-ui/lib/components/ButtonGroup/buttonGroup.js
+++ b/packages/venia-ui/lib/components/ButtonGroup/buttonGroup.js
@@ -38,16 +38,22 @@ const ButtonGroup = props => {
  * @property {Object} classes An object containing the class names for the
  * ButtonGroup component.
  * @property {string} classes.root classes for root container
- * @property {InferProps<children, key>[]} items the items to evaluate
+ * @property {buttonProps[]} items the items to evaluate
  * memoization recomputation.
- * @property {ReactNodeLike} children any elements that will be child
- * elements inside the root container.
- * @property {string} key the unique for a `Button` element.
  */
 ButtonGroup.propTypes = {
     classes: shape({
         root: string
     }),
+    /**
+     * Props for a {@link ButtonGroup} button component
+     * 
+     * @typedef buttonProps
+     * 
+     * @property {ReactNodeLike} children component to render for the
+     * ButtonGroups's button component
+     * @property {string} key  the unique id for a button element
+     */
     items: arrayOf(
         shape({
             children: node.isRequired,

--- a/packages/venia-ui/lib/components/ButtonGroup/buttonGroup.js
+++ b/packages/venia-ui/lib/components/ButtonGroup/buttonGroup.js
@@ -47,9 +47,9 @@ ButtonGroup.propTypes = {
     }),
     /**
      * Props for a {@link ButtonGroup} button component
-     * 
+     *
      * @typedef buttonProps
-     * 
+     *
      * @property {ReactNodeLike} children component to render for the
      * ButtonGroups's button component
      * @property {string} key  the unique id for a button element

--- a/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
@@ -56,6 +56,14 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'venia-ui/lib/components/Mask/mask.js',
+        type: 'function'
+    },
+    {
+        target: 'venia-ui/lib/components/Modal/modal.js',
+        type: 'function'
+    },
+    {
         target: 'venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Video/video.js',
         type: 'function'
     },

--- a/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
@@ -52,6 +52,10 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'venia-ui/lib/components/Logo/logo.js',
+        type: 'function'
+    },
+    {
         target: 'venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Video/video.js',
         type: 'function'
     },

--- a/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
@@ -68,6 +68,10 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'venia-ui/lib/components/Trigger/trigger.js',
+        type: 'function'
+    },
+    {
         target: 'venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Video/video.js',
         type: 'function'
     },

--- a/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
@@ -64,6 +64,10 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'venia-ui/lib/components/ProductImageCarousel/carousel.js',
+        type: 'function'
+    },
+    {
         target: 'venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Video/video.js',
         type: 'function'
     },

--- a/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
@@ -48,6 +48,10 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'venia-ui/lib/components/ButtonGroup/buttonGroup.js',
+        type: 'function'
+    },
+    {
         target: 'venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Video/video.js',
         type: 'function'
     },

--- a/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia-concept/index.js
@@ -44,6 +44,10 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'venia-ui/lib/components/Button/button.js',
+        type: 'function'
+    },
+    {
         target: 'venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Video/video.js',
         type: 'function'
     },

--- a/pwa-devdocs/src/_data/venia-pwa-concept.yml
+++ b/pwa-devdocs/src/_data/venia-pwa-concept.yml
@@ -15,8 +15,29 @@ entries:
   - label: UI component reference
     entries:
     
+    - label: Button
+      url: /venia-ui/reference/components/Button/
+
+    - label: ButtonGroup
+      url: /venia-ui/reference/components/ButtonGroup/
+
+    - label: Logo
+      url: /venia-ui/reference/components/Logo/
+
+    - label: Mask
+      url: /venia-ui/reference/components/Mask/
+
+    - label: Modal
+      url: /venia-ui/reference/components/Modal/
+
+    - label: ProductImageCarousel
+      url: /venia-ui/reference/components/ProductImageCarousel/
+
     - label: ToastContainer
       url: /venia-ui/reference/components/ToastContainer/
+
+    - label: Trigger
+      url: /venia-ui/reference/components/Trigger/
 
   - label: Features
     entries:

--- a/pwa-devdocs/src/venia-ui/reference/components/Button/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Button/index.md
@@ -1,0 +1,10 @@
+---
+title: Button
+---
+
+<!--
+The reference doc content is generated automatically from the source code.
+To update this section, update the doc blocks in the source code
+-->
+
+{% include auto-generated/venia-ui/lib/components/Button/button.md %}

--- a/pwa-devdocs/src/venia-ui/reference/components/ButtonGroup/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/ButtonGroup/index.md
@@ -1,0 +1,10 @@
+---
+title: ButtonGroup
+---
+
+<!--
+The reference doc content is generated automatically from the source code.
+To update this section, update the doc blocks in the source code
+-->
+
+{% include auto-generated/venia-ui/lib/components/ButtonGroup/buttonGroup.md %}

--- a/pwa-devdocs/src/venia-ui/reference/components/Logo/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Logo/index.md
@@ -1,5 +1,5 @@
 ---
-title: Button
+title: Logo
 ---
 
 <!--
@@ -7,4 +7,4 @@ The reference doc content is generated automatically from the source code.
 To update this section, update the doc blocks in the source code
 -->
 
-{% include auto-generated/venia-ui/lib/components/Button/button.md %}
+{% include auto-generated/venia-ui/lib/components/Logo/logo.md %}

--- a/pwa-devdocs/src/venia-ui/reference/components/Mask/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Mask/index.md
@@ -1,0 +1,10 @@
+---
+title: Mask
+---
+
+<!--
+The reference doc content is generated automatically from the source code.
+To update this section, update the doc blocks in the source code
+-->
+
+{% include auto-generated/venia-ui/lib/components/Mask/mask.md %}

--- a/pwa-devdocs/src/venia-ui/reference/components/Modal/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Modal/index.md
@@ -1,0 +1,10 @@
+---
+title: Modal
+---
+
+<!--
+The reference doc content is generated automatically from the source code.
+To update this section, update the doc blocks in the source code
+-->
+
+{% include auto-generated/venia-ui/lib/components/Modal/modal.md %}

--- a/pwa-devdocs/src/venia-ui/reference/components/ProductImageCarousel/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/ProductImageCarousel/index.md
@@ -1,0 +1,10 @@
+---
+title: ProductImageCarousel
+---
+
+<!--
+The reference doc content is generated automatically from the source code.
+To update this section, update the doc blocks in the source code
+-->
+
+{% include auto-generated/venia-ui/lib/components/ProductImageCarousel/carousel.md %}

--- a/pwa-devdocs/src/venia-ui/reference/components/Trigger/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Trigger/index.md
@@ -1,0 +1,10 @@
+---
+title: Trigger
+---
+
+<!--
+The reference doc content is generated automatically from the source code.
+To update this section, update the doc blocks in the source code
+-->
+
+{% include auto-generated/venia-ui/lib/components/Trigger/trigger.md %}


### PR DESCRIPTION
## Description

Publishes reference docs for the following Venia UI components:

* Button
* ButtonGroup
* Logo
* Mask
* Modal
* ProductImageCarousel
* Trigger

## Related Issue

PWA-88

## Acceptance 

@sirugh 
@jimbo 

### Verification Stakeholders

@sirugh 
@jimbo 

### Verification steps

1. Navigate to `pwa-devdocs` directory
2. Build the HTML preview: `npm run develop`
3. Verify pages for the new components exists and listed in the navigation in the **Venia** section