### PR TITLE
feat: use magento 2 theme configuration logo if available otherwise d…

### DIFF
--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -6,7 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
  * @param {*} props.query the footer data query
  */
 export const useLogo = props => {
-    const { query } = props;
+    const { query, veniaLogo, veniaWidth, veniaHeight, veniaAlt } = props;
     const { error, data } = useQuery(query);
 
     useEffect(() => {
@@ -14,8 +14,19 @@ export const useLogo = props => {
             console.log('Error fetching logo data.');
         }
     }, [error]);
+    
+    let logoSrc;
+
+    if(data && data.storeConfig && data.storeConfig.header_logo_src) {
+        logoSrc = ((data && data.storeConfig && data.storeConfig.secure_base_media_url) + "logo/" + (data && data.storeConfig && data.storeConfig.header_logo_src));
+    } else {
+        logoSrc = veniaLogo.logo
+    }
 
     return {
-        logoData: data
+        configSrc: logoSrc,
+        configWidth: data && data.storeConfig && data.storeConfig.logo_width || veniaWidth.width,
+        configHeight: data && data.storeConfig && data.storeConfig.logo_height || veniaHeight.height,
+        configAlt: data && data.storeConfig && data.storeConfig.logo_alt || veniaAlt
     };
 };

--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useQuery } from '@apollo/react-hooks';
+
+/**
+ *
+ * @param {*} props.query the footer data query
+ */
+export const useLogo = props => {
+    const { query } = props;
+    const { error, data } = useQuery(query);
+
+    useEffect(() => {
+        if (error) {
+            console.log('Error fetching logo data.');
+        }
+    }, [error]);
+	
+    return {
+		logoData: data
+    };
+};

--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -10,7 +10,13 @@ import { useQuery } from '@apollo/react-hooks';
  * @param defaultAlt for logo alt text
  */
 export const useLogo = props => {
-    const { query, defaultSrc, defaultWidth, defaultHeight, defaultAlt } = props;
+    const {
+        query,
+        defaultSrc,
+        defaultWidth,
+        defaultHeight,
+        defaultAlt
+    } = props;
     const { error, data } = useQuery(query);
 
     useEffect(() => {
@@ -41,6 +47,7 @@ export const useLogo = props => {
             (data && data.storeConfig && data.storeConfig.logo_height) ||
             defaultHeight,
         alt:
-            (data && data.storeConfig && data.storeConfig.logo_alt) || defaultAlt
+            (data && data.storeConfig && data.storeConfig.logo_alt) ||
+            defaultAlt
     };
 };

--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -3,7 +3,11 @@ import { useQuery } from '@apollo/react-hooks';
 
 /**
  *
- * @param {*} props.query the footer data query
+ * @param query for magento theme logo
+ * @param defaultSrc for logo path
+ * @param defaultWidth for logo width
+ * @param defaultHeight for logo height
+ * @param defaultAlt for logo alt text
  */
 export const useLogo = props => {
     const { query, defaultSrc, defaultWidth, defaultHeight, defaultAlt } = props;
@@ -29,14 +33,14 @@ export const useLogo = props => {
     }
 
     return {
-        configSrc: logoSrc,
-        configWidth:
+        src: logoSrc,
+        logoWidth:
             (data && data.storeConfig && data.storeConfig.logo_width) ||
             defaultWidth,
-        configHeight:
+        logoHeight:
             (data && data.storeConfig && data.storeConfig.logo_height) ||
             defaultHeight,
-        configAlt:
+        alt:
             (data && data.storeConfig && data.storeConfig.logo_alt) || defaultAlt
     };
 };

--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -14,8 +14,8 @@ export const useLogo = props => {
             console.log('Error fetching logo data.');
         }
     }, [error]);
-	
+
     return {
-		logoData: data
+        logoData: data
     };
 };

--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -14,19 +14,29 @@ export const useLogo = props => {
             console.log('Error fetching logo data.');
         }
     }, [error]);
-    
+
     let logoSrc;
 
