### PR TITLE
[bugfix] After adding product to cart toggle the cart drawer

### DIFF
--- a/packages/peregrine/lib/store/actions/cart/__tests__/asyncActions.spec.js
+++ b/packages/peregrine/lib/store/actions/cart/__tests__/asyncActions.spec.js
@@ -189,7 +189,7 @@ describe('addItemToCart', () => {
         // Call the function.
         await addItemToCart(payload)(...thunkArgs);
 
-        expect(dispatch).toHaveBeenCalledTimes(4);
+        expect(dispatch).toHaveBeenCalledTimes(3);
         // Make assertions.
         expect(dispatch).toHaveBeenNthCalledWith(
             1,
@@ -197,9 +197,7 @@ describe('addItemToCart', () => {
         );
         // getCartDetails
         expect(dispatch).toHaveBeenNthCalledWith(2, expect.any(Function));
-        // toggleDrawer
-        expect(dispatch).toHaveBeenNthCalledWith(3, expect.any(Function));
-        expect(dispatch).toHaveBeenNthCalledWith(4, actions.addItem.receive());
+        expect(dispatch).toHaveBeenNthCalledWith(3, actions.addItem.receive());
     });
 
     test('its thunk tries to recreate a cart on non-network, invalid cart failure', async () => {
@@ -219,7 +217,7 @@ describe('addItemToCart', () => {
             ...customPayload
         })(...thunkArgs);
 
-        expect(dispatch).toHaveBeenCalledTimes(9);
+        expect(dispatch).toHaveBeenCalledTimes(8);
 
         /*
          * Initial attempt will fail.
@@ -249,10 +247,8 @@ describe('addItemToCart', () => {
         );
         // getCartDetails
         expect(dispatch).toHaveBeenNthCalledWith(7, expect.any(Function));
-        // toggleDrawer
-        expect(dispatch).toHaveBeenNthCalledWith(8, expect.any(Function));
         // addItem.receive
-        expect(dispatch).toHaveBeenNthCalledWith(9, actions.addItem.receive());
+        expect(dispatch).toHaveBeenNthCalledWith(8, actions.addItem.receive());
     });
 });
 

--- a/packages/peregrine/lib/store/actions/cart/asyncActions.js
+++ b/packages/peregrine/lib/store/actions/cart/asyncActions.js
@@ -1,5 +1,4 @@
 import BrowserPersistence from '../../../util/simplePersistence';
-import { toggleDrawer } from '../app';
 import actions from './actions';
 
 const storage = new BrowserPersistence();
@@ -86,7 +85,6 @@ export const addItemToCart = (payload = {}) => {
                     fetchCartDetails
                 })
             );
-            await dispatch(toggleDrawer('cart'));
             dispatch(actions.addItem.receive());
         } catch (error) {
             dispatch(actions.addItem.receive(error));

--- a/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
@@ -2,10 +2,11 @@ import { useCallback, useState, useMemo } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
 
+import { useAppContext } from '@magento/peregrine/lib/context/app';
+import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 import { appendOptionsToPayload } from '@magento/peregrine/lib/util/appendOptionsToPayload';
 import { findMatchingVariant } from '@magento/peregrine/lib/util/findMatchingProductVariant';
 import { isProductConfigurable } from '@magento/peregrine/lib/util/isProductConfigurable';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 
 const INITIAL_OPTION_CODES = new Map();
 const INITIAL_OPTION_SELECTIONS = new Map();
@@ -159,6 +160,7 @@ export const useProductFullDetail = props => {
         productType
     );
 
+    const [, { toggleDrawer }] = useAppContext();
     const [{ isAddingItem }, { addItemToCart }] = useCartContext();
 
     const [addConfigurableProductToCart] = useMutation(
@@ -204,7 +206,7 @@ export const useProductFullDetail = props => {
         [product, optionCodes, optionSelections]
     );
 
-    const handleAddToCart = useCallback(() => {
+    const handleAddToCart = useCallback(async () => {
         const payload = {
             item: product,
             productType,
@@ -224,12 +226,13 @@ export const useProductFullDetail = props => {
                 addItemMutation = addConfigurableProductToCart;
             }
 
-            addItemToCart({
+            await addItemToCart({
                 ...payload,
                 addItemMutation,
                 fetchCartDetails,
                 fetchCartId
             });
+            toggleDrawer('cart');
         } else {
             console.error('Unsupported product type. Cannot add to cart.');
         }
@@ -244,7 +247,8 @@ export const useProductFullDetail = props => {
         optionSelections,
         product,
         productType,
-        quantity
+        quantity,
+        toggleDrawer
     ]);
 
     const handleSelectionChange = useCallback(

--- a/packages/venia-ui/lib/components/ProductFullDetail/__tests__/productFullDetail.spec.js
+++ b/packages/venia-ui/lib/components/ProductFullDetail/__tests__/productFullDetail.spec.js
@@ -20,6 +20,14 @@ jest.mock('@apollo/react-hooks', () => ({
     ])
 }));
 
+jest.mock('@magento/peregrine/lib/context/app', () => {
+    const state = {};
+    const api = { toggleDrawer: jest.fn() };
+    const useAppContext = jest.fn(() => [state, api]);
+
+    return { useAppContext };
+});
+
 jest.mock('@magento/peregrine/lib/context/cart', () => {
     const cartState = { isAddingItem: false };
     const cartApi = { addItemToCart: jest.fn() };


### PR DESCRIPTION
## Description

When we moved updateItem to gql we, for configurable items, used the remove/add actions internally.

The add action used to invoke `toggleDrawer('cart')`, which no longer makes sense in this sense.

So instead of toggling within the action we now toggle in the UI where we should, after the action resolves.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-253](https://jira.corp.magento.com/browse/PWA-253).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Add a configurable item to the cart. It should toggle the cart.
2. Add a simple item to the cart. It should toggle the cart.
2. Update the configurable item. It should not close the cart after it is updated.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
