### PR TITLE
Improve Jest error detection and reporter output (#1615)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@magento/eslint-config": "~1.4.1",
     "@types/jest": "~24.0.18",
+    "caller-id": "~0.1.0",
     "chalk": "~2.4.2",
     "chokidar": "~2.1.2",
     "coveralls": "~3.0.3",

--- a/packages/pwa-buildpack/lib/Utilities/__tests__/graphQL.spec.js
+++ b/packages/pwa-buildpack/lib/Utilities/__tests__/graphQL.spec.js
@@ -71,15 +71,15 @@ describe('getMediaUrl', () => {
 
     test('it should reject when an error occurs', async () => {
         // Setup: simulate a failed fetch.
-        fetch.mockReturnValueOnce(Promise.reject());
+        fetch.mockRejectedValueOnce(new Error('gee'));
 
         // Test & Assert.
-        await expect(getMediaURL()).rejects;
+        await expect(getMediaURL()).rejects.toThrowError('gee');
     });
 
     test('it should reject when the response does not contain storeConfig.secure_base_media_url', async () => {
         // Setup: simulate a response that doesn't have storeConfig.secure_base_media_url.
-        fetch.mockReturnValueOnce(
+        fetch.mockResolvedValueOnce(
             Promise.resolve({
                 json: () => ({
                     data: {}
@@ -120,10 +120,10 @@ describe('getSchemaTypes', () => {
 
     test('it should reject when an error occurs', async () => {
         // Setup: mock fetch returning the successfully.
-        fetch.mockReturnValueOnce(Promise.reject('Error!'));
+        fetch.mockResolvedValueOnce('Error!');
 
         // Test & Assert.
-        await expect(getSchemaTypes()).rejects;
+        await expect(getSchemaTypes()).rejects.toThrowError();
     });
 });
 
@@ -161,9 +161,9 @@ describe('getUnionAndInterfaceTypes', () => {
 
     test('it should reject when an error occurs', async () => {
         // Setup: mock fetch returning the successfully.
-        fetch.mockReturnValueOnce(Promise.reject('Error!'));
+        fetch.mockResolvedValueOnce('Error!');
 
         // Test & Assert.
-        await expect(getUnionAndInterfaceTypes()).rejects;
+        await expect(getUnionAndInterfaceTypes()).rejects.toThrowError();
     });
 });

--- a/packages/venia-concept/__mocks__/fileMock.js
+++ b/packages/venia-concept/__mocks__/fileMock.js
@@ -1,1 +1,0 @@
-module.exports = 'test-file-stub';

--- a/packages/venia-concept/src/__tests__/index.spec.js
+++ b/packages/venia-concept/src/__tests__/index.spec.js
@@ -113,31 +113,3 @@ test('renders the root and subscribes to global events', async () => {
         );
     });
 });
-
-test('registers service worker in prod', () => {
-    const testSwRegistration = async () => {
-        window.addEventListener.mockClear();
-        require('../');
-        const loadListeners = getEventSubscriptions(window, 'load');
-        expect(loadListeners).toHaveLength(1);
-        await loadListeners[0]();
-        expect(navigator.serviceWorker.register).toHaveBeenCalledWith('sw.js');
-    };
-    jest.isolateModules(async () => {
-        const oldNodeEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
-        await testSwRegistration();
-        process.env.NODE_ENV = oldNodeEnv;
-    });
-    jest.isolateModules(async () => {
-        process.env.DEV_SERVER_SERVICE_WORKER_ENABLED = '1';
-        await testSwRegistration();
-    });
-    jest.isolateModules(async () => {
-        process.env.DEV_SERVER_SERVICE_WORKER_ENABLED = '1';
-        navigator.serviceWorker.register.mockRejectedValueOnce(
-            new Error('waaaaagh')
-        );
-        await testSwRegistration();
-    });
-});

--- a/packages/venia-ui/lib/components/ProductFullDetail/__tests__/productFullDetail.spec.js
+++ b/packages/venia-ui/lib/components/ProductFullDetail/__tests__/productFullDetail.spec.js
@@ -6,7 +6,7 @@ import {
 
 import ProductFullDetail from '../productFullDetail';
 
-jest.mock('../../ProductOptions');
+jest.mock('../../ProductOptions', () => () => null);
 jest.mock('../../../classify');
 jest.mock('@magento/peregrine/lib/context/cart', () => {
     const cartState = { isAddingItem: false };

--- a/scripts/jest-catch-rejections.js
+++ b/scripts/jest-catch-rejections.js
@@ -1,0 +1,7 @@
+// Companion to the unhandled rejection captureing environment implemented in
+// `./jest-decorate-env`. This file runs after environment setup, so we can now
+// subscribe to the global unhandledRejection handler.
+if (!process.env.ONLY_SUBSCRIBE_UNHANDLED_REJECTIONS_ONCE) {
+    process.on('unhandledRejection', global.promiseRejectionHandler);
+    process.env.ONLY_SUBSCRIBE_UNHANDLED_REJECTIONS_ONCE = 1;
+}

--- a/scripts/jest-decorate-env.js
+++ b/scripts/jest-decorate-env.js
@@ -1,0 +1,68 @@
+/**
+ * This environment decorator forces any test files containing unhandled promise
+ * rejections to fail. Without it, Node will warn the unhandled rejection as a
+ * future error, but allow the test suite to pass (as of 10.x-12.x).
+ *
+ * We don't want that; even if the issue is just in the test and not the code,
+ * an unhandled rejection _always_ means that the test isn't running correctly,
+ * and it may be returning a false positive. So this environment file tracks
+ * unhandled rejections that occurred during a test run, and then when the run
+ * completes, it will throw a global exception if any unhandled promise
+ * rejections occurred.
+ *
+ * Related links:
+ * https://stackoverflow.com/questions/50121134/how-do-i-fail-a-test-in-jest-when-an-uncaught-promise-rejection-occurs Description of technique
+ * https://github.com/facebook/jest/issues/3251 Jest repo issue
+ * https://gitlab.com/gitlab-org/gitlab-foss/merge_requests/26424/diffs GitLab site source has a similar fix
+ */
+
+// Cleanly printing errors from Jest.
+const { ErrorWithStack } = require('jest-util');
+
+// A test may have several nested timeouts before the rejection occurs; this
+// allows us to pop those async event loops a few times by awaiting a full
+// event loop.
+const tick = () => new Promise(setImmediate);
+
+// We need to make this change for both `jsdom` and `node` environments, so
+// this is actually a function which returns an extended class--that way, we
+// can reuse the code for both environments.
+module.exports = Base =>
+    class RejectionHandlingEnv extends Base {
+        constructor(config, context) {
+            super(config, context);
+            // Environment runs once per test file, so this is an array of all
+            // unhandled rejections in one test file (not the whole test plan).
+            this.unhandledRejections = [];
+
+            // We can't reliably subscribe until _after_ the environment is set
+            // up, but there is no handler for that in the environment. Instead,
+            // we set a global and then subscribe in ./jest-catch-rejections.js,
+            // which jest.config.js runs after environment setup using the
+            // setupFilesAfterEnv config.
+            this.global.promiseRejectionHandler = error =>
+                this.unhandledRejections.push(error);
+        }
+
+        async teardown() {
+            // wait four tickets for promises nested that deep
+            await tick();
+            await tick();
+            await tick();
+            await tick();
+
+            const numUnhandled = this.unhandledRejections.length;
+
+            if (numUnhandled > 0) {
+                let msg = `${numUnhandled} unhandled Promise rejections in this file. Check each test to make sure all Promise rejections are handled. Promises rejected with:`;
+                for (let i = 0; i < numUnhandled; i++) {
+                    msg += ` [#${i + 1}: ${this.unhandledRejections[i]}]`;
+                }
+                // Fail the whole test suite. This will stop all test output
+                // until the rejected promises are fixed.
+                throw new ErrorWithStack(msg, RejectionHandlingEnv);
+            }
+
+            await super.teardown();
+        }
+    };

--- a/scripts/jest-env-jsdom.js
+++ b/scripts/jest-env-jsdom.js
@@ -1,0 +1,6 @@
+// Unhandled-exception-logging jsdom environment.
+// The `./jest-decorate-env` file returns a function that extends any Jest
+// environment class with unhandled rejection handling.
+module.exports = require('./jest-decorate-env')(
+    require('jest-environment-jsdom')
+);

--- a/scripts/jest-env-node.js
+++ b/scripts/jest-env-node.js
@@ -1,0 +1,6 @@
+// Unhandled-exception-logging node environment.
+// The `./jest-decorate-env` file returns a function that extends any Jest
+// environment class with unhandled rejection handling.
+module.exports = require('./jest-decorate-env')(
+    require('jest-environment-node')
+);

--- a/scripts/jest-magic-console.js
+++ b/scripts/jest-magic-console.js
@@ -1,0 +1,58 @@
+/**
+ * Spanish console magic. Quiets the console during test reporting, except
+ * for console methods called _within tests themselves._
+ */
+
+// Turn this whole thing off if we're in debug mode.
+if (!process.env.DEBUG && !process.env.NODE_DEBUG) {
+    const testFileRE = /(__tests__|__helpers__|__mocks__)/;
+
+    const callerId = require('caller-id');
+
+    // keep a ref to the real console for the real homies
+    const realConsole = console;
+
+    // build a fake console using property descriptors
+    const descriptors = {};
+    // in both node and jsdom, the console methods are own properties, so we
+    // can just iterate through them to replace them all
+    for (const method of Object.keys(realConsole)) {
+        // declare the function instead of inlining it because we need a
+        // reference to it to get the correct stacktrace
+        function methodProxy() {
+            // use v8 introspection to get a current stack trace, then pop
+            // frames off the stack until you're in the function that called
+            // this methodProxy, which would be the callsite of `console.log` or
+            // whatever console method you use.
+            const caller = callerId.getDetailedString(methodProxy);
+
+            // callerId.getDetailedString() returns a string including a path
+            // to the calling file, e.g. "render at /path/to/component.js:25"
+            // so we test if the calling file path has a __tests__ directory in
+            // it (or __helpers__ or __mocks__).
+
+            // so if it's a test file itself calling the console method...
+            if (testFileRE.test(caller)) {
+                // then let it through!
+                return realConsole[method].apply(realConsole, arguments);
+            }
+            // otherwise, assume that the application code is calling the
+            // console, and don't output it.
+        }
+        // building the descriptors object method by method
+        descriptors[method] = {
+            value: methodProxy,
+            // the below properties must be true for Jest to spy on and stub
+            // out this fake console when it wants to
+            configurable: true,
+            enumerable: true,
+            writable: true
+        };
+    }
+    // we've built a descriptor object subbing console methods with methodProxy
+
+    // now use it to create a new object and override the global console
+    // Object.create puts Console in the prototype chain, so any code checking
+    // the console's identity will be fooled..
+    global.console = Object.create(console, descriptors);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,6 +4882,13 @@ caller-callsite@^2.0.0:
   dependencies:
     callsites "^2.0.0"
 
+caller-id@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-id/-/caller-id-0.1.0.tgz#59bdac0893d12c3871408279231f97458364f07b"
+  integrity sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=
+  dependencies:
+    stack-trace "~0.0.7"
+
 caller-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
@@ -14846,6 +14853,11 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-trace@~0.0.7:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Description

Improve Jest exception handling and clean up Jest reporter output.

- Remove `fileMock` from venia-concept, since it's used in `venia-ui` now.
- Add env setup file which suppresses console output from application code, _but allows console output from tests themselves_ for debugging purposes (don't leave console output in your tests please)
- Add custom environments for both jsdom and nodejs tests which capture unhandled promise rejections and fail tests if they exist
- Correct the tests that were now failing:
  - `packages/pwa-buildpack/lib/Utilities/__tests__/graphQL.spec.js` was testing promise rejections with statements like `expect(promise).rejects`. In Jest you need to add another assertion after `.rejects`.
  - `packages/venia-concept/src/__tests__/index.spec.js` was trying to re-require the module in a way that caused unhandled rejections. Refactored the implementation for testability and simplified the test.
  - `packages/venia-ui/lib/components/ProductFullDetail/__tests__/productFullDetail.spec.js` was mocking a React component in a way that made it render `undefined`, which was causing a problem in `react-test-renderer`.

### Notes:
- Unhandled promise rejections should be test failures. This solution isn't perfect, but we're trying to get there.
- If you want console output, you can either put console output in the test itself, or set the environment variables `NODE_DEBUG` to `DEBUG` to a non-empty value.
- **Please don't leave console output in your test files.** Console output in your app files themselves will be suppressed, so you don't have to worry about that.

## Related Issue
Closes #1615.

## Acceptance 
### Verification Stakeholders

All core devs and QA:
  - @jimbo  
  - @supernova-at 
  - @sirugh
  - @revanth0212 
  - @dpatil-magento 

### Verification Steps

1. Check out the branch and run a clean install.
2. Run `yarn test`.
3. Observe clean output without messy console logging.
4. Run `NODE_DEBUG=1 yarn test`.
5. Observe all the console output like before.
6. Edit a test and break it: remove an `await` from an asynchronous test to cause an unhandled rejection.
7. Run `yarn run test:dev`.
8. Observe watch mode showing broken test.
9. Correct the test and save the file.
10. Observe watch mode recovering.

Optional:

1. Add a `console.log` statement to a test file, helper file, or mock file.
2. Run `yarn test`.
3. Observe that the console message appears in reporter output even though the others are suppressed.

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