-    if(data && data.storeConfig && data.storeConfig.header_logo_src) {
-        logoSrc = ((data && data.storeConfig && data.storeConfig.secure_base_media_url) + "logo/" + (data && data.storeConfig && data.storeConfig.header_logo_src));
+    if (data && data.storeConfig && data.storeConfig.header_logo_src) {
+        logoSrc =
+            (data &&
+                data.storeConfig &&
+                data.storeConfig.secure_base_media_url) +
+            'logo/' +
+            (data && data.storeConfig && data.storeConfig.header_logo_src);
     } else {
-        logoSrc = veniaLogo.logo
+        logoSrc = veniaLogo.logo;
     }
 
     return {
         configSrc: logoSrc,
-        configWidth: data && data.storeConfig && data.storeConfig.logo_width || veniaWidth.width,
-        configHeight: data && data.storeConfig && data.storeConfig.logo_height || veniaHeight.height,
-        configAlt: data && data.storeConfig && data.storeConfig.logo_alt || veniaAlt
+        configWidth:
+            (data && data.storeConfig && data.storeConfig.logo_width) ||
+            veniaWidth.width,
+        configHeight:
+            (data && data.storeConfig && data.storeConfig.logo_height) ||
+            veniaHeight.height,
+        configAlt:
+            (data && data.storeConfig && data.storeConfig.logo_alt) || veniaAlt
     };
 };

