### PR TITLE
[PWA-261] [SAFARI][DESKTOP][CLOUD] Default swatch image ratio is not proper on product details page 

### DIFF
--- a/packages/peregrine/lib/talons/Image/__tests__/useResourceImage.spec.js
+++ b/packages/peregrine/lib/talons/Image/__tests__/useResourceImage.spec.js
@@ -6,9 +6,9 @@ import { useResourceImage } from '../useResourceImage';
 const SMALL_RESOURCE_SIZE = 100;
 const props = {
     generateSrcset: jest.fn(() => 'mock_srcset'),
+    generateUrl: jest.fn(() => () => 'mock_resource_url'),
     height: 125,
     resource: 'unit_test_resource.jpg',
-    resourceUrl: jest.fn(() => 'mock_resource_url'),
     type: 'image-product',
     widths: new Map().set('default', SMALL_RESOURCE_SIZE)
 };
@@ -36,13 +36,13 @@ test('it returns the proper shape', () => {
     });
 });
 
-test('it calls generateSrcset and resourceUrl', () => {
+test('it calls generateSrcset and generateUrl', () => {
     // Act.
     createTestInstance(<Component {...props} />);
 
     // Assert.
     expect(props.generateSrcset).toHaveBeenCalled();
-    expect(props.resourceUrl).toHaveBeenCalled();
+    expect(props.generateUrl).toHaveBeenCalled();
 });
 
 describe('sizes', () => {

--- a/packages/peregrine/lib/talons/Image/useResourceImage.js
+++ b/packages/peregrine/lib/talons/Image/useResourceImage.js
@@ -24,13 +24,9 @@ export const useResourceImage = props => {
         widths
     } = props;
 
-    const src = useMemo(() => generateUrl(resource, type)(width, height), [
-        generateUrl,
-        height,
-        resource,
-        type,
-        width
-    ]);
+    const src = useMemo(() => {
+        return generateUrl(resource, type)(width, height);
+    }, [generateUrl, height, resource, type, width]);
 
     const srcSet = useMemo(() => {
         return generateSrcset(resource, type);

--- a/packages/peregrine/lib/talons/Image/useResourceImage.js
+++ b/packages/peregrine/lib/talons/Image/useResourceImage.js
@@ -28,7 +28,8 @@ export const useResourceImage = props => {
         return resourceUrl(resource, {
             type,
             height: height,
-            width: width
+            width: width,
+            fit: 'cover'
         });
     }, [height, resource, resourceUrl, type, width]);
 

--- a/packages/peregrine/lib/talons/Image/useResourceImage.js
+++ b/packages/peregrine/lib/talons/Image/useResourceImage.js
@@ -16,22 +16,21 @@ import { UNCONSTRAINED_SIZE_KEY } from './useImage';
 export const useResourceImage = props => {
     const {
         generateSrcset,
+        generateUrl,
         height,
         resource,
-        resourceUrl,
         type,
         width,
         widths
     } = props;
 
-    const src = useMemo(() => {
-        return resourceUrl(resource, {
-            type,
-            height: height,
-            width: width,
-            fit: 'cover'
-        });
-    }, [height, resource, resourceUrl, type, width]);
+    const src = useMemo(() => generateUrl(resource, type)(width, height), [
+        generateUrl,
+        height,
+        resource,
+        type,
+        width
+    ]);
 
     const srcSet = useMemo(() => {
         return generateSrcset(resource, type);

--- a/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/item.spec.js.snap
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/item.spec.js.snap
@@ -64,7 +64,7 @@ exports[`renders correctly with valid item data 1`] = `
         onError={[MockFunction]}
         onLoad={[MockFunction]}
         sizes="(max-width: 640px) 300px, 840px"
-        src="/media/catalog/product/foo/bar/pic.png?auto=webp&format=pjpg&width=100&height=375"
+        src="/media/catalog/product/foo/bar/pic.png?auto=webp&format=pjpg&width=100&height=375&fit=cover"
         srcSet="/media/catalog/product/foo/bar/pic.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/foo/bar/pic.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/foo/bar/pic.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,

--- a/packages/venia-ui/lib/components/Image/___tests__/__snapshots__/image.spec.js.snap
+++ b/packages/venia-ui/lib/components/Image/___tests__/__snapshots__/image.spec.js.snap
@@ -18,7 +18,7 @@ exports[`renders an image correctly when given resource 1`] = `
     onError={[MockFunction]}
     onLoad={[MockFunction]}
     sizes="100px"
-    src="/media/catalog/product/timeless.jpg?auto=webp&format=pjpg&width=100"
+    src="/media/catalog/product/timeless.jpg?auto=webp&format=pjpg&width=100&fit=cover"
     srcSet="/media/catalog/product/timeless.jpg?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/timeless.jpg?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/timeless.jpg?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,

--- a/packages/venia-ui/lib/components/Image/resourceImage.js
+++ b/packages/venia-ui/lib/components/Image/resourceImage.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { func, instanceOf, number, oneOfType, string } from 'prop-types';
-import { resourceUrl } from '@magento/venia-drivers';
 import { useResourceImage } from '@magento/peregrine/lib/talons/Image/useResourceImage';
 
-import { generateSrcset } from '../../util/images';
+import { generateSrcset, generateUrl } from '../../util/images';
 
 /**
  * Renders a Magento resource image.
@@ -34,9 +33,9 @@ const ResourceImage = props => {
 
     const talonProps = useResourceImage({
         generateSrcset,
+        generateUrl,
         height,
         resource,
-        resourceUrl,
         type,
         width,
         widths

--- a/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
@@ -128,7 +128,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
         onError={[Function]}
         onLoad={[Function]}
         sizes="640px"
-        src="/media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=640"
+        src="/media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=640&fit=cover"
         srcSet="/media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,
@@ -192,7 +192,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
           onError={[Function]}
           onLoad={[Function]}
           sizes="135px"
-          src="/media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=135&height=170"
+          src="/media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=135&height=170&fit=cover"
           srcSet="/media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail1.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,
@@ -229,7 +229,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
           onError={[Function]}
           onLoad={[Function]}
           sizes="135px"
-          src="/media/catalog/product/thumbnail2.png?auto=webp&format=pjpg&width=135&height=170"
+          src="/media/catalog/product/thumbnail2.png?auto=webp&format=pjpg&width=135&height=170&fit=cover"
           srcSet="/media/catalog/product/thumbnail2.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail2.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail2.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,
@@ -266,7 +266,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
           onError={[Function]}
           onLoad={[Function]}
           sizes="135px"
-          src="/media/catalog/product/thumbnail3.png?auto=webp&format=pjpg&width=135&height=170"
+          src="/media/catalog/product/thumbnail3.png?auto=webp&format=pjpg&width=135&height=170&fit=cover"
           srcSet="/media/catalog/product/thumbnail3.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail3.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail3.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,
@@ -303,7 +303,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
           onError={[Function]}
           onLoad={[Function]}
           sizes="135px"
-          src="/media/catalog/product/thumbnail4.png?auto=webp&format=pjpg&width=135&height=170"
+          src="/media/catalog/product/thumbnail4.png?auto=webp&format=pjpg&width=135&height=170&fit=cover"
           srcSet="/media/catalog/product/thumbnail4.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail4.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail4.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,

--- a/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/thumbnail.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/thumbnail.spec.js.snap
@@ -24,7 +24,7 @@ exports[`renders root class if not the active Thumbnail 1`] = `
       onError={[Function]}
       onLoad={[Function]}
       sizes="135px"
-      src="/media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=135&height=170"
+      src="/media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=135&height=170&fit=cover"
       srcSet="/media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,
@@ -64,7 +64,7 @@ exports[`renders the Thumbnail component correctly 1`] = `
       onError={[Function]}
       onLoad={[Function]}
       sizes="135px"
-      src="/media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=135&height=170"
+      src="/media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=135&height=170&fit=cover"
       srcSet="/media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=40&height=50&fit=cover 40w,
 /media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=80&height=100&fit=cover 80w,
 /media/catalog/product/thumbnail.png?auto=webp&format=pjpg&width=160&height=200&fit=cover 160w,

--- a/packages/venia-ui/lib/util/images.js
+++ b/packages/venia-ui/lib/util/images.js
@@ -19,7 +19,7 @@ export const imageWidths = new Map(
     })
 );
 
-const generateUrl = (imageURL, mediaBase) => (width, height) =>
+export const generateUrl = (imageURL, mediaBase) => (width, height) =>
     resourceUrl(imageURL, {
         type: mediaBase,
         width,


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

URL - /valeria-two-layer-tank.html

/valeria-two-layer-tank.html

-Steps –

Hit any of the above cloud deployed URL in SAFARI browser on desktop.
Observe the first default swatch image.
Corrected Steps (if you don't see behavior, be sure to clear all caches)

Navigate to Category page to preload thumbnail images (/venia-tops.html)
Then navigate to a PDP (/vitalia-top.html)
Observe aspect ratio of thumbnail and main image (appears to be serving from service worker cache, then applying cropping again)
Expected - All swatch images should have right ratio.

Actual - First swatch image ration is not proper.

Note - 
1. Works fine on 4.0.0 Magento Cloud https://venia.magento.com/

2. Works fine on 5.0.0 AWS deployed instances (https://pr-2043.pwa-venia.com/valeria-two-layer-tank.html). Issue only with Magento Cloud deployments.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-261](https://jira.corp.magento.com/browse/PWA-261)] [SAFARI][DESKTOP][CLOUD] Default swatch image ratio is not proper on product details page

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Start Venia with Service Workers enabled, a Fastly backend, and IMAGE_OPTIMIZING_ORIGIN=backend
2. Follow steps in description for repro and verify issue no longer exists
3. Navigate around other pages with images and verify no regressions introduced with image aspect ratio

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
