### PR TITLE
[PB] PWA - Empty Products Content Type Shows No Products to Display Message on Storefront

### DIFF
--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/__tests__/__snapshots__/products.spec.js.snap
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/__tests__/__snapshots__/products.spec.js.snap
@@ -1,84 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render products with all props & no products 1`] = `
-<div
-  className=" test-class"
-  style={
-    Object {
-      "border": "solid",
-      "borderColor": "red",
-      "borderRadius": "15px",
-      "borderWidth": "10px",
-      "marginBottom": "10px",
-      "marginLeft": "10px",
-      "marginRight": "10px",
-      "marginTop": "10px",
-      "paddingBottom": "10px",
-      "paddingLeft": "10px",
-      "paddingRight": "10px",
-      "paddingTop": "10px",
-      "textAlign": "right",
-    }
-  }
->
-  <div>
-    No products to display
-  </div>
-</div>
-`;
+exports[`render products with all props & no products 1`] = `null`;
 
-exports[`render products with error state 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "border": undefined,
-      "borderColor": undefined,
-      "borderRadius": undefined,
-      "borderWidth": undefined,
-      "marginBottom": undefined,
-      "marginLeft": undefined,
-      "marginRight": undefined,
-      "marginTop": undefined,
-      "paddingBottom": undefined,
-      "paddingLeft": undefined,
-      "paddingRight": undefined,
-      "paddingTop": undefined,
-      "textAlign": undefined,
-    }
-  }
->
-  <div>
-    No products to display
-  </div>
-</div>
-`;
+exports[`render products with error state in development mode 1`] = `null`;
+
+exports[`render products with error state in production mode 1`] = `null`;
 
 exports[`render products with loading state 1`] = `null`;
 
-exports[`render products with no props & no products 1`] = `
-<div
-  className=""
-  style={
-    Object {
-      "border": undefined,
-      "borderColor": undefined,
-      "borderRadius": undefined,
-      "borderWidth": undefined,
-      "marginBottom": undefined,
-      "marginLeft": undefined,
-      "marginRight": undefined,
-      "marginTop": undefined,
-      "paddingBottom": undefined,
-      "paddingLeft": undefined,
-      "paddingRight": undefined,
-      "paddingTop": undefined,
-      "textAlign": undefined,
-    }
-  }
->
-  <div>
-    No products to display
-  </div>
-</div>
-`;
+exports[`render products with no props & no products 1`] = `null`;

--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/__tests__/products.spec.js
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/__tests__/products.spec.js
@@ -93,7 +93,11 @@ test('render products with loading state', () => {
     expect(component.toJSON()).toMatchSnapshot();
 });
 
-test('render products with error state', () => {
+test('render products with error state in production mode', () => {
+    const oldEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    jest.spyOn(console, 'error').mockImplementation();
+
     useQuery.mockImplementation(() => {
         return {
             data: {
@@ -109,6 +113,36 @@ test('render products with error state', () => {
     const component = createTestInstance(<Products />);
 
     expect(component.toJSON()).toMatchSnapshot();
+    expect(console.error).not.toHaveBeenCalled();
+
+    process.env.NODE_ENV = oldEnv;
+    console.error.mockRestore();
+});
+
+test('render products with error state in development mode', () => {
+    const oldEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    jest.spyOn(console, 'error').mockImplementation();
+
+    useQuery.mockImplementation(() => {
+        return {
+            data: {
+                products: {
+                    items: []
+                }
+            },
+            error: true,
+            loading: false
+        };
+    });
+
+    const component = createTestInstance(<Products />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+    expect(console.error).toHaveBeenCalled();
+
+    process.env.NODE_ENV = oldEnv;
+    console.error.mockRestore();
 });
 
 test('render products and ensure order is correct passed to Gallery', () => {

--- a/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/products.js
+++ b/packages/venia-ui/lib/components/RichContent/PageBuilder/ContentTypes/Products/products.js
@@ -100,14 +100,11 @@ const Products = props => {
     if (loading) return null;
 
     if (error || data.products.items.length === 0) {
-        return (
-            <div
-                style={dynamicStyles}
-                className={[classes.root, ...cssClasses].join(' ')}
-            >
-                <div className={classes.error}>{'No products to display'}</div>
-            </div>
-        );
+        if (process.env.NODE_ENV === 'development') {
+            console.error(error);
+        }
+
+        return null;
     }
 
     const items = restoreSortOrder(skus, data.products.items);


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

PWA - Empty Products Content Type Shows No Products to Display Message on Storefront

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
https://jira.corp.magento.com/browse/PB-339

### Verification Steps
See https://jira.corp.magento.com/browse/PB-339
