### PR TITLE
Keeps current Accordion sections open

### DIFF
--- a/packages/peregrine/lib/talons/Accordion/useAccordion.js
+++ b/packages/peregrine/lib/talons/Accordion/useAccordion.js
@@ -31,6 +31,8 @@ export const useAccordion = props => {
 
     // If any of the sections have their isOpen prop set to true initially,
     // honor that.
+    // We never want to re-run this effect, even if deps change.
+    /* eslint-disable react-hooks/exhaustive-deps */
     useEffect(() => {
         const isOpenPropTruthy = child => child.props.isOpen;
 
@@ -57,7 +59,8 @@ export const useAccordion = props => {
         }
 
         setOpenSectionIds(initialOpenSectionIds);
-    }, [canOpenMultiple, children]);
+    }, []);
+    /* eslint-enable react-hooks/exhaustive-deps */
 
     return {
         handleSectionToggle,

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
@@ -50,14 +50,12 @@ exports[`it renders Venia price adjustments 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <polyline
-              points="18 15 12 9 6 15"
+              points="6 9 12 15 18 9"
             />
           </svg>
         </span>
       </button>
-      <div>
-        <CouponCode />
-      </div>
+      <div />
     </div>
     <div>
       <button

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
@@ -63,33 +63,7 @@ exports[`it renders Venia price adjustments 1`] = `
       </button>
       <div />
     </div>
-    <div>
-      <button
-        onClick={[Function]}
-      >
-        <div>
-          Apply Gift Card
-        </div>
-        <span>
-          <svg
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polyline
-              points="6 9 12 15 18 9"
-            />
-          </svg>
-        </span>
-      </button>
-      <div />
-    </div>
+    <GiftCardSection />
     <div>
       <button
         onClick={[Function]}

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
@@ -23,18 +23,12 @@ exports[`it renders Venia price adjustments 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <polyline
-              points="18 15 12 9 6 15"
+              points="6 9 12 15 18 9"
             />
           </svg>
         </span>
       </button>
-      <div>
-        <a
-          href="https://jira.corp.magento.com/browse/PWA-239"
-        >
-          Shipping Methods to be completed by PWA-239.
-        </a>
-      </div>
+      <div />
     </div>
     <div>
       <button

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/priceAdjustments.spec.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/priceAdjustments.spec.js
@@ -3,8 +3,6 @@ import { createTestInstance } from '@magento/peregrine';
 
 import PriceAdjustments from '../priceAdjustments';
 
-jest.mock('../CouponCode/couponCode', () => 'CouponCode');
-
 test('it renders Venia price adjustments', () => {
     // Act.
     const instance = createTestInstance(<PriceAdjustments />);

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/priceAdjustments.spec.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/priceAdjustments.spec.js
@@ -3,6 +3,8 @@ import { createTestInstance } from '@magento/peregrine';
 
 import PriceAdjustments from '../priceAdjustments';
 
+jest.mock('../giftCardSection', () => 'GiftCardSection');
+
 test('it renders Venia price adjustments', () => {
     // Act.
     const instance = createTestInstance(<PriceAdjustments />);

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/priceAdjustments.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/priceAdjustments.js
@@ -18,7 +18,6 @@ const PriceAdjustments = props => {
             <Accordion canOpenMultiple={true}>
                 <Section
                     id={'shipping_method'}
-                    isOpen={true}
                     title={'Select Shipping Method'}
                 >
                     <a href="https://jira.corp.magento.com/browse/PWA-239">

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/priceAdjustments.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/priceAdjustments.js
@@ -21,11 +21,7 @@ const PriceAdjustments = props => {
                         Shipping Methods to be completed by PWA-239.
                     </a>
                 </Section>
-                <Section
-                    id={'coupon_code'}
-                    isOpen={true}
-                    title={'Enter Coupon Code'}
-                >
+                <Section id={'coupon_code'} title={'Enter Coupon Code'}>
                     <CouponCode />
                 </Section>
                 <Section id={'gift_card'} title={'Apply Gift Card'}>


### PR DESCRIPTION
## Description

This PR fixes the problem where Accordion sections were "resetting" back to their initial state after mutations occurred in subsections (add a coupon, apply a gift card, etc.).

This was because the `useEffect` function that enforced the initial setting of which sections should be open or closed was firing whenever Accordion `children` changed, which includes the contents of the `Accordion` sections. And these sections `children` were often changing based on the results of a mutation. For example: a list of gift cards would appear once you apply a gift card.

This PR also sets the price adjustments accordion to have all sections _closed_ initially.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes PWA-359.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->


### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the `/cart` page
1. Verify that the price adjustments accordion initially doesn't have any sections open
1. Open the `Coupon` or `GiftCard` section
1. Apply or remove a coupon or gift card
1. See that the section remains open and that the Accordion doesn't reset back to no sections open.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
