### PR TITLE
Fixed binary file reading

### DIFF
--- a/packages/upward-js/lib/IOAdapter.js
+++ b/packages/upward-js/lib/IOAdapter.js
@@ -20,6 +20,14 @@ class IOAdapter {
                         `Cannot read ${resolvedPath} because it is outside ${baseDir}`
                     );
                 }
+
+                /**
+                 * Replaces binary as null.
+                 * For some reason nodejs interprets 'binary' as 'latin1'.
+                 * See: https://stackoverflow.com/a/46441727
+                 */
+                if (enc === 'binary') enc = null;
+
                 return readFile(resolvedPath, enc);
             }
         });

--- a/packages/upward-js/lib/middleware.js
+++ b/packages/upward-js/lib/middleware.js
@@ -112,7 +112,8 @@ class UpwardMiddleware {
                 res.status(response.status)
                     .set(response.headers)
                     .send(
-                        typeof response.body === 'string'
+                        typeof response.body === 'string' ||
+                            Buffer.isBuffer(response.body)
                             ? response.body
                             : response.body.toString()
                     );

--- a/packages/venia-ui/upward.yml
+++ b/packages/venia-ui/upward.yml
@@ -35,6 +35,8 @@ staticFromRoot:
             resolver: file
             parse:
               inline: text
+            encoding:
+              inline: binary
             file:
                 resolver: template
                 engine: mustache


### PR DESCRIPTION
Fixed issue of 'binary' not being correctly parsed. Node.js parses 'binary' as 'latin1'. To achieve reading the file as a binary the file encoding needs to be set to null. See https://stackoverflow.com/a/46441727.

## Description

Changed 'binary' encoding to equal null when reading a file.
When resolving the body, Buffers will not be converted into strings.
Added `encoding: binary` to staticFilesRoot in upward.yml for venia-ui

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #2049 

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Start venia in staging.
2. Verify that the favicon shows up.
