### PR TITLE
Switches products filter by name to use match input type instead of eq

### DIFF
--- a/packages/venia-ui/lib/queries/getProductDetailByName.graphql
+++ b/packages/venia-ui/lib/queries/getProductDetailByName.graphql
@@ -1,5 +1,5 @@
 query productDetailByName($name: String, $onServer: Boolean!) {
-    products(filter: { name: { eq: $name } }) {
+    products(filter: { name: { match: $name } }) {
         items {
             __typename
             id


### PR DESCRIPTION
## Description

In 2.3.4, graphQL updated the product filter for name to use a `match` input rather than `eq`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-233](https://jira.corp.magento.com/browse/PWA-233).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Set your backend in .env to a 2.3.4 instance
2. Add a **Configurable** item to your cart
3. Open the cart and click to edit the item. It should open the options form in the cart.
4. Check the network tab for the /graphql query. Make sure the `getProductDetailsByName` query has filter with `match` and not `eq`.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
