### PR TITLE
Update page layout so footer will be pushed to bottom of viewport

### DIFF
--- a/packages/venia-concept/src/index.css
+++ b/packages/venia-concept/src/index.css
@@ -35,6 +35,7 @@ html {
     line-height: 1;
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
+    height: 100%;
 }
 
 body {
@@ -42,6 +43,7 @@ body {
     color: rgb(var(--venia-text));
     margin: 0;
     padding: 0;
+    height: 100%;
 }
 
 html[data-scroll-lock='true'],
@@ -115,4 +117,8 @@ button {
 button:disabled {
     cursor: default;
     touch-action: none;
+}
+
+:global(#root) {
+    height: 100%;
 }

--- a/packages/venia-ui/lib/components/Main/main.css
+++ b/packages/venia-ui/lib/components/Main/main.css
@@ -3,6 +3,9 @@
     color: rgb(var(--venia-text));
     position: relative;
     z-index: 1;
+    height: 100%;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
 }
 
 .root_masked {
@@ -10,7 +13,6 @@
 }
 
 .page {
-    min-height: 100vh;
 }
 
 .page_masked {


### PR DESCRIPTION
## Description

This PR fixes an issue with the page content being forced to a certain height, meaning the footer will never be within the viewport on page load, even if the page being loaded is very short.
With this update, if the page's content isn't long enough to push the footer, then it will place itself at the bottom of the viewport, otherwise it will be placed at the end of the pages content. This ensures there is never "leading/trailing whitespace" around the footer

## Related Issue
Closes #2177.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
1. Go to the hoempage.
2. Verify the footer is visible.

## Screenshots / Screen Captures (if appropriate)
**Before:**
![image](https://user-images.githubusercontent.com/18253422/74896503-5dd35000-53e4-11ea-9ca8-b719c0cb1357.png)

**After:**
![image](https://user-images.githubusercontent.com/18253422/74896563-80656900-53e4-11ea-89c0-5082e8ad0f26.png)


**With long content:**
![image](https://user-images.githubusercontent.com/18253422/74896524-6fb4f300-53e4-11ea-89fa-b8ca47e2d2f2.png)

