### PR TITLE
Added tests for registerImagePreFetchHandler in SW.

### DIFF
--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
@@ -1,9 +1,15 @@
+jest.mock('../networkUtils');
+
+import { PREFETCH_IMAGES } from '@magento/venia-ui/lib/constants/swMessageTypes';
 import { THIRTY_DAYS, CATALOG_CACHE_NAME } from '../../defaults';
 import {
     isResizedCatalogImage,
     findSameOrLargerImage,
-    createCatalogCacheHandler
+    createCatalogCacheHandler,
+    registerImagePreFetchHandler
 } from '../imageCacheHandler';
+import { __handlers__ } from '../messageHandler';
+import { isFastNetwork } from '../networkUtils';
 
 describe('Testing isResizedCatalogImage', () => {
     const validCatalogImageURL =
@@ -172,5 +178,126 @@ describe('Testing createCatalogCacheHandler', () => {
         );
 
         expect(cacheableResponsePlugin.statuses).toEqual([0, 200]);
+    });
+});
+
+describe('Testing registerImagePreFetchHandler', () => {
+    function clearHandlersObject() {
+        Object.keys(__handlers__).forEach(messageType => {
+            delete __handlers__[messageType];
+        });
+    }
+
+    const mockMatchFn = jest.fn();
+
+    const mockPutFn = jest.fn();
+
+    const mockFetch = jest.fn();
+
+    beforeAll(() => {
+        global.fetch = mockFetch;
+        global.caches = {
+            open: function() {
+                return Promise.resolve({
+                    put: mockPutFn
+                });
+            },
+            match: mockMatchFn
+        };
+    });
+
+    beforeEach(() => {
+        clearHandlersObject();
+        mockMatchFn.mockRestore();
+        mockPutFn.mockRestore();
+        mockFetch.mockRestore();
+    });
+
+    test('registerImagePreFetchHandler should create a handler for PREFETCH_IMAGES', () => {
+        expect(__handlers__).not.toHaveProperty(PREFETCH_IMAGES);
+
+        registerImagePreFetchHandler();
+
+        expect(__handlers__).toHaveProperty(PREFETCH_IMAGES);
+    });
+
+    test("PREFETCH_IMAGES's handler should not pre fetch is network is slow and send error status as reply", () => {
+        const mockPostmessage = jest.fn();
+        const event = { ports: [{ postMessage: mockPostmessage }] };
+        const payload = {
+            urls: []
+        };
+
+        isFastNetwork.mockReturnValue(false);
+
+        registerImagePreFetchHandler();
+
+        const returnValue = __handlers__[PREFETCH_IMAGES][0](payload, event);
+
+        expect(mockPostmessage).toHaveBeenCalledWith({
+            status: 'error',
+            message: `Slow Network detected. Not pre-fetching images. ${
+                payload.urls
+            }`
+        });
+
+        expect(returnValue).toBeNull();
+    });
+
+    test("If fast network, PREFETCH_IMAGES's handler should fetch images if not cached already and cache it for future use", async () => {
+        const sampleUrl = 'www.adobe.com';
+        const mockPostmessage = jest.fn();
+        const event = { ports: [{ postMessage: mockPostmessage }] };
+        const payload = {
+            urls: [sampleUrl]
+        };
+        const mockClone = jest.fn();
+        const mockRespose = {
+            clone: mockClone
+        };
+        const mockCloneReturnValue = {};
+
+        isFastNetwork.mockReturnValue(true);
+        mockMatchFn.mockReturnValue(Promise.resolve(null));
+        mockFetch.mockReturnValue(Promise.resolve(mockRespose));
+        mockClone.mockReturnValue(mockCloneReturnValue);
+        mockPutFn.mockReturnValue(Promise.resolve(true));
+
+        registerImagePreFetchHandler();
+
+        const handler = __handlers__[PREFETCH_IMAGES][0];
+
+        const returnValue = await handler(payload, event);
+
+        expect(mockPostmessage).toHaveBeenCalledWith({ status: 'done' });
+        expect(mockFetch).toHaveBeenCalledWith(sampleUrl);
+        expect(mockPutFn).toHaveBeenCalledWith(sampleUrl, mockCloneReturnValue);
+        expect(returnValue[0]).toBe(mockRespose);
+    });
+
+    test("If fast network, PERFETCH_IMAGES's handler should not fetch images if already cached", async () => {
+        const sampleUrl = 'www.adobe.com';
+        const mockPostmessage = jest.fn();
+        const event = { ports: [{ postMessage: mockPostmessage }] };
+        const payload = {
+            urls: [sampleUrl]
+        };
+        const mockRespose = {};
+
+        isFastNetwork.mockReturnValue(true);
+        mockMatchFn.mockReturnValue(Promise.resolve(mockRespose));
+        mockFetch.mockReturnValue(Promise.resolve(mockRespose));
+        mockPutFn.mockReturnValue(Promise.resolve(true));
+
+        registerImagePreFetchHandler();
+
+        const handler = __handlers__[PREFETCH_IMAGES][0];
+
+        const returnValue = await handler(payload, event);
+
+        expect(mockPostmessage).toHaveBeenCalledWith({ status: 'done' });
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockPutFn).not.toHaveBeenCalled();
+        expect(returnValue[0]).toBe(mockRespose);
     });
 });

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
@@ -221,7 +221,7 @@ describe('Testing registerImagePreFetchHandler', () => {
         expect(__handlers__).toHaveProperty(PREFETCH_IMAGES);
     });
 
-    test("PREFETCH_IMAGES's handler should not pre fetch is network is slow and send error status as reply", () => {
+    test("PREFETCH_IMAGES's handler should not pre fetch if network is slow and send error status as reply", () => {
         const mockPostmessage = jest.fn();
         const event = { ports: [{ postMessage: mockPostmessage }] };
         const payload = {


### PR DESCRIPTION
## Description

These are tests for the `registerImagePreFetchHandler` which was added recently as part of #1938.

## Related Issue
Closes https://jira.corp.magento.com/browse/PWA-189

### Verification Steps
1. Run `yarn test:ci`. Should not see any errors.

## Checklist
None