### PR TITLE
[SPIKE] Use response objects instead of making numerous details requests

### DIFF
--- a/packages/peregrine/lib/store/reducers/cart.js
+++ b/packages/peregrine/lib/store/reducers/cart.js
@@ -45,8 +45,6 @@ const reducerMap = {
 
         return {
             ...state,
-            // The only time we should spread the payload into the cart store
-            // is after we've fetched cart details.
             ...payload,
             isLoading: false
         };
@@ -68,6 +66,7 @@ const reducerMap = {
 
         return {
             ...state,
+            ...payload,
             isAddingItem: false
         };
     },
@@ -86,10 +85,9 @@ const reducerMap = {
             };
         }
 
-        // We don't actually have to update any items here
-        // because we force a refresh from the server.
         return {
             ...state,
+            ...payload,
             isUpdatingItem: false
         };
     },
@@ -101,7 +99,8 @@ const reducerMap = {
             };
         }
         return {
-            ...state
+            ...state,
+            ...payload
         };
     },
     [actions.reset]: () => initialState

--- a/packages/peregrine/lib/talons/MiniCart/useCartOptions.js
+++ b/packages/peregrine/lib/talons/MiniCart/useCartOptions.js
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 
 import { appendOptionsToPayload } from '../../util/appendOptionsToPayload';
 import { isProductConfigurable } from '../../util/isProductConfigurable';
@@ -29,7 +28,6 @@ export const useCartOptions = props => {
         configItem,
         createCartMutation,
         endEditItem,
-        getCartDetailsQuery,
         removeItemMutation,
         updateItemMutation
     } = props;
