### PR TITLE
Removes id from getCustomer response object

### DIFF
--- a/packages/peregrine/lib/talons/AuthModal/useAuthModal.js
+++ b/packages/peregrine/lib/talons/AuthModal/useAuthModal.js
@@ -46,7 +46,7 @@ export const useAuthModal = props => {
     // If the user is authed, the only valid view is "MY_ACCOUNT".
     // view an also be `MENU` but in that case we don't want to act.
     useEffect(() => {
-        if (currentUser && currentUser.id && UNAUTHED_ONLY.includes(view)) {
+        if (currentUser && currentUser.email && UNAUTHED_ONLY.includes(view)) {
             showMyAccount();
         }
     }, [currentUser, showMyAccount, view]);

--- a/packages/venia-ui/lib/queries/getCustomer.graphql
+++ b/packages/venia-ui/lib/queries/getCustomer.graphql
@@ -1,7 +1,6 @@
 # expects bearer header to be set via context to return data
 query getCustomer {
     customer {
-        id
         email
         firstname
         lastname


### PR DESCRIPTION
## Description

`id` is no longer returned by the customer query. The check can just use a different field from the customer response object.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-228](https://jira.corp.magento.com/browse/PWA-228).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Reset local storage
2. Sign in. It should show you the normal authed view after and it should not infinitely spin.
3. Sign out and sign in again -- make sure nothing broke because of the removed `id`.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