--- a/packages/peregrine/lib/talons/Logo/useLogo.js
+++ b/packages/peregrine/lib/talons/Logo/useLogo.js
@@ -6,7 +6,7 @@ import { useQuery } from '@apollo/react-hooks';
  * @param {*} props.query the footer data query
  */
 export const useLogo = props => {
-    const { query, veniaLogo, veniaWidth, veniaHeight, veniaAlt } = props;
+    const { query, defaultSrc, defaultWidth, defaultHeight, defaultAlt } = props;
     const { error, data } = useQuery(query);
 
     useEffect(() => {
@@ -25,18 +25,18 @@ export const useLogo = props => {
             'logo/' +
             (data && data.storeConfig && data.storeConfig.header_logo_src);
     } else {
-        logoSrc = veniaLogo.logo;
+        logoSrc = defaultSrc;
     }
 
     return {
         configSrc: logoSrc,
         configWidth:
             (data && data.storeConfig && data.storeConfig.logo_width) ||
-            veniaWidth.width,
+            defaultWidth,
         configHeight:
             (data && data.storeConfig && data.storeConfig.logo_height) ||
-            veniaHeight.height,
+            defaultHeight,
         configAlt:
-            (data && data.storeConfig && data.storeConfig.logo_alt) || veniaAlt
+            (data && data.storeConfig && data.storeConfig.logo_alt) || defaultAlt
     };
 };

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { mergeClasses } from '../../classify';
 import Image from '../Image';
 import logo from './logo.svg';
+import { useLogo } from '@magento/peregrine/lib/talons/Logo/useLogo';
+import GET_LOGO_DATA from '../../queries/getStoreConfigData.graphql';
 
 /**
  * A component that renders a logo in the header.
@@ -18,16 +20,64 @@ const Logo = props => {
     const { height, width } = props;
     const classes = mergeClasses({}, props.classes);
 
-    return (
-        <Image
-            alt="Venia"
-            classes={{ image: classes.logo }}
-            height={height}
-            src={logo}
-            title="Venia"
-            width={width}
-        />
-    );
+    const talonProps = useLogo({
+        query: GET_LOGO_DATA
+    });
+    const { logoData } = talonProps;
+
+    if(logoData) {
+        
+        if(logoData && logoData.storeConfig && logoData.storeConfig.header_logo_src) {
+            var defaultPath = "/media/logo/";
+            var logoTempFinalSrc = logoData && logoData.storeConfig && logoData.storeConfig.header_logo_src;
+            var logoFinalSrc = defaultPath+logoTempFinalSrc;
+        } else {
+            var logoFinalSrc = {logo};
+        }
+        
+        if(logoData && logoData.storeConfig && logoData.storeConfig.logo_width) {
+            var logoFinalWidth = logoData && logoData.storeConfig && logoData.storeConfig.logo_width;
+        } else {
+            var logoFinalWidth = props.width;
+        }
+        
+        if(logoData && logoData.storeConfig && logoData.storeConfig.logo_height) {
+            var logoFinalHeight = logoData && logoData.storeConfig && logoData.storeConfig.logo_height;
+        } else {
+            var logoFinalHeight = props.height;
+        }
+        
+        if(logoData && logoData.storeConfig && logoData.storeConfig.logo_alt) {
+            var logoFinalAlt = logoData && logoData.storeConfig && logoData.storeConfig.logo_alt;
+        } else {
+            var logoFinalAlt = "Venia";
+        }
+        
+        return (
+            <Image
+                alt={logoFinalAlt}
+                classes={{ image: classes.logo }}
+                height={logoFinalHeight}
+                src={logoFinalSrc}
+                title={logoFinalAlt}
+                width={logoFinalWidth}
+            />
+        );
+        
+    } else {
+
+        return (
+            <Image
+                alt="Venia"
+                classes={{ image: classes.logo }}
+                height={height}
+                src={logo}
+                title="Venia"
+                width={width}
+            />
+        );
+
+    }    
 };
 
 /**

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -25,34 +25,64 @@ const Logo = props => {
     });
     const { logoData } = talonProps;
 
-    if(logoData) {
-        
-        if(logoData && logoData.storeConfig && logoData.storeConfig.header_logo_src) {
-            var defaultPath = "/media/logo/";
-            var logoTempFinalSrc = logoData && logoData.storeConfig && logoData.storeConfig.header_logo_src;
-            var logoFinalSrc = defaultPath+logoTempFinalSrc;
+    let logoFinalSrc;
+    let logoFinalWidth;
+    let logoFinalAlt;
+    let logoFinalHeight;
+    let logoTempFinalSrc;
+    let defaultPath;
+
+    if (logoData) {
+        if (
+            logoData &&
+            logoData.storeConfig &&
+            logoData.storeConfig.header_logo_src
+        ) {
+            defaultPath = '/media/logo/';
+            logoTempFinalSrc =
+                logoData &&
+                logoData.storeConfig &&
+                logoData.storeConfig.header_logo_src;
+            logoFinalSrc = defaultPath + logoTempFinalSrc;
         } else {
-            var logoFinalSrc = {logo};
+            logoFinalSrc = { logo };
         }
-        
-        if(logoData && logoData.storeConfig && logoData.storeConfig.logo_width) {
-            var logoFinalWidth = logoData && logoData.storeConfig && logoData.storeConfig.logo_width;
+
+        if (
+            logoData &&
+            logoData.storeConfig &&
+            logoData.storeConfig.logo_width
+        ) {
+            logoFinalWidth =
+                logoData &&
+                logoData.storeConfig &&
+                logoData.storeConfig.logo_width;
         } else {
-            var logoFinalWidth = props.width;
+            logoFinalWidth = props.width;
         }
-        
-        if(logoData && logoData.storeConfig && logoData.storeConfig.logo_height) {
-            var logoFinalHeight = logoData && logoData.storeConfig && logoData.storeConfig.logo_height;
+
+        if (
+            logoData &&
+            logoData.storeConfig &&
+            logoData.storeConfig.logo_height
+        ) {
+            logoFinalHeight =
+                logoData &&
+                logoData.storeConfig &&
+                logoData.storeConfig.logo_height;
         } else {
-            var logoFinalHeight = props.height;
+            logoFinalHeight = props.height;
         }
-        
-        if(logoData && logoData.storeConfig && logoData.storeConfig.logo_alt) {
-            var logoFinalAlt = logoData && logoData.storeConfig && logoData.storeConfig.logo_alt;
+
+        if (logoData && logoData.storeConfig && logoData.storeConfig.logo_alt) {
+            logoFinalAlt =
+                logoData &&
+                logoData.storeConfig &&
+                logoData.storeConfig.logo_alt;
         } else {
-            var logoFinalAlt = "Venia";
+            logoFinalAlt = 'Venia';
         }
-        
+
         return (
             <Image
                 alt={logoFinalAlt}
@@ -63,9 +93,7 @@ const Logo = props => {
                 width={logoFinalWidth}
             />
         );
-        
     } else {
-
         return (
             <Image
                 alt="Venia"
@@ -76,8 +104,7 @@ const Logo = props => {
                 width={width}
             />
         );
-
-    }    
+    }
 };
 
 /**

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -22,10 +22,10 @@ const Logo = props => {
 
     const talonProps = useLogo({
         query: GET_LOGO_DATA,
-        veniaLogo: { logo },
-        veniaWidth: { width },
-        veniaHeight: { height },
-        veniaAlt: 'Venia'
+        defaultSrc: logo,
+        defaultWidth: width,
+        defaultHeight: height,
+        defaultAlt: 'Venia Logo'
     });
     const { configSrc, configWidth, configHeight, configAlt } = talonProps;
 

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -27,16 +27,16 @@ const Logo = props => {
         defaultHeight: height,
         defaultAlt: 'Venia Logo'
     });
-    const { configSrc, configWidth, configHeight, configAlt } = talonProps;
+    const { src, logoWidth, logoHeight, alt } = talonProps;
 
     return (
         <Image
-            alt={configAlt}
+            alt={alt}
             classes={{ image: classes.logo }}
-            height={configHeight}
-            src={configSrc}
-            title={configAlt}
-            width={configWidth}
+            height={logoHeight}
+            src={src}
+            title={alt}
+            width={logoWidth}
         />
     );
 };

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -22,17 +22,12 @@ const Logo = props => {
 
     const talonProps = useLogo({
         query: GET_LOGO_DATA,
-        veniaLogo: {logo},
-        veniaWidth: {width},
-        veniaHeight: {height},
+        veniaLogo: { logo },
+        veniaWidth: { width },
+        veniaHeight: { height },
         veniaAlt: 'Venia'
     });
-    const { 
-        configSrc,
-        configWidth,
-        configHeight,
-        configAlt
-    } = talonProps;
+    const { configSrc, configWidth, configHeight, configAlt } = talonProps;
 
     return (
         <Image
@@ -44,7 +39,6 @@ const Logo = props => {
             width={configWidth}
         />
     );
-    
 };
 
 /**

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -21,90 +21,30 @@ const Logo = props => {
     const classes = mergeClasses({}, props.classes);
 
     const talonProps = useLogo({
-        query: GET_LOGO_DATA
+        query: GET_LOGO_DATA,
+        veniaLogo: {logo},
+        veniaWidth: {width},
+        veniaHeight: {height},
+        veniaAlt: 'Venia'
     });
-    const { logoData } = talonProps;
+    const { 
+        configSrc,
+        configWidth,
+        configHeight,
+        configAlt
+    } = talonProps;
 
-    let logoFinalSrc;
-    let logoFinalWidth;
-    let logoFinalAlt;
-    let logoFinalHeight;
-    let logoTempFinalSrc;
-    let defaultPath;
-
-    if (logoData) {
-        if (
-            logoData &&
-            logoData.storeConfig &&
-            logoData.storeConfig.header_logo_src
-        ) {
-            defaultPath = '/media/logo/';
-            logoTempFinalSrc =
-                logoData &&
-                logoData.storeConfig &&
-                logoData.storeConfig.header_logo_src;
-            logoFinalSrc = defaultPath + logoTempFinalSrc;
-        } else {
-            logoFinalSrc = { logo };
-        }
-
-        if (
-            logoData &&
-            logoData.storeConfig &&
-            logoData.storeConfig.logo_width
-        ) {
-            logoFinalWidth =
-                logoData &&
-                logoData.storeConfig &&
-                logoData.storeConfig.logo_width;
-        } else {
-            logoFinalWidth = props.width;
-        }
-
-        if (
-            logoData &&
-            logoData.storeConfig &&
-            logoData.storeConfig.logo_height
-        ) {
-            logoFinalHeight =
-                logoData &&
-                logoData.storeConfig &&
-                logoData.storeConfig.logo_height;
-        } else {
-            logoFinalHeight = props.height;
-        }
-
-        if (logoData && logoData.storeConfig && logoData.storeConfig.logo_alt) {
-            logoFinalAlt =
-                logoData &&
-                logoData.storeConfig &&
-                logoData.storeConfig.logo_alt;
-        } else {
-            logoFinalAlt = 'Venia';
-        }
-
-        return (
-            <Image
-                alt={logoFinalAlt}
-                classes={{ image: classes.logo }}
-                height={logoFinalHeight}
-                src={logoFinalSrc}
-                title={logoFinalAlt}
-                width={logoFinalWidth}
-            />
-        );
-    } else {
-        return (
-            <Image
-                alt="Venia"
-                classes={{ image: classes.logo }}
-                height={height}
-                src={logo}
-                title="Venia"
-                width={width}
-            />
-        );
-    }
+    return (
+        <Image
+            alt={configAlt}
+            classes={{ image: classes.logo }}
+            height={configHeight}
+            src={configSrc}
+            title={configAlt}
+            width={configWidth}
+        />
+    );
+    
 };
 
 /**

--- a/packages/venia-ui/lib/queries/getStoreConfigData.graphql
+++ b/packages/venia-ui/lib/queries/getStoreConfigData.graphql
@@ -2,5 +2,9 @@ query storeConfigData {
     storeConfig {
         id
         copyright
+        header_logo_src
+        logo_width
+        logo_height
+        logo_alt
     }
 }

--- a/packages/venia-ui/lib/queries/getStoreConfigData.graphql
+++ b/packages/venia-ui/lib/queries/getStoreConfigData.graphql
@@ -6,5 +6,6 @@ query storeConfigData {
         logo_width
         logo_height
         logo_alt
+        secure_base_media_url
     }
 }


### PR DESCRIPTION
closes #2047 

## Description

Replace default venia logo with logo that stored in magento 2 back-end theme configuration logo
Enhanced feature 

### Verification Steps
1. Add logo in magento 2 back-end theme configuration and check PWA store front logo changed on not.
2. Remove logo from magento 2 back-end theme configuration and check PWA store front logo changed back to original venia logo