@@ -55,7 +53,6 @@ export const useCartOptions = props => {
     const [fetchCartId] = useMutation(createCartMutation);
     const [removeItem] = useMutation(removeItemMutation);
     const [updateItem] = useMutation(updateItemMutation);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const initialOptionSelections = useMemo(() => {
         const result = new Map();
@@ -118,7 +115,6 @@ export const useCartOptions = props => {
         await updateItemInCart({
             ...payload,
             addItemMutation,
-            fetchCartDetails,
             fetchCartId,
             removeItem,
             updateItem
@@ -129,7 +125,6 @@ export const useCartOptions = props => {
         quantity,
         cartItem.id,
         updateItemInCart,
-        fetchCartDetails,
         fetchCartId,
         removeItem,
         updateItem,

--- a/packages/peregrine/lib/talons/MiniCart/useProduct.js
+++ b/packages/peregrine/lib/talons/MiniCart/useProduct.js
@@ -1,13 +1,11 @@
 import { useCallback, useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 
 export const useProduct = props => {
     const {
         beginEditItem,
         createCartMutation,
-        getCartDetailsQuery,
         item,
         removeItemMutation
     } = props;
@@ -22,7 +20,6 @@ export const useProduct = props => {
 
     const [fetchCartId] = useMutation(createCartMutation);
     const [removeItem] = useMutation(removeItemMutation);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const handleFavoriteItem = useCallback(() => {
         setIsFavorite(!isFavorite);
@@ -36,11 +33,10 @@ export const useProduct = props => {
         setIsLoading(true);
         removeItemFromCart({
             item,
-            fetchCartDetails,
             fetchCartId,
             removeItem
         });
-    }, [fetchCartDetails, fetchCartId, item, removeItem, removeItemFromCart]);
+    }, [fetchCartId, item, removeItem, removeItemFromCart]);
 
     return {
         handleEditItem,

--- a/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
@@ -5,7 +5,7 @@ import { useCartContext } from '@magento/peregrine/lib/context/cart';
 import { appendOptionsToPayload } from '@magento/peregrine/lib/util/appendOptionsToPayload';
 import { findMatchingVariant } from '@magento/peregrine/lib/util/findMatchingProductVariant';
 import { isProductConfigurable } from '@magento/peregrine/lib/util/isProductConfigurable';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
+import { useAppContext } from '../../context/app';
 
 const INITIAL_OPTION_CODES = new Map();
 const INITIAL_OPTION_SELECTIONS = new Map();
@@ -149,7 +149,6 @@ export const useProductFullDetail = props => {
         addConfigurableProductToCartMutation,
         addSimpleProductToCartMutation,
         createCartMutation,
-        getCartDetailsQuery,
         product
     } = props;
 
@@ -160,6 +159,7 @@ export const useProductFullDetail = props => {
     );
 
     const [{ isAddingItem }, { addItemToCart }] = useCartContext();
+    const [, { toggleDrawer }] = useAppContext();
 
     const [addConfigurableProductToCart] = useMutation(
         addConfigurableProductToCartMutation
@@ -170,8 +170,6 @@ export const useProductFullDetail = props => {
     );
 
     const [fetchCartId] = useMutation(createCartMutation);
-
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const [quantity, setQuantity] = useState(INITIAL_QUANTITY);
 
@@ -204,7 +202,7 @@ export const useProductFullDetail = props => {
         [product, optionCodes, optionSelections]
     );
 
-    const handleAddToCart = useCallback(() => {
+    const handleAddToCart = useCallback(async () => {
         const payload = {
             item: product,
             productType,
@@ -224,12 +222,12 @@ export const useProductFullDetail = props => {
                 addItemMutation = addConfigurableProductToCart;
             }
 
-            addItemToCart({
+            await addItemToCart({
                 ...payload,
                 addItemMutation,
-                fetchCartDetails,
                 fetchCartId
             });
+            toggleDrawer('cart');
         } else {
             console.error('Unsupported product type. Cannot add to cart.');
         }
@@ -237,14 +235,14 @@ export const useProductFullDetail = props => {
         addConfigurableProductToCart,
         addItemToCart,
         addSimpleProductToCart,
-        fetchCartDetails,
         fetchCartId,
         isSupportedProductType,
         optionCodes,
         optionSelections,
         product,
         productType,
-        quantity
+        quantity,
+        toggleDrawer
     ]);
 
     const handleSelectionChange = useCallback(

--- a/packages/venia-ui/lib/components/MiniCart/cartOptions.js
+++ b/packages/venia-ui/lib/components/MiniCart/cartOptions.js
@@ -15,7 +15,6 @@ import ADD_SIMPLE_MUTATION from '../../queries/addSimpleProductsToCart.graphql';
 import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
 import REMOVE_ITEM_MUTATION from '../../queries/removeItem.graphql';
 import UPDATE_ITEM_MUTATION from '../../queries/updateItemInCart.graphql';
-import GET_CART_DETAILS_QUERY from '../../queries/getCartDetails.graphql';
 
 import defaultClasses from './cartOptions.css';
 
@@ -37,7 +36,6 @@ const CartOptions = props => {
         configItem,
         createCartMutation: CREATE_CART_MUTATION,
         endEditItem,
-        getCartDetailsQuery: GET_CART_DETAILS_QUERY,
         removeItemMutation: REMOVE_ITEM_MUTATION,
         updateItemMutation: UPDATE_ITEM_MUTATION
     });

--- a/packages/venia-ui/lib/components/MiniCart/product.js
+++ b/packages/venia-ui/lib/components/MiniCart/product.js
@@ -13,7 +13,6 @@ import ProductOptions from './productOptions';
 import Section from './section';
 import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
 import REMOVE_ITEM_MUTATION from '../../queries/removeItem.graphql';
-import GET_CART_DETAILS_QUERY from '../../queries/getCartDetails.graphql';
 
 const PRODUCT_IMAGE_WIDTH = 80;
 
@@ -23,7 +22,6 @@ const Product = props => {
     const talonProps = useProduct({
         beginEditItem,
         createCartMutation: CREATE_CART_MUTATION,
-        getCartDetailsQuery: GET_CART_DETAILS_QUERY,
         item,
         removeItemMutation: REMOVE_ITEM_MUTATION
     });

--- a/packages/venia-ui/lib/components/ProductFullDetail/productFullDetail.js
+++ b/packages/venia-ui/lib/components/ProductFullDetail/productFullDetail.js
@@ -15,7 +15,6 @@ import RichText from '../RichText';
 import ADD_CONFIGURABLE_MUTATION from '../../queries/addConfigurableProductsToCart.graphql';
 import ADD_SIMPLE_MUTATION from '../../queries/addSimpleProductsToCart.graphql';
 import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
-import GET_CART_DETAILS_QUERY from '../../queries/getCartDetails.graphql';
 
 import defaultClasses from './productFullDetail.css';
 import { mergeClasses } from '../../classify';
@@ -29,7 +28,6 @@ const ProductFullDetail = props => {
         addConfigurableProductToCartMutation: ADD_CONFIGURABLE_MUTATION,
         addSimpleProductToCartMutation: ADD_SIMPLE_MUTATION,
         createCartMutation: CREATE_CART_MUTATION,
-        getCartDetailsQuery: GET_CART_DETAILS_QUERY,
         product
     });
 

--- a/packages/venia-ui/lib/queries/addConfigurableProductsToCart.graphql
+++ b/packages/venia-ui/lib/queries/addConfigurableProductsToCart.graphql
@@ -32,6 +32,7 @@ mutation addConfigurableProductToCart(
                             }
                         }
                     }
+                    url_key
                 }
                 quantity
                 ... on ConfigurableCartItem {

--- a/packages/venia-ui/lib/queries/addConfigurableProductsToCart.graphql
+++ b/packages/venia-ui/lib/queries/addConfigurableProductsToCart.graphql
@@ -4,7 +4,7 @@ mutation addConfigurableProductToCart(
     $sku: String!
     $parentSku: String!
 ) {
-    addConfigurableProductsToCart(
+    response: addConfigurableProductsToCart(
         input: {
             cart_id: $cartId
             cart_items: [
@@ -21,8 +21,33 @@ mutation addConfigurableProductToCart(
                 product {
                     name
                     sku
+                    small_image {
+                        url
+                        label
+                    }
+                    price {
+                        regularPrice {
+                            amount {
+                                value
+                            }
+                        }
+                    }
                 }
                 quantity
+                ... on ConfigurableCartItem {
+                    configurable_options {
+                        id
+                        option_label
+                        value_id
+                        value_label
+                    }
+                }
+            }
+            prices {
+                grand_total {
+                    value
+                    currency
+                }
             }
         }
     }

--- a/packages/venia-ui/lib/queries/addSimpleProductsToCart.graphql
+++ b/packages/venia-ui/lib/queries/addSimpleProductsToCart.graphql
@@ -3,7 +3,7 @@ mutation addSimpleProductToCart(
     $quantity: Float!
     $sku: String!
 ) {
-    addSimpleProductsToCart(
+    response: addSimpleProductsToCart(
         input: {
             cart_id: $cartId
             cart_items: [{ data: { quantity: $quantity, sku: $sku } }]
@@ -15,8 +15,33 @@ mutation addSimpleProductToCart(
                 product {
                     name
                     sku
+                    small_image {
+                        url
+                        label
+                    }
+                    price {
+                        regularPrice {
+                            amount {
+                                value
+                            }
+                        }
+                    }
                 }
                 quantity
+                ... on ConfigurableCartItem {
+                    configurable_options {
+                        id
+                        option_label
+                        value_id
+                        value_label
+                    }
+                }
+            }
+            prices {
+                grand_total {
+                    value
+                    currency
+                }
             }
         }
     }

--- a/packages/venia-ui/lib/queries/addSimpleProductsToCart.graphql
+++ b/packages/venia-ui/lib/queries/addSimpleProductsToCart.graphql
@@ -26,6 +26,7 @@ mutation addSimpleProductToCart(
                             }
                         }
                     }
+                    url_key
                 }
                 quantity
                 ... on ConfigurableCartItem {

--- a/packages/venia-ui/lib/queries/getCartDetails.graphql
+++ b/packages/venia-ui/lib/queries/getCartDetails.graphql
@@ -5,6 +5,7 @@ query getCartDetails($cartId: String!) {
             product {
                 name
                 sku
+                url_key
                 small_image {
                     url
                     label

--- a/packages/venia-ui/lib/queries/removeItem.graphql
+++ b/packages/venia-ui/lib/queries/removeItem.graphql
@@ -8,6 +8,7 @@ mutation remoteItem($cartId: String!, $itemId: Int!) {
                 product {
                     name
                     sku
+                    url_key
                     small_image {
                         url
                         label

--- a/packages/venia-ui/lib/queries/removeItem.graphql
+++ b/packages/venia-ui/lib/queries/removeItem.graphql
@@ -1,12 +1,40 @@
 mutation remoteItem($cartId: String!, $itemId: Int!) {
-    removeItemFromCart(input: { cart_id: $cartId, cart_item_id: $itemId }) {
+    response: removeItemFromCart(
+        input: { cart_id: $cartId, cart_item_id: $itemId }
+    ) {
         cart {
             items {
                 id
                 product {
                     name
+                    sku
+                    small_image {
+                        url
+                        label
+                    }
+                    price {
+                        regularPrice {
+                            amount {
+                                value
+                            }
+                        }
+                    }
                 }
                 quantity
+                ... on ConfigurableCartItem {
+                    configurable_options {
+                        id
+                        option_label
+                        value_id
+                        value_label
+                    }
+                }
+            }
+            prices {
+                grand_total {
+                    value
+                    currency
+                }
             }
         }
     }

--- a/packages/venia-ui/lib/queries/updateItemInCart.graphql
+++ b/packages/venia-ui/lib/queries/updateItemInCart.graphql
@@ -1,5 +1,5 @@
 mutation updateItemInCart($cartId: String!, $itemId: Int!, $quantity: Float!) {
-    updateCartItems(
+    response: updateCartItems(
         input: {
             cart_id: $cartId
             cart_items: [{ cart_item_id: $itemId, quantity: $quantity }]
@@ -10,8 +10,34 @@ mutation updateItemInCart($cartId: String!, $itemId: Int!, $quantity: Float!) {
                 id
                 product {
                     name
+                    sku
+                    small_image {
+                        url
+                        label
+                    }
+                    price {
+                        regularPrice {
+                            amount {
+                                value
+                            }
+                        }
+                    }
                 }
                 quantity
+                ... on ConfigurableCartItem {
+                    configurable_options {
+                        id
+                        option_label
+                        value_id
+                        value_label
+                    }
+                }
+            }
+            prices {
+                grand_total {
+                    value
+                    currency
+                }
             }
         }
     }


### PR DESCRIPTION
##  Description

What does it look like if we use GQL to return the data we need to render the cart rather than calling a new fetch after each mutation? This!

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the FOO page.
2. Verify the BAR shows up.
3. Make sure BAZ does a thing.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
