### PR TITLE
Object Accessor Util

### DIFF
--- a/packages/peregrine/lib/util/objectAccessor.js
+++ b/packages/peregrine/lib/util/objectAccessor.js
@@ -1,0 +1,35 @@
+function isNull(val) {
+  return val === null;
+}
+
+function isUndefined(val) {
+  return val === undefined;
+}
+
+function or(fn1, fn2) {
+  return function(val) {
+    return fn1(val) || fn2(val);
+  };
+}
+
+function isNullOrUndefined(val) {
+  return or(isNull, isUndefined)(val);
+}
+
+export function pathOr(backup, keyArray, obj) {
+  const [key, ...rest] = keyArray;
+  const result = obj[key];
+  if (rest.length) {
+    if (result instanceof Object) {
+      return pathOr(backup, rest, result);
+    } else {
+      return backup;
+    }
+  } else {
+    return isNullOrUndefined(result) ? backup : result;
+  }
+}
+
+export function propOr(backup, key, obj) {
+  return pathOr(backup, [key], obj);
+}

--- a/packages/peregrine/lib/util/objectAccessor.js
+++ b/packages/peregrine/lib/util/objectAccessor.js
@@ -1,35 +1,35 @@
 function isNull(val) {
-  return val === null;
+    return val === null;
 }
 
 function isUndefined(val) {
-  return val === undefined;
+    return val === undefined;
 }
 
 function or(fn1, fn2) {
-  return function(val) {
-    return fn1(val) || fn2(val);
-  };
+    return function(val) {
+        return fn1(val) || fn2(val);
+    };
 }
 
 function isNullOrUndefined(val) {
-  return or(isNull, isUndefined)(val);
+    return or(isNull, isUndefined)(val);
 }
 
 export function pathOr(backup, keyArray, obj) {
-  const [key, ...rest] = keyArray;
-  const result = obj[key];
-  if (rest.length) {
-    if (result instanceof Object) {
-      return pathOr(backup, rest, result);
+    const [key, ...rest] = keyArray;
+    const result = obj[key];
+    if (rest.length) {
+        if (result instanceof Object) {
+            return pathOr(backup, rest, result);
+        } else {
+            return backup;
+        }
     } else {
-      return backup;
+        return isNullOrUndefined(result) ? backup : result;
     }
-  } else {
-    return isNullOrUndefined(result) ? backup : result;
-  }
 }
 
 export function propOr(backup, key, obj) {
-  return pathOr(backup, [key], obj);
+    return pathOr(backup, [key], obj);
 }


### PR DESCRIPTION
## Description

Adding Object Accessor utilities to ease up code blocks like `obj && obj.bar && obj.bar.baz` with a simple and powerful API.

`(obj && obj.bar && obj.bar.baz) || 'defaultValue'` -> `pathOr('defaultValue', ['bar', 'baz'], obj)`

## Related Issue
Closes nothing. Created this out of self-interest.

### Verification Steps
None

## Checklist
None