### PR TITLE
[Owls] PB-422: Extensions utilizing Page Builder as their content creation tool will break with upgrade

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Row/__tests__/__snapshots__/row.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Row/__tests__/__snapshots__/row.spec.js.snap
@@ -15,10 +15,6 @@ exports[`render full-bleed row 1`] = `
       "marginRight": undefined,
       "marginTop": undefined,
       "minHeight": undefined,
-      "paddingBottom": undefined,
-      "paddingLeft": undefined,
-      "paddingRight": undefined,
-      "paddingTop": undefined,
       "textAlign": undefined,
     }
   }
@@ -54,14 +50,6 @@ exports[`render row with all props configured 1`] = `
 >
   <div
     className="contained"
-    style={
-      Object {
-        "paddingBottom": "10px",
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
-        "paddingTop": "10px",
-      }
-    }
   />
 </div>
 `;

--- a/packages/pagebuilder/lib/ContentTypes/Row/__tests__/__snapshots__/row.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Row/__tests__/__snapshots__/row.spec.js.snap
@@ -15,6 +15,10 @@ exports[`render full-bleed row 1`] = `
       "marginRight": undefined,
       "marginTop": undefined,
       "minHeight": undefined,
+      "paddingBottom": undefined,
+      "paddingLeft": undefined,
+      "paddingRight": undefined,
+      "paddingTop": undefined,
       "textAlign": undefined,
     }
   }
@@ -44,6 +48,10 @@ exports[`render row with all props configured 1`] = `
       "marginRight": "10px",
       "marginTop": "10px",
       "minHeight": "200px",
+      "paddingBottom": "10px",
+      "paddingLeft": "10px",
+      "paddingRight": "10px",
+      "paddingTop": "10px",
       "textAlign": "right",
     }
   }

--- a/packages/pagebuilder/lib/ContentTypes/Row/__tests__/configAggregator.spec.js
+++ b/packages/pagebuilder/lib/ContentTypes/Row/__tests__/configAggregator.spec.js
@@ -12,13 +12,12 @@ test('config is aggregated correctly for row appearance == contained', () => {
             minHeight: null,
             backgroundColor: null,
             enableParallax: false,
-            parallaxSpeed: 0.5,
-            paddingTop: '10px'
+            parallaxSpeed: 0.5
         })
     );
 });
 
-test('config is aggregated correctly for row appearance == full-bleed', () => {
+test('config is aggregated correctly for row appearance != contained', () => {
     const node = document.createElement('div');
     node.innerHTML = `<div data-content-type="row" data-appearance="full-bleed" data-enable-parallax="1" data-parallax-speed="2.0" data-background-images="{}" data-element="main" style="justify-content: flex-end; display: flex; flex-direction: column; background-color: rgb(33, 255, 255); background-position: left top; background-size: contain; background-repeat: no-repeat; background-attachment: scroll; border-style: none; border-width: 1px; border-radius: 0px; min-height: 900px; margin: 0px 0px 10px; padding: 10px;"></div>`;
     const config = configAggregator(node.childNodes[0], {
@@ -30,23 +29,7 @@ test('config is aggregated correctly for row appearance == full-bleed', () => {
             minHeight: '900px',
             backgroundColor: 'rgb(33, 255, 255)',
             enableParallax: true,
-            parallaxSpeed: 2.0,
-            paddingTop: '10px'
-        })
-    );
-});
-
-test('config is aggregated correctly for row appearance == full-width', () => {
-    const node = document.createElement('div');
-    node.innerHTML = `<div data-content-type="row" data-appearance="full-width" data-enable-parallax="1" data-parallax-speed="2.0" data-background-images="{}" data-element="main" style="justify-content: flex-end; display: flex; flex-direction: column; background-color: rgb(33, 255, 255); background-position: left top; background-size: contain; background-repeat: no-repeat; background-attachment: scroll; border-style: none; border-width: 1px; border-radius: 0px; min-height: 900px; margin: 0px 0px 10px; padding: 0px;"><div class="row-full-width-inner" data-element="inner" style="padding: 25px 10px;"></div></div>`;
-    const config = configAggregator(node.childNodes[0], {
-        appearance: 'full-width'
-    });
-
-    expect(config).toEqual(
-        expect.objectContaining({
-            paddingTop: '25px',
-            paddingLeft: '10px'
+            parallaxSpeed: 2.0
         })
     );
 });

--- a/packages/pagebuilder/lib/ContentTypes/Row/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Row/configAggregator.js
@@ -2,7 +2,6 @@ import {
     getAdvanced,
     getBackgroundImages,
     getVerticalAlignment,
-    getPadding,
     getIsHidden
 } from '../../utils';
 
@@ -10,10 +9,6 @@ export default (node, props) => {
     // Determine which node holds the data for the appearance
     const dataNode =
         props.appearance === 'contained' ? node.childNodes[0] : node;
-    const paddingNode =
-        props.appearance === 'full-width' || props.appearance === 'contained'
-            ? node.childNodes[0]
-            : node;
     return {
         minHeight: dataNode.style.minHeight ? dataNode.style.minHeight : null,
         ...getVerticalAlignment(dataNode),
@@ -24,7 +19,6 @@ export default (node, props) => {
         enableParallax: dataNode.getAttribute('data-enable-parallax') === '1',
         parallaxSpeed: parseFloat(dataNode.getAttribute('data-parallax-speed')),
         ...getAdvanced(dataNode),
-        ...getPadding(paddingNode),
         ...getIsHidden(node)
     };
 };

--- a/packages/pagebuilder/lib/ContentTypes/Row/row.js
+++ b/packages/pagebuilder/lib/ContentTypes/Row/row.js
@@ -70,10 +70,7 @@ const Row = props => {
         marginTop,
         marginRight,
         marginBottom,
-        marginLeft
-    };
-
-    const paddingStyles = {
+        marginLeft,
         paddingTop,
         paddingRight,
         paddingBottom,
@@ -164,7 +161,7 @@ const Row = props => {
         return (
             <div
                 ref={backgroundElement}
-                style={{ ...dynamicStyles, ...paddingStyles }}
+                style={dynamicStyles}
                 className={[classes.root, ...cssClasses].join(' ')}
             >
                 {children}
@@ -179,9 +176,7 @@ const Row = props => {
                 style={dynamicStyles}
                 className={[classes.root, ...cssClasses].join(' ')}
             >
-                <div style={paddingStyles} className={classes.contained}>
-                    {children}
-                </div>
+                <div className={classes.contained}>{children}</div>
             </div>
         );
     }
@@ -191,7 +186,7 @@ const Row = props => {
             <div
                 ref={backgroundElement}
                 className={classes.inner}
-                style={{ ...dynamicStyles, ...paddingStyles }}
+                style={dynamicStyles}
             >
                 {children}
             </div>


### PR DESCRIPTION
## Description
We resolved a bug as part of our BiC epic PB-55 which will only be migrated for entities that are declared in our configuration. This means any extension which uses Page Builder as a content creation tool will not be upgraded and thus break. This could use the content to become corrupted if modified by the user without it being migrated. So we reverted bugfix that contains BiC changes

## Related Issue
[PB-422](https://jira.corp.magento.com/browse/PB-422) Extensions utilizing Page Builder as their content creation tool will break with upgrade

## Acceptance 
Bugfix should be reverted

### Verification Steps
1. Create Page Builder content with one contained row containing a button. 
2. Duplicate that row and change the appearance from contained to Full Width.
3. Verify the buttons in each row are not aligned

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
