### PR TITLE
Add Support -  `Apollo Client Devtools ` on Development

### DIFF
--- a/packages/venia-ui/lib/drivers/adapter.js
+++ b/packages/venia-ui/lib/drivers/adapter.js
@@ -64,7 +64,12 @@ const VeniaAdapter = props => {
             : VeniaAdapter.apolloLink(apiBase);
 
         const cache = apollo.cache ? apollo.cache : preInstantiatedCache;
-        const client = new ApolloClient({ cache, link });
+        const connectToDevTools = process.env.NODE_ENV !== 'production';
+        const client = new ApolloClient({
+            cache,
+            link,
+            connectToDevTools: connectToDevTools
+        });
 
         client.apiBase = apiBase;
 


### PR DESCRIPTION
## Description
Add Support for Google Chrome `Apollo Client Devtools`
https://www.apollographql.com/docs/react/development-testing/developer-tooling/

**Features**
- The devtools appear as an "Apollo" tab in your Chrome inspector, along side the "Elements" and "Console" tabs. There are currently 3 main features of the devtools:
- GraphiQL: Send queries to your server through the Apollo network interface, or query the Apollo cache to see what data is loaded.
- Normalized store inspector: Visualize your GraphQL store the way Apollo Client sees it, and search by field names or values.
- Watched query inspector: View active queries and variables, and locate the associated UI components.



## Related Issue
Closes #2105

## Acceptance 

### Verification Steps
-  Install Chrome extension
-  git checkout my branch
-  execute `yarn run watch:venia`
-  Open Developer Tool you should see:
![Screen](https://user-images.githubusercontent.com/5289370/72630698-2c81e300-3953-11ea-8b43-1f18ceaa9805.png)

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
