### PR TITLE
[spike] Rugh/spike cart cache

### DIFF
--- a/packages/peregrine/lib/context/cart.js
+++ b/packages/peregrine/lib/context/cart.js
@@ -1,14 +1,17 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import { useLazyQuery } from '@apollo/react-hooks';
 import { connect } from 'react-redux';
 
 import actions from '../store/actions/cart/actions';
 import * as asyncActions from '../store/actions/cart/asyncActions';
 import bindActionCreators from '../util/bindActionCreators';
 
+// TODO Where would we store this?
+import GET_CART_DETAILS_QUERY from '../../../venia-ui/lib/queries/getCartDetails.graphql';
+
 const CartContext = createContext();
 
-const isCartEmpty = cart =>
-    !cart || !cart.details.items || cart.details.items.length === 0;
+const isCartEmpty = cart => !cart || !cart.items || cart.items.length === 0;
 
 const getTotalQuantity = items =>
     items.reduce((total, item) => total + item.quantity, 0);
@@ -16,9 +19,22 @@ const getTotalQuantity = items =>
 const CartContextProvider = props => {
     const { actions, asyncActions, cartState, children } = props;
 
+    const { cartId } = cartState;
+    const [fetchCartDetails, { data = {} }] = useLazyQuery(
+        GET_CART_DETAILS_QUERY
+    );
+
+    useEffect(() => {
+        if (cartId) {
+            fetchCartDetails({
+                variables: { cartId }
+            });
+        }
+    }, [cartId, fetchCartDetails]);
+
     // Make deeply nested details easier to retrieve and provide empty defaults
     const derivedDetails = useMemo(() => {
-        if (isCartEmpty(cartState)) {
+        if (isCartEmpty(data.cart)) {
             return {
                 currencyCode: 'USD',
                 numItems: 0,
@@ -26,16 +42,17 @@ const CartContextProvider = props => {
             };
         } else {
             return {
-                currencyCode: cartState.details.prices.grand_total.currency,
-                numItems: getTotalQuantity(cartState.details.items),
-                subtotal: cartState.details.prices.grand_total.value
+                currencyCode: data.cart.prices.grand_total.currency,
+                numItems: getTotalQuantity(data.cart.items),
+                subtotal: data.cart.prices.grand_total.value
             };
         }
-    }, [cartState]);
+    }, [data.cart]);
 
     const derivedCartState = {
         ...cartState,
-        isEmpty: isCartEmpty(cartState),
+        isEmpty: isCartEmpty(data.cart),
+        details: (data && data.cart) || {},
         derivedDetails
     };
 

--- a/packages/peregrine/lib/talons/App/useApp.js
+++ b/packages/peregrine/lib/talons/App/useApp.js
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+
 import errorRecord from '@magento/peregrine/lib/util/createErrorRecord';
 import { useAppContext } from '@magento/peregrine/lib/context/app';
+import { useCartContext } from '@magento/peregrine/lib/context/cart';
+
+// TODO: Pass from component
+import CREATE_CART_MUTATION from '../../../../venia-ui/lib/queries/createCart.graphql';
 
 const dismissers = new WeakMap();
 
@@ -40,6 +46,14 @@ export const useApp = props => {
     } = props;
 
     const [isHTMLUpdateAvailable, setHTMLUpdateAvailable] = useState(false);
+    const [fetchCartId] = useMutation(CREATE_CART_MUTATION);
+    const [, { createCart }] = useCartContext();
+
+    useEffect(() => {
+        createCart({
+            fetchCartId
+        });
+    }, [createCart, fetchCartId]);
 
     const resetHTMLUpdateAvaialable = useCallback(
         () => setHTMLUpdateAvailable(false),

--- a/packages/peregrine/lib/talons/CreateAccount/useCreateAccount.js
+++ b/packages/peregrine/lib/talons/CreateAccount/useCreateAccount.js
@@ -26,14 +26,13 @@ export const useCreateAccount = props => {
         createAccountQuery,
         createCartMutation,
         customerQuery,
-        getCartDetailsQuery,
         initialValues = {},
         onSubmit,
         signInMutation
     } = props;
 
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [, { createCart, getCartDetails, removeCart }] = useCartContext();
+    const [, { createCart, removeCart }] = useCartContext();
     const [
         { isGettingDetails, isSignedIn },
         { getUserDetails, setToken }
@@ -46,7 +45,6 @@ export const useCreateAccount = props => {
     const [fetchCartId] = useMutation(createCartMutation);
     const [signIn, { error: signInError }] = useMutation(signInMutation);
     const fetchUserDetails = useAwaitQuery(customerQuery);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const errors = [];
     if (createAccountError) {
@@ -83,18 +81,14 @@ export const useCreateAccount = props => {
 
                 await setToken(token);
 
-                await getUserDetails({ fetchUserDetails });
-
+                // Immediately remove/create the cart.
+                // TODO: This logic may be replacable with mergeCart in 2.3.4
                 await removeCart();
-
-                await createCart({
+                createCart({
                     fetchCartId
                 });
 
-                await getCartDetails({
-                    fetchCartId,
-                    fetchCartDetails
-                });
+                await getUserDetails({ fetchUserDetails });
 
                 // Finally, invoke the post-submission callback.
                 onSubmit();
@@ -108,10 +102,8 @@ export const useCreateAccount = props => {
         [
             createAccount,
             createCart,
-            fetchCartDetails,
             fetchCartId,
             fetchUserDetails,
-            getCartDetails,
             getUserDetails,
             onSubmit,
             removeCart,

--- a/packages/peregrine/lib/talons/Header/useCartTrigger.js
+++ b/packages/peregrine/lib/talons/Header/useCartTrigger.js
@@ -1,15 +1,46 @@
-import { useCallback } from 'react';
-import { useCartContext } from '@magento/peregrine/lib/context/cart';
+import { useCallback, useEffect } from 'react';
+import { useLazyQuery } from '@apollo/react-hooks';
+
 import { useAppContext } from '@magento/peregrine/lib/context/app';
+import { useCartContext } from '@magento/peregrine/lib/context/cart';
+
+import gql from 'graphql-tag';
+
+const GET_ITEM_QUANTITY_GQL = gql`
+    query getCartDetails($cartId: String!) {
+        cart(cart_id: $cartId) {
+            items {
+                id
+                quantity
+            }
+        }
+    }
+`;
+
+const getTotalQuantity = items =>
+    items.reduce((total, item) => total + item.quantity, 0);
 
 export const useCartTrigger = () => {
     const [, { toggleDrawer }] = useAppContext();
-    const [{ derivedDetails }] = useCartContext();
-    const { numItems: itemCount } = derivedDetails;
+    const [{ cartId }] = useCartContext();
+    const [getItemQuantities, { data }] = useLazyQuery(GET_ITEM_QUANTITY_GQL);
+
+    useEffect(() => {
+        if (cartId) {
+            getItemQuantities({
+                variables: { cartId }
+            });
+        }
+    }, [cartId, getItemQuantities]);
 
     const handleClick = useCallback(async () => {
         toggleDrawer('cart');
     }, [toggleDrawer]);
+
+    const itemCount =
+        data && data.cart && data.cart.items
+            ? getTotalQuantity(data.cart.items)
+            : 0;
 
     return {
         handleClick,

--- a/packages/peregrine/lib/talons/Header/useCartTrigger.js
+++ b/packages/peregrine/lib/talons/Header/useCartTrigger.js
@@ -1,32 +1,15 @@
-import { useCallback, useEffect } from 'react';
-import { useMutation } from '@apollo/react-hooks';
+import { useCallback } from 'react';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
 import { useAppContext } from '@magento/peregrine/lib/context/app';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 
-export const useCartTrigger = props => {
-    const { createCartMutation, getCartDetailsQuery } = props;
+export const useCartTrigger = () => {
     const [, { toggleDrawer }] = useAppContext();
-    const [{ derivedDetails }, { getCartDetails }] = useCartContext();
+    const [{ derivedDetails }] = useCartContext();
     const { numItems: itemCount } = derivedDetails;
-
-    const [fetchCartId] = useMutation(createCartMutation);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
-
-    useEffect(() => {
-        getCartDetails({
-            fetchCartId,
-            fetchCartDetails
-        });
-    }, [fetchCartDetails, fetchCartId, getCartDetails]);
 
     const handleClick = useCallback(async () => {
         toggleDrawer('cart');
-        await getCartDetails({
-            fetchCartId,
-            fetchCartDetails
-        });
-    }, [fetchCartDetails, fetchCartId, getCartDetails, toggleDrawer]);
+    }, [toggleDrawer]);
 
     return {
         handleClick,

--- a/packages/peregrine/lib/talons/MiniCart/useCartOptions.js
+++ b/packages/peregrine/lib/talons/MiniCart/useCartOptions.js
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 
 import { appendOptionsToPayload } from '../../util/appendOptionsToPayload';
 import { isProductConfigurable } from '../../util/isProductConfigurable';
@@ -55,7 +54,6 @@ export const useCartOptions = props => {
     const [fetchCartId] = useMutation(createCartMutation);
     const [removeItem] = useMutation(removeItemMutation);
     const [updateItem] = useMutation(updateItemMutation);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const initialOptionSelections = useMemo(() => {
         const result = new Map();
@@ -118,7 +116,7 @@ export const useCartOptions = props => {
         await updateItemInCart({
             ...payload,
             addItemMutation,
-            fetchCartDetails,
+            getCartDetailsQuery,
             fetchCartId,
             removeItem,
             updateItem
@@ -129,7 +127,7 @@ export const useCartOptions = props => {
         quantity,
         cartItem.id,
         updateItemInCart,
-        fetchCartDetails,
+        getCartDetailsQuery,
         fetchCartId,
         removeItem,
         updateItem,

--- a/packages/peregrine/lib/talons/MiniCart/useProduct.js
+++ b/packages/peregrine/lib/talons/MiniCart/useProduct.js
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 
 export const useProduct = props => {
     const {
@@ -22,7 +21,6 @@ export const useProduct = props => {
 
     const [fetchCartId] = useMutation(createCartMutation);
     const [removeItem] = useMutation(removeItemMutation);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const handleFavoriteItem = useCallback(() => {
         setIsFavorite(!isFavorite);
@@ -36,11 +34,17 @@ export const useProduct = props => {
         setIsLoading(true);
         removeItemFromCart({
             item,
-            fetchCartDetails,
+            getCartDetailsQuery,
             fetchCartId,
             removeItem
         });
-    }, [fetchCartDetails, fetchCartId, item, removeItem, removeItemFromCart]);
+    }, [
+        fetchCartId,
+        getCartDetailsQuery,
+        item,
+        removeItem,
+        removeItemFromCart
+    ]);
 
     return {
         handleEditItem,

--- a/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
@@ -3,7 +3,6 @@ import { useMutation } from '@apollo/react-hooks';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
 
 import { useAppContext } from '@magento/peregrine/lib/context/app';
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 import { appendOptionsToPayload } from '@magento/peregrine/lib/util/appendOptionsToPayload';
 import { findMatchingVariant } from '@magento/peregrine/lib/util/findMatchingProductVariant';
 import { isProductConfigurable } from '@magento/peregrine/lib/util/isProductConfigurable';

--- a/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
@@ -173,8 +173,6 @@ export const useProductFullDetail = props => {
 
     const [fetchCartId] = useMutation(createCartMutation);
 
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
-
     const [quantity, setQuantity] = useState(INITIAL_QUANTITY);
 
     const breadcrumbCategoryId = useMemo(
@@ -229,8 +227,8 @@ export const useProductFullDetail = props => {
             await addItemToCart({
                 ...payload,
                 addItemMutation,
-                fetchCartDetails,
-                fetchCartId
+                fetchCartId,
+                getCartDetailsQuery
             });
             toggleDrawer('cart');
         } else {
@@ -240,8 +238,8 @@ export const useProductFullDetail = props => {
         addConfigurableProductToCart,
         addItemToCart,
         addSimpleProductToCart,
-        fetchCartDetails,
         fetchCartId,
+        getCartDetailsQuery,
         isSupportedProductType,
         optionCodes,
         optionSelections,

--- a/packages/peregrine/lib/talons/SignIn/useSignIn.js
+++ b/packages/peregrine/lib/talons/SignIn/useSignIn.js
@@ -8,7 +8,6 @@ export const useSignIn = props => {
     const {
         createCartMutation,
         customerQuery,
-        getCartDetailsQuery,
         setDefaultUsername,
         showCreateAccount,
         showForgotPassword,
@@ -17,7 +16,7 @@ export const useSignIn = props => {
 
     const [isSigningIn, setIsSigningIn] = useState(false);
 
-    const [, { createCart, getCartDetails, removeCart }] = useCartContext();
+    const [, { createCart, removeCart }] = useCartContext();
     const [
         { isGettingDetails, getDetailsError },
         { getUserDetails, setToken }
@@ -26,7 +25,6 @@ export const useSignIn = props => {
     const [signIn, { error: signInError }] = useMutation(signInMutation);
     const [fetchCartId] = useMutation(createCartMutation);
     const fetchUserDetails = useAwaitQuery(customerQuery);
-    const fetchCartDetails = useAwaitQuery(getCartDetailsQuery);
 
     const errors = [];
     if (signInError) {
@@ -51,17 +49,15 @@ export const useSignIn = props => {
                     response && response.data.generateCustomerToken.token;
 
                 await setToken(token);
-                await getUserDetails({ fetchUserDetails });
 
-                // Then remove the old, guest cart and get the cart id from gql.
+                // Immediately remove/create the cart.
                 // TODO: This logic may be replacable with mergeCart in 2.3.4
                 await removeCart();
-
-                await createCart({
+                createCart({
                     fetchCartId
                 });
 
-                await getCartDetails({ fetchCartId, fetchCartDetails });
+                await getUserDetails({ fetchUserDetails });
             } catch (error) {
                 if (process.env.NODE_ENV === 'development') {
                     console.error(error);
@@ -72,10 +68,8 @@ export const useSignIn = props => {
         },
         [
             createCart,
-            fetchCartDetails,
             fetchCartId,
             fetchUserDetails,
-            getCartDetails,
             getUserDetails,
             removeCart,
             setToken,

--- a/packages/venia-ui/lib/components/CreateAccount/createAccount.js
+++ b/packages/venia-ui/lib/components/CreateAccount/createAccount.js
@@ -22,7 +22,6 @@ import CREATE_ACCOUNT_MUTATION from '../../queries/createAccount.graphql';
 import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
 import SIGN_IN_MUTATION from '../../queries/signIn.graphql';
 import GET_CUSTOMER_QUERY from '../../queries/getCustomer.graphql';
-import GET_CART_DETAILS_QUERY from '../../queries/getCartDetails.graphql';
 
 const LEAD =
     'Check out faster, use multiple addresses, track orders and more by creating an account!';
@@ -32,7 +31,6 @@ const CreateAccount = props => {
         createAccountQuery: CREATE_ACCOUNT_MUTATION,
         createCartMutation: CREATE_CART_MUTATION,
         customerQuery: GET_CUSTOMER_QUERY,
-        getCartDetailsQuery: GET_CART_DETAILS_QUERY,
         initialValues: props.initialValues,
         onSubmit: props.onSubmit,
         signInMutation: SIGN_IN_MUTATION

--- a/packages/venia-ui/lib/components/Header/cartTrigger.js
+++ b/packages/venia-ui/lib/components/Header/cartTrigger.js
@@ -6,8 +6,6 @@ import { useCartTrigger } from '@magento/peregrine/lib/talons/Header/useCartTrig
 
 import Icon from '../Icon';
 import { mergeClasses } from '../../classify';
-import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
-import GET_CART_DETAILS_QUERY from '../../queries/getCartDetails.graphql';
 import defaultClasses from './cartTrigger.css';
 
 const CART_ICON_FILLED = (
@@ -29,10 +27,7 @@ const CART_ICON_EMPTY = (
 );
 
 const CartTrigger = props => {
-    const { handleClick, itemCount } = useCartTrigger({
-        createCartMutation: CREATE_CART_MUTATION,
-        getCartDetailsQuery: GET_CART_DETAILS_QUERY
-    });
+    const { handleClick, itemCount } = useCartTrigger();
 
     const classes = mergeClasses(defaultClasses, props.classes);
     const cartIcon = itemCount > 0 ? CART_ICON_FILLED : CART_ICON_EMPTY;

--- a/packages/venia-ui/lib/components/SignIn/signIn.js
+++ b/packages/venia-ui/lib/components/SignIn/signIn.js
@@ -15,7 +15,6 @@ import { useSignIn } from '@magento/peregrine/lib/talons/SignIn/useSignIn';
 import CREATE_CART_MUTATION from '../../queries/createCart.graphql';
 import GET_CUSTOMER_QUERY from '../../queries/getCustomer.graphql';
 import SIGN_IN_MUTATION from '../../queries/signIn.graphql';
-import GET_CART_DETAILS_QUERY from '../../queries/getCartDetails.graphql';
 
 const SignIn = props => {
     const classes = mergeClasses(defaultClasses, props.classes);
@@ -24,7 +23,6 @@ const SignIn = props => {
     const talonProps = useSignIn({
         createCartMutation: CREATE_CART_MUTATION,
         customerQuery: GET_CUSTOMER_QUERY,
-        getCartDetailsQuery: GET_CART_DETAILS_QUERY,
         signInMutation: SIGN_IN_MUTATION,
         setDefaultUsername,
         showCreateAccount,


### PR DESCRIPTION
An exploration of what it looks like to use apollo/graphql cache instead of redux. We still use the redux store for things like `cartId` and shared UI state, but in this PR the cart details come from graphql!

Some key things:

* Instead of spreading `fetchDetails` queries around the app I put it in the cart context provider. This is a similar pattern to what I had spiked before. Alternatively, all components that care about cart state can make fetch calls with specific queries using the cart id. It should still use the gql cache.

* `cartTrigger` is now _much_ smaller. It no longer has an effect that requests details yet it still gets updated whenever cart state changes!

* We still have to remove/create cart within actions. If we did this at, say, the cart context as an effect for not having a `cartId` we would have the problem where our retries didn't have the cartId we propagate to the redux store.

TODO:

* `getCartDetails` never cached and we always cleared the stale cart after signIn. We will need to figure out a way to do this. Probably something related to `update` callback to the signIn query.