### PR TITLE
[JIRA-262] Robust HTML update checking.

### DIFF
--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -36,7 +36,9 @@
     "url": "https://github.com/magento/pwa-studio/issues"
   },
   "homepage": "https://github.com/magento/pwa-studio/tree/master/packages/venia-concept#readme",
-  "dependencies": {},
+  "dependencies": {
+    "node-html-parser": "~1.1.16"
+  },
   "devDependencies": {
     "@babel/core": "~7.3.4",
     "@babel/plugin-proposal-class-properties": "~7.3.4",

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -36,9 +36,7 @@
     "url": "https://github.com/magento/pwa-studio/issues"
   },
   "homepage": "https://github.com/magento/pwa-studio/tree/master/packages/venia-concept#readme",
-  "dependencies": {
-    "node-html-parser": "~1.1.16"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "~7.3.4",
     "@babel/plugin-proposal-class-properties": "~7.3.4",
@@ -93,6 +91,7 @@
     "lodash.over": "~4.7.0",
     "memoize-one": "~5.0.0",
     "memory-fs": "~0.4.1",
+    "node-html-parser": "~1.1.16",
     "prettier": "~1.16.4",
     "prop-types": "~15.7.2",
     "react": "~16.9.0",

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
@@ -437,3 +437,78 @@ test('fetchDidSucceed should not call sendMessageToWindow if data-image-optimizi
 
     expect(sendMessageToWindow).not.toHaveBeenCalled();
 });
+
+test('fetchDidSucceed should call sendMessageToWindow if a resouce has been added', async () => {
+    /**
+     * Mocking Request to return different values first 2 times.
+     * Adds a resource second time to mock a resource addition.
+     */
+    global.Response.prototype.text = jest
+        .fn()
+        .mockReturnValueOnce(
+            Promise.resolve(
+                '<html><link href="www.adobe.com/spectrumCss.css"></link></html>'
+            )
+        )
+        .mockReturnValueOnce(
+            Promise.resolve(
+                '<html><link href="www.adobe.com/spectrumCss_v0.css"></link><link href="www.adobe.com/spectrumCss_v1.css"></link></html>'
+            )
+        )
+        .mockReturnValue(
+            Promise.resolve(
+                '<html><link href="www.adobe.com/spectrumCss.css"></link></html>'
+            )
+        );
+    global.Response.prototype.clone = function() {
+        return new Response();
+    };
+
+    /**
+     * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
+     */
+    matchFn.mockReturnValue(Promise.resolve(new Response()));
+
+    const url = 'https://develop.pwa-venia.com/';
+    const request = new Request(url);
+    const response = new Response();
+
+    await cacheHTMLPlugin.fetchDidSucceed({ request, response });
+
+    expect(sendMessageToWindow).toHaveBeenCalled();
+});
+
+test('fetchDidSucceed should call sendMessageToWindow if a resouce has been removed', async () => {
+    /**
+     * Mocking Request to return different values first 2 times.
+     * Removes a resource second time to mock a resource removal.
+     */
+    global.Response.prototype.text = jest
+        .fn()
+        .mockReturnValueOnce(
+            Promise.resolve(
+                '<html><link href="www.adobe.com/spectrumCss_v0.css"></link><link href="www.adobe.com/spectrumCss_v1.css"></link></html>'
+            )
+        )
+        .mockReturnValue(
+            Promise.resolve(
+                '<html><link href="www.adobe.com/spectrumCss.css"></link></html>'
+            )
+        );
+    global.Response.prototype.clone = function() {
+        return new Response();
+    };
+
+    /**
+     * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
+     */
+    matchFn.mockReturnValue(Promise.resolve(new Response()));
+
+    const url = 'https://develop.pwa-venia.com/';
+    const request = new Request(url);
+    const response = new Response();
+
+    await cacheHTMLPlugin.fetchDidSucceed({ request, response });
+
+    expect(sendMessageToWindow).toHaveBeenCalled();
+});

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
@@ -162,7 +162,7 @@ test("fetchDidSucceed should call sendMessageToWindow if 1 or more script tag's 
         return Promise.resolve(
             `<html><script src="www.adobe.com/analytics_script_${Math.random()
                 .toString()
-                .slice(2)}></script></html>`
+                .slice(2)}"></script></html>`
         );
     };
     global.Response.prototype.clone = function() {
@@ -189,9 +189,9 @@ test("fetchDidSucceed should not call sendMessageToWindow if script tag's src ha
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
-            `<html><script src="www.adobe.com/analytics_script_v1></script><script>var x = ${Math.random()
+            `<html><script src="www.adobe.com/analytics_script_v1"></script><script>var x = ${Math.random()
                 .toString()
-                .slice(2)}</script></html>`
+                .slice(2)}"</script></html>`
         );
     };
     global.Response.prototype.clone = function() {

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
@@ -101,7 +101,8 @@ test('fetchDidSucceed should not call sendMessageToWindow if the cache does not 
 
 test('fetchDidSucceed should call sendMessageToWindow if the response has a different title from what is in the cache', async () => {
     /**
-     * Mocking Request to return different value when .text is called.
+     * Mocking Request to return different value for the tag
+     * when .textis  called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -129,9 +130,10 @@ test('fetchDidSucceed should call sendMessageToWindow if the response has a diff
     expect(sendMessageToWindow).toHaveBeenCalledWith(HTML_UPDATE_AVAILABLE);
 });
 
-test('fetchDidSucceed should not call sendMessageToWindow is the response has same title as that in the cache', async () => {
+test('fetchDidSucceed should not call sendMessageToWindow if the response has same title as that in the cache', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return same value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve('<html><title>Same Title</title></html>');
@@ -154,9 +156,10 @@ test('fetchDidSucceed should not call sendMessageToWindow is the response has sa
     expect(sendMessageToWindow).not.toHaveBeenCalled();
 });
 
-test("fetchDidSucceed should call sendMessageToWindow if 1 or more script tag's src has changed", async () => {
+test("fetchDidSucceed should call sendMessageToWindow if one or more script tag's src has changed", async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return a different value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -185,7 +188,8 @@ test("fetchDidSucceed should call sendMessageToWindow if 1 or more script tag's 
 
 test("fetchDidSucceed should not call sendMessageToWindow if script tag's src has not changed even though the wrapped JS has changed", async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return a different value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -212,9 +216,10 @@ test("fetchDidSucceed should not call sendMessageToWindow if script tag's src ha
     expect(sendMessageToWindow).not.toHaveBeenCalled();
 });
 
-test("fetchDidSucceed should call sendMessageToWindow if 1 or more link's href has changed", async () => {
+test("fetchDidSucceed should call sendMessageToWindow if one or more link's href has changed", async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return a different value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -243,7 +248,8 @@ test("fetchDidSucceed should call sendMessageToWindow if 1 or more link's href h
 
 test("fetchDidSucceed should not call sendMessageToWindow if link's href has not changed", async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return same value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -268,9 +274,10 @@ test("fetchDidSucceed should not call sendMessageToWindow if link's href has not
     expect(sendMessageToWindow).not.toHaveBeenCalled();
 });
 
-test('fetchDidSucceed should call sendMessageToWindow if 1 or more styles have changed', async () => {
+test('fetchDidSucceed should call sendMessageToWindow if one or more styles have changed', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return a different value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -301,7 +308,8 @@ test('fetchDidSucceed should call sendMessageToWindow if 1 or more styles have c
 
 test('fetchDidSucceed should not call sendMessageToWindow if styles have not changed', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return same value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -328,7 +336,8 @@ test('fetchDidSucceed should not call sendMessageToWindow if styles have not cha
 
 test('fetchDidSucceed should call sendMessageToWindow if data-media-backend attribute in the html tag has changed', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return a different value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -355,9 +364,10 @@ test('fetchDidSucceed should call sendMessageToWindow if data-media-backend attr
     expect(sendMessageToWindow).toHaveBeenCalled();
 });
 
-test('fetchDidSucceed should not call sendMessageToWindow if data-media-backend attribute in the html tag not changed', async () => {
+test('fetchDidSucceed should not call sendMessageToWindow if data-media-backend attribute in the html tag has not changed', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return same value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -384,7 +394,8 @@ test('fetchDidSucceed should not call sendMessageToWindow if data-media-backend 
 
 test('fetchDidSucceed should call sendMessageToWindow if data-image-optimizing-origin attribute in the html tag has changed', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return a different value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
@@ -411,9 +422,10 @@ test('fetchDidSucceed should call sendMessageToWindow if data-image-optimizing-o
     expect(sendMessageToWindow).toHaveBeenCalled();
 });
 
-test('fetchDidSucceed should not call sendMessageToWindow if data-image-optimizing-origin attribute in the html tag not changed', async () => {
+test('fetchDidSucceed should not call sendMessageToWindow if data-image-optimizing-origin attribute in the html tag has not changed', async () => {
     /**
-     * Mocking Request to return same value when .text is called.
+     * Mocking Request to return same value for
+     * the tag when .text is called on the response.
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
@@ -93,9 +93,9 @@ test('fetchDidSucceed should call sendMessageToWindow if the response is differe
      */
     global.Response.prototype.text = function() {
         return Promise.resolve(
-            `Hey I am random text ${Math.random()
+            `<html><title>Title - ${Math.random()
                 .toString()
-                .slice(2)}`
+                .slice(2)}</title></html>`
         );
     };
     global.Response.prototype.clone = function() {
@@ -105,11 +105,13 @@ test('fetchDidSucceed should call sendMessageToWindow if the response is differe
     /**
      * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
      */
-    matchFn.mockReturnValue(Promise.resolve(new Response()));
+    matchFn.mockReturnValue(
+        Promise.resolve(new Response('<html><title>Old Title</title></html>'))
+    );
 
     const url = 'https://develop.pwa-venia.com/';
     const request = new Request(url);
-    const response = new Response();
+    const response = new Response('<html><title>New Title</title></html>');
 
     await cacheHTMLPlugin.fetchDidSucceed({ request, response });
 
@@ -134,7 +136,7 @@ test('fetchDidSucceed should not call sendMessageToWindow if the response if sam
      * Mocking Request to return same value when .text is called.
      */
     global.Response.prototype.text = function() {
-        return Promise.resolve('Hey I am same text');
+        return Promise.resolve('<html><title>Same Title</title></html>');
     };
     global.Response.prototype.clone = function() {
         return new Response();
@@ -143,11 +145,13 @@ test('fetchDidSucceed should not call sendMessageToWindow if the response if sam
     /**
      * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
      */
-    matchFn.mockReturnValue(Promise.resolve(new Response()));
+    matchFn.mockReturnValue(
+        Promise.resolve(new Response('<html><title>Old Title</title></html>'))
+    );
 
     const url = 'https://develop.pwa-venia.com/';
     const request = new Request(url);
-    const response = new Response();
+    const response = new Response('<html><title>New Title</title></html>');
 
     await cacheHTMLPlugin.fetchDidSucceed({ request, response });
 

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/htmlHandler.spec.js
@@ -325,3 +325,115 @@ test('fetchDidSucceed should not call sendMessageToWindow if styles have not cha
 
     expect(sendMessageToWindow).not.toHaveBeenCalled();
 });
+
+test('fetchDidSucceed should call sendMessageToWindow if data-media-backend attribute in the html tag has changed', async () => {
+    /**
+     * Mocking Request to return same value when .text is called.
+     */
+    global.Response.prototype.text = function() {
+        return Promise.resolve(
+            `<html data-media-backend=www.magento-cloud.com/instance_${Math.random()
+                .toString()
+                .slice(2)}></html>`
+        );
+    };
+    global.Response.prototype.clone = function() {
+        return new Response();
+    };
+
+    /**
+     * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
+     */
+    matchFn.mockReturnValue(Promise.resolve(new Response()));
+
+    const url = 'https://develop.pwa-venia.com/';
+    const request = new Request(url);
+    const response = new Response();
+
+    await cacheHTMLPlugin.fetchDidSucceed({ request, response });
+
+    expect(sendMessageToWindow).toHaveBeenCalled();
+});
+
+test('fetchDidSucceed should not call sendMessageToWindow if data-media-backend attribute in the html tag not changed', async () => {
+    /**
+     * Mocking Request to return same value when .text is called.
+     */
+    global.Response.prototype.text = function() {
+        return Promise.resolve(
+            '<html data-media-backend=www.magento-cloud.com/instance_01></html>'
+        );
+    };
+    global.Response.prototype.clone = function() {
+        return new Response();
+    };
+
+    /**
+     * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
+     */
+    matchFn.mockReturnValue(Promise.resolve(new Response()));
+
+    const url = 'https://develop.pwa-venia.com/';
+    const request = new Request(url);
+    const response = new Response();
+
+    await cacheHTMLPlugin.fetchDidSucceed({ request, response });
+
+    expect(sendMessageToWindow).not.toHaveBeenCalled();
+});
+
+test('fetchDidSucceed should call sendMessageToWindow if data-image-optimizing-origin attribute in the html tag has changed', async () => {
+    /**
+     * Mocking Request to return same value when .text is called.
+     */
+    global.Response.prototype.text = function() {
+        return Promise.resolve(
+            `<html data-image-optimizing-origin=source_${Math.random()
+                .toString()
+                .slice(2)}></html>`
+        );
+    };
+    global.Response.prototype.clone = function() {
+        return new Response();
+    };
+
+    /**
+     * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
+     */
+    matchFn.mockReturnValue(Promise.resolve(new Response()));
+
+    const url = 'https://develop.pwa-venia.com/';
+    const request = new Request(url);
+    const response = new Response();
+
+    await cacheHTMLPlugin.fetchDidSucceed({ request, response });
+
+    expect(sendMessageToWindow).toHaveBeenCalled();
+});
+
+test('fetchDidSucceed should not call sendMessageToWindow if data-image-optimizing-origin attribute in the html tag not changed', async () => {
+    /**
+     * Mocking Request to return same value when .text is called.
+     */
+    global.Response.prototype.text = function() {
+        return Promise.resolve(
+            '<html data-image-optimizing-origin=source_01></html>'
+        );
+    };
+    global.Response.prototype.clone = function() {
+        return new Response();
+    };
+
+    /**
+     * Mocking cache to have a response for 'https://develop.pwa-venia.com/'
+     */
+    matchFn.mockReturnValue(Promise.resolve(new Response()));
+
+    const url = 'https://develop.pwa-venia.com/';
+    const request = new Request(url);
+    const response = new Response();
+
+    await cacheHTMLPlugin.fetchDidSucceed({ request, response });
+
+    expect(sendMessageToWindow).not.toHaveBeenCalled();
+});

--- a/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
@@ -181,7 +181,12 @@ export const cacheHTMLPlugin = {
             const cachedResponse = await cachedResponseObj.text();
             const clonedResponse = await response.clone().text();
 
+            /**
+             * Dont bother caculating changes if the response string
+             * has not changed. Saves CPU cycles most of the time.
+             */
             if (
+                clonedResponse !== cachedResponse &&
                 hasHTMLChanged(
                     parse(clonedResponse, { style: true }),
                     parse(cachedResponse, { style: true })

--- a/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
@@ -1,6 +1,118 @@
 import { HTML_UPDATE_AVAILABLE } from '@magento/venia-ui/lib/constants/swMessageTypes';
+import { parse } from 'node-html-parser';
 
 import { sendMessageToWindow } from './messageHandler';
+
+const generateScriptResource = htmlElement => htmlElement.attributes.src;
+
+const generateLinkResource = htmlElement => htmlElement.attributes.href;
+
+const generateStyleResource = htmlElement => htmlElement.text;
+
+/**
+ * Generates list of resources from the parsed HTML object.
+ *
+ * @param {HTMLElement} parsedHTML
+ *
+ * @returns { scripts: [string], links: [string], styles: [string] }
+ */
+const generateResources = parsedHTML => {
+    const resources = {};
+
+    resources.scripts = parsedHTML
+        .querySelectorAll('script')
+        .map(generateScriptResource)
+        .sort();
+
+    resources.links = parsedHTML
+        .querySelectorAll('link')
+        .map(generateLinkResource)
+        .sort();
+
+    resources.styles = parsedHTML
+        .querySelectorAll('style')
+        .map(generateStyleResource)
+        .sort();
+
+    return resources;
+};
+
+/**
+ * Returns true if resouce url/urls have changed.
+ *
+ * @param {HTMLElement} newDOM
+ * @param {HTMLElement} oldDOM
+ *
+ * @returns Boolean
+ */
+const haveResourcesChanged = (newDOM, oldDOM) => {
+    const newResources = generateResources(newDOM);
+    const oldResources = generateResources(oldDOM);
+    const keysToCompare = Object.keys(newResources);
+
+    return !keysToCompare.reduce((acc, key) => {
+        const hasResourceChanged =
+            newResources[key].toString() === oldResources[key].toString();
+
+        return acc && hasResourceChanged;
+    }, true);
+};
+
+/**
+ * Returns true if title has changed.
+ *
+ * @param {HTMLElement} newDOM
+ * @param {HTMLElement} oldDOM
+ *
+ * @returns Boolean
+ */
+const hasTitleChanged = (newDOM, oldDOM) => {
+    const oldTitle = oldDOM.querySelector('title').text;
+    const newTitle = newDOM.querySelector('title').text;
+
+    return newTitle !== oldTitle;
+};
+
+/**
+ * Returns true if media backend url has changed.
+ *
+ * @param {HTMLElement} newDOM
+ * @param {HTMLElement} oldDOM
+ *
+ * @returns Boolean
+ */
+const hasBackendUrlChanged = (newDOM, oldDOM) => {
+    const oldUrl = oldDOM.querySelector('html').attributes[
+        'data-media-backend'
+    ];
+    const newUrl = newDOM.querySelector('html').attributes[
+        'data-media-backend'
+    ];
+
+    return newUrl !== oldUrl;
+};
+
+/**
+ * Array of verfication functions to run to determine
+ * if HTML has changed and needs updation on the UI.
+ */
+const verificationFunctions = [
+    haveResourcesChanged,
+    hasTitleChanged,
+    hasBackendUrlChanged
+];
+
+/**
+ * Runs all verification functions with new and old
+ * HTML to determine if HTML has changed.
+ *
+ * @param {HTMLElement} newDOM
+ * @param {HTMLElement} oldDOM
+ */
+const hasHTMLChanged = (newDOM, oldDOM) =>
+    verificationFunctions.reduce((acc, fn) => {
+        return acc || fn(newDOM, oldDOM);
+    }, false);
 
 const cloneRequestWithDiffURL = (request, url) =>
     url
@@ -35,7 +147,7 @@ export const cacheHTMLPlugin = {
          * Check if there is a response cached for the request
          * URL. If yes, compare the content of both the cached
          * response and the new response. If they are different
-         * send a the `HTML_UPDATE_AVAILABLE` message to window.
+         * send the `HTML_UPDATE_AVAILABLE` message to window.
          */
         const cachedResponseObj = await caches.match(
             new URL(request.url).pathname
@@ -43,7 +155,13 @@ export const cacheHTMLPlugin = {
         if (cachedResponseObj) {
             const cachedResponse = await cachedResponseObj.text();
             const clonedResponse = await response.clone().text();
-            if (cachedResponse !== clonedResponse) {
+
+            if (
+                hasHTMLChanged(
+                    parse(clonedResponse, { style: true }),
+                    parse(cachedResponse, { style: true })
+                )
+            ) {
                 sendMessageToWindow(HTML_UPDATE_AVAILABLE);
             }
         }

--- a/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
@@ -9,6 +9,8 @@ const generateLinkResource = htmlElement => htmlElement.attributes.href;
 
 const generateStyleResource = htmlElement => htmlElement.text;
 
+const identity = x => x;
+
 /**
  * Generates list of resources from the parsed HTML object.
  *
@@ -22,16 +24,19 @@ const generateResources = parsedHTML => {
     resources.scripts = parsedHTML
         .querySelectorAll('script')
         .map(generateScriptResource)
+        .filter(identity)
         .sort();
 
     resources.links = parsedHTML
         .querySelectorAll('link')
         .map(generateLinkResource)
+        .filter(identity)
         .sort();
 
     resources.styles = parsedHTML
         .querySelectorAll('style')
         .map(generateStyleResource)
+        .filter(identity)
         .sort();
 
     return resources;

--- a/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
@@ -72,8 +72,8 @@ const haveResourcesChanged = (newDOM, oldDOM) => {
  * @returns Boolean
  */
 const hasTitleChanged = (newDOM, oldDOM) => {
-    const oldTitle = oldDOM.querySelector('title').text;
-    const newTitle = newDOM.querySelector('title').text;
+    const oldTitle = (oldDOM.querySelector('title') || {}).text;
+    const newTitle = (newDOM.querySelector('title') || {}).text;
 
     return newTitle !== oldTitle;
 };

--- a/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
@@ -98,13 +98,33 @@ const hasBackendUrlChanged = (newDOM, oldDOM) => {
 };
 
 /**
+ * Returns true if image optimizing origin has changed.
+ *
+ * @param {HTMLElement} newDOM
+ * @param {HTMLElement} oldDOM
+ *
+ * @returns Boolean
+ */
+const hasImageOptimizingOriginChanged = (newDOM, oldDOM) => {
+    const oldOrigin = oldDOM.querySelector('html').attributes[
+        'data-image-optimizing-origin'
+    ];
+    const newOrigin = newDOM.querySelector('html').attributes[
+        'data-image-optimizing-origin'
+    ];
+
+    return newOrigin !== oldOrigin;
+};
+
+/**
  * Array of verfication functions to run to determine
  * if HTML has changed and needs updation on the UI.
  */
 const verificationFunctions = [
     haveResourcesChanged,
     hasTitleChanged,
-    hasBackendUrlChanged
+    hasBackendUrlChanged,
+    hasImageOptimizingOriginChanged
 ];
 
 /**

--- a/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/htmlHandler.js
@@ -55,12 +55,9 @@ const haveResourcesChanged = (newDOM, oldDOM) => {
     const oldResources = generateResources(oldDOM);
     const keysToCompare = Object.keys(newResources);
 
-    return !keysToCompare.reduce((acc, key) => {
-        const hasResourceChanged =
-            newResources[key].toString() === oldResources[key].toString();
-
-        return acc && hasResourceChanged;
-    }, true);
+    return !keysToCompare.every(
+        key => newResources[key].toString() === oldResources[key].toString()
+    );
 };
 
 /**
@@ -135,9 +132,7 @@ const verificationFunctions = [
  * @param {HTMLElement} oldDOM
  */
 const hasHTMLChanged = (newDOM, oldDOM) =>
-    verificationFunctions.reduce((acc, fn) => {
-        return acc || fn(newDOM, oldDOM);
-    }, false);
+    verificationFunctions.some(fn => fn(newDOM, oldDOM));
 
 const cloneRequestWithDiffURL = (request, url) =>
     url

--- a/yarn.lock
+++ b/yarn.lock
@@ -9830,6 +9830,11 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
+
 he@1.2.x, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -12894,6 +12899,13 @@ node-gyp@^3.6.2:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
+
+node-html-parser@~1.1.16:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.1.16.tgz#59f072bcabf1cf6e23f7878a76e0c3b81b9194fa"
+  integrity sha512-cfqTZIYDdp5cGh3NvCD5dcEDP7hfyni7WgyFacmDynLlIZaF3GVlRk8yMARhWp/PobWt1KaCV8VKdP5LKWiVbg==
+  dependencies:
+    he "1.1.1"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Description

Robust HTML update checking using Node HTML Parser.

The issue with current HTML checking is, it is a simple byte to byte comparison. Even if there is a change to an unrelated part of the HTML file that does not affect the App, SW will send a message to UI to show the update toast.

With this change, we can define what the comparison checker needs to compare to deduce if an update is needed.

As of now, this checker tracks, `style`, `link`, `script` and `title` tags along with `data-media-backend` and `data-image-optimizing-origin` attributes of the`html` tag.

We can add new validation functions as we go along.

This approach uses `node-html-parser` which adds 28KB to the bundle size before zipping.

## Related Issue
Closes [JIRA-262](https://jira.corp.magento.com/browse/PWA-262)

### Verification Steps
Can only be tested in local.

1. Run `yarn build && yarn stage:venia`
2. Go to the deployed webpage and refresh a couple times to make sure the SW is installed.
3. Go to the build directory, `venia-concept/dist/index.html` and change `title` or `data-media-backend` or any `style`.
4. Refresh the deployed web page. You should see the update toast.
5. Go back to the `index.html` file and change any entity that is not tracked, like `meta` tag.
6. Repeat step 4 and you should not see any update toast.

## Checklist
* Should not cause any issues in development mode. Ie. `yarn watch:venia`.
