### PR TITLE
[feature] Use removeItemFromCart mutation in minicart product

### DIFF
--- a/packages/peregrine/lib/store/actions/cart/asyncActions.js
+++ b/packages/peregrine/lib/store/actions/cart/asyncActions.js
@@ -233,9 +233,8 @@ export const removeItemFromCart = payload => {
     return async function thunk(dispatch, getState) {
         dispatch(actions.removeItem.request(payload));
 
-        const {
-            cart: { cartId }
-        } = getState();
+        const { cart } = getState();
+        const { cartId } = cart;
 
         try {
             await removeItem({

--- a/packages/peregrine/lib/store/actions/cart/asyncActions.js
+++ b/packages/peregrine/lib/store/actions/cart/asyncActions.js
@@ -228,50 +228,29 @@ export const updateItemInCart = (payload = {}) => {
 };
 
 export const removeItemFromCart = payload => {
-    const { item, fetchCartId } = payload;
+    const { item, fetchCartId, removeItem } = payload;
 
     return async function thunk(dispatch, getState) {
         dispatch(actions.removeItem.request(payload));
 
-        const { cart, user } = getState();
-        const { isSignedIn } = user;
-        let isLastItem = false;
-
-        if (cart.details && cart.details.items_count === 1) {
-            isLastItem = true;
-        }
+        const {
+            cart: { cartId }
+        } = getState();
 
         try {
-            const { cartId } = cart;
-            let cartEndpoint;
-
-            if (!isSignedIn) {
-                if (!cartId) {
-                    const missingCartIdError = new Error(
-                        'Missing required information: cartId'
-                    );
-                    missingCartIdError.noCartId = true;
-                    throw missingCartIdError;
+            await removeItem({
+                variables: {
+                    cartId,
+                    itemId: item.item_id
                 }
-                cartEndpoint = `/rest/V1/guest-carts/${cartId}/items/${
-                    item.item_id
-                }`;
-            } else {
-                cartEndpoint = `/rest/V1/carts/mine/items/${item.item_id}`;
-            }
-
-            await request(cartEndpoint, {
-                method: 'DELETE'
             });
 
             dispatch(actions.removeItem.receive());
         } catch (error) {
-            const { response, noCartId } = error;
-
             dispatch(actions.removeItem.receive(error));
 
-            // check if the cart has expired
-            if (noCartId || (response && response.status === 404)) {
+            const shouldResetCart = !error.networkError && isInvalidCart(error);
+            if (shouldResetCart) {
                 // Delete the cached ID from local storage.
                 // The reducer handles clearing out the bad ID from Redux.
                 // In contrast to the save, make sure storage deletion is
@@ -284,29 +263,7 @@ export const removeItemFromCart = payload => {
                         fetchCartId
                     })
                 );
-
-                if (isSignedIn) {
-                    // The user is signed in and we just received their cart.
-                    // Retry this operation.
-                    return thunk(...arguments);
-                }
-
-                // Else the user is a guest and just received a brand new (empty) cart.
-                // We don't retry because we'd be attempting to remove an item
-                // from an empty cart.
             }
-        }
-
-        // When removing the last item in the cart, perform a reset of the Cart ID
-        // and create a new cart to prevent a bug where the next item added to the
-        // cart has a price of 0. Otherwise refresh cart details to get updated totals.
-        if (isLastItem) {
-            await dispatch(removeCart());
-            await dispatch(
-                createCart({
-                    fetchCartId
-                })
-            );
         }
 
         await dispatch(
@@ -541,4 +498,14 @@ export function getQuoteIdForRest(cart, user) {
         }
         return cart.cartId;
     }
+}
+
+// Returns true if the cart is invalid.
+function isInvalidCart(error) {
+    return !!(
+        error.graphQLErrors &&
+        error.graphQLErrors.find(err =>
+            err.message.includes('Could not find a cart')
+        )
+    );
 }

--- a/packages/peregrine/lib/talons/MiniCart/useMiniCart.js
+++ b/packages/peregrine/lib/talons/MiniCart/useMiniCart.js
@@ -11,10 +11,7 @@ export const useMiniCart = props => {
     const { createCartMutation } = props;
     const [fetchCartId] = useMutation(createCartMutation);
     const [{ drawer }, { closeDrawer }] = useAppContext();
-    const [
-        cartState,
-        { updateItemInCart, removeItemFromCart }
-    ] = useCartContext();
+    const [cartState, { updateItemInCart }] = useCartContext();
     const [, { cancelCheckout }] = useCheckoutContext();
     const [step, setStep] = useState('cart');
 
@@ -85,7 +82,6 @@ export const useMiniCart = props => {
         isOpen,
         isUpdatingItem,
         numItems,
-        removeItemFromCart,
         setStep,
         shouldShowFooter,
         step,

--- a/packages/peregrine/lib/talons/MiniCart/useProduct.js
+++ b/packages/peregrine/lib/talons/MiniCart/useProduct.js
@@ -1,18 +1,23 @@
 import { useCallback, useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
+import { useCartContext } from '@magento/peregrine/lib/context/cart';
 
 export const useProduct = props => {
     const {
         beginEditItem,
         createCartMutation,
         item,
-        removeItemFromCart
+        removeItemMutation
     } = props;
     const { image, name, options, price, qty } = item;
+
     const [isFavorite, setIsFavorite] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [, { removeItemFromCart }] = useCartContext();
 
     const [fetchCartId] = useMutation(createCartMutation);
+    const [removeItem] = useMutation(removeItemMutation);
+
     const handleFavoriteItem = useCallback(() => {
         setIsFavorite(!isFavorite);
     }, [isFavorite]);
@@ -25,9 +30,10 @@ export const useProduct = props => {
         setIsLoading(true);
         removeItemFromCart({
             item,
-            fetchCartId
+            fetchCartId,
+            removeItem
         });
-    }, [fetchCartId, item, removeItemFromCart]);
+    }, [fetchCartId, item, removeItem, removeItemFromCart]);
 
     return {
         handleEditItem,

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/miniCart.spec.js.snap
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/miniCart.spec.js.snap
@@ -59,7 +59,6 @@ exports[`renders the correct tree 1`] = `
     isEditingItem={false}
     isLoading={false}
     isUpdatingItem={false}
-    removeItemFromCart={[MockFunction]}
     updateItemInCart={[Function]}
   />
   <button

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/productList.spec.js.snap
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/productList.spec.js.snap
@@ -16,7 +16,6 @@ exports[`renders a list of Products when items are supplied 1`] = `
         "sku": "sku1",
       }
     }
-    removeItemFromCart={[MockFunction]}
   />
   <Product
     beginEditItem={[MockFunction]}
@@ -32,7 +31,6 @@ exports[`renders a list of Products when items are supplied 1`] = `
         "sku": "sku2",
       }
     }
-    removeItemFromCart={[MockFunction]}
   />
 </ul>
 `;

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/miniCart.spec.js
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/miniCart.spec.js
@@ -32,7 +32,7 @@ jest.mock('@magento/peregrine/lib/context/cart', () => {
         details: {},
         totals: {}
     };
-    const api = { updateItemInCart: jest.fn(), removeItemFromCart: jest.fn() };
+    const api = { updateItemInCart: jest.fn() };
     const useCartContext = jest.fn(() => [state, api]);
 
     return { useCartContext };

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/product.spec.js
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/product.spec.js
@@ -16,6 +16,14 @@ jest.mock('@apollo/react-hooks', () => ({
     ])
 }));
 
+jest.mock('@magento/peregrine/lib/context/cart', () => {
+    const state = {};
+    const api = { removeItemFromCart: jest.fn() };
+    const useCartContext = jest.fn(() => [state, api]);
+
+    return { useCartContext };
+});
+
 jest.mock('react', () => {
     const React = jest.requireActual('react');
     const memoSpy = jest.spyOn(React, 'useMemo');

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/productList.spec.js
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/productList.spec.js
@@ -26,9 +26,9 @@ const defaultProps = {
             sku: 'sku2'
         }
     ],
-    currencyCode: 'USD',
-    removeItemFromCart: jest.fn()
+    currencyCode: 'USD'
 };
+
 test('renders a list with no items when items are not supplied', () => {
     const props = {
         ...defaultProps,

--- a/packages/venia-ui/lib/components/MiniCart/body.js
+++ b/packages/venia-ui/lib/components/MiniCart/body.js
@@ -25,7 +25,6 @@ const Body = props => {
         isEditingItem,
         isLoading,
         isUpdatingItem,
-        removeItemFromCart,
         updateItemInCart
     } = props;
 
@@ -63,7 +62,6 @@ const Body = props => {
                 beginEditItem={handleBeginEditItem}
                 cartItems={cartItems}
                 currencyCode={currencyCode}
-                removeItemFromCart={removeItemFromCart}
             />
         </div>
     );
@@ -83,7 +81,6 @@ Body.propTypes = {
     isEditingItem: bool,
     isLoading: bool,
     isUpdatingItem: bool,
-    removeItemFromCart: func,
     updateItemInCart: func
 };
 

--- a/packages/venia-ui/lib/components/MiniCart/miniCart.js
+++ b/packages/venia-ui/lib/components/MiniCart/miniCart.js
@@ -26,7 +26,6 @@ const MiniCart = props => {
         isOpen,
         isUpdatingItem,
         numItems,
-        removeItemFromCart,
         setStep,
         shouldShowFooter,
         step,
@@ -62,7 +61,6 @@ const MiniCart = props => {
                 isEditingItem={isEditingItem}
                 isLoading={isLoading}
                 isUpdatingItem={isUpdatingItem}
-                removeItemFromCart={removeItemFromCart}
                 updateItemInCart={handleUpdateItemInCart}
             />
             <Mask isActive={isMiniCartMaskOpen} dismiss={handleDismiss} />

--- a/packages/venia-ui/lib/components/MiniCart/product.js
+++ b/packages/venia-ui/lib/components/MiniCart/product.js
@@ -12,17 +12,18 @@ import defaultClasses from './product.css';
 import ProductOptions from './productOptions';
 import Section from './section';
 import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
+import REMOVE_ITEM_MUTATION from '../../queries/removeItem.graphql';
 
 const PRODUCT_IMAGE_WIDTH = 80;
 
 const Product = props => {
-    const { beginEditItem, currencyCode, item, removeItemFromCart } = props;
+    const { beginEditItem, currencyCode, item } = props;
 
     const talonProps = useProduct({
         beginEditItem,
         createCartMutation: CREATE_CART_MUTATION,
         item,
-        removeItemFromCart
+        removeItemMutation: REMOVE_ITEM_MUTATION
     });
 
     const {
@@ -116,8 +117,7 @@ Product.propTypes = {
         options: array,
         price: number,
         qty: number
-    }).isRequired,
-    removeItemFromCart: func.isRequired
+    }).isRequired
 };
 
 export default Product;

--- a/packages/venia-ui/lib/components/MiniCart/productList.js
+++ b/packages/venia-ui/lib/components/MiniCart/productList.js
@@ -7,12 +7,7 @@ import Product from './product';
 import defaultClasses from './productList.css';
 
 const ProductList = props => {
-    const {
-        beginEditItem,
-        cartItems,
-        currencyCode,
-        removeItemFromCart
-    } = props;
+    const { beginEditItem, cartItems, currencyCode } = props;
 
     const products = useMemo(
         () =>
@@ -23,11 +18,10 @@ const ProductList = props => {
                         currencyCode={currencyCode}
                         item={product}
                         key={product.item_id}
-                        removeItemFromCart={removeItemFromCart}
                     />
                 );
             }),
-        [beginEditItem, cartItems, currencyCode, removeItemFromCart]
+        [beginEditItem, cartItems, currencyCode]
     );
 
     const classes = mergeClasses(defaultClasses, props.classes);
@@ -41,8 +35,7 @@ ProductList.propTypes = {
     classes: shape({
         root: string
     }),
-    currencyCode: string,
-    removeItemFromCart: func
+    currencyCode: string
 };
 
 export default ProductList;

--- a/packages/venia-ui/lib/queries/removeItem.graphql
+++ b/packages/venia-ui/lib/queries/removeItem.graphql
@@ -1,0 +1,13 @@
+mutation remoteItem($cartId: String!, $itemId: Int!) {
+    removeItemFromCart(input: { cart_id: $cartId, cart_item_id: $itemId }) {
+        cart {
+            items {
+                id
+                product {
+                    name
+                }
+                quantity
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Replaces the REST removal endpoint with use of the graphql mutation.
I also removed some prop threading of the action. Now the `useProduct` talon in minicart directly imports the cart context to use the action.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-142](https://jira.corp.magento.com/browse/PWA-142).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Add an item to your cart.
2. Remove the item.
3. Sign in and repeat steps 1 and 2.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
