### PR TITLE
Fix conditionals in JSX

### DIFF
--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/ShippingMethods/shippingMethods.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/ShippingMethods/shippingMethods.js
@@ -24,6 +24,38 @@ const ShippingMethods = props => {
 
     const classes = mergeClasses(defaultClasses, props.classes);
 
+    const radios =
+        isShowingForm && hasMethods ? (
+            <Fragment>
+                <h3 className={classes.prompt}>Shipping Methods</h3>
+                <Form>
+                    <ShippingRadios
+                        selectedShippingMethod={selectedShippingMethod}
+                        shippingMethods={shippingMethods}
+                    />
+                </Form>
+            </Fragment>
+        ) : null;
+
+    const formOrPlaceholder = isShowingForm ? (
+        <Fragment>
+            <ShippingForm
+                hasMethods={hasMethods}
+                selectedShippingFields={selectedShippingFields}
+            />
+            {radios}
+        </Fragment>
+    ) : (
+        <Button
+            classes={{ root_lowPriority: classes.estimateLink }}
+            priority="low"
+            type="button"
+            onClick={showForm}
+        >
+            I want to estimate my shipping
+        </Button>
+    );
+
     return (
         <div className={classes.root}>
             <p className={classes.message}>
@@ -31,36 +63,7 @@ const ShippingMethods = props => {
                 provide the Country, State, and ZIP for the destination of your
                 order.
             </p>
-            {isShowingForm ? (
-                <Fragment>
-                    <ShippingForm
-                        hasMethods={hasMethods}
-                        selectedShippingFields={selectedShippingFields}
-                    />
-                    {hasMethods ? (
-                        <Fragment>
-                            <h3 className={classes.prompt}>Shipping Methods</h3>
-                            <Form>
-                                <ShippingRadios
-                                    selectedShippingMethod={
-                                        selectedShippingMethod
-                                    }
-                                    shippingMethods={shippingMethods}
-                                />
-                            </Form>
-                        </Fragment>
-                    ) : null}
-                </Fragment>
-            ) : (
-                <Button
-                    classes={{ root_lowPriority: classes.estimateLink }}
-                    priority="low"
-                    type="button"
-                    onClick={showForm}
-                >
-                    I want to estimate my shipping
-                </Button>
-            )}
+            {formOrPlaceholder}
         </div>
     );
 };

--- a/packages/venia-ui/lib/components/CartPage/PriceSummary/discountSummary.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceSummary/discountSummary.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import gql from 'graphql-tag';
 import { Price } from '@magento/peregrine';
 
@@ -40,7 +40,7 @@ const DiscountSummary = props => {
     const discount = getDiscount(props.data);
 
     return discount.value ? (
-        <>
+        <Fragment>
             <span className={classes.lineItemLabel}>{'Discounts applied'}</span>
             <span className={classes.price}>
                 {'-'}
@@ -49,7 +49,7 @@ const DiscountSummary = props => {
                     currencyCode={discount.currency}
                 />
             </span>
-        </>
+        </Fragment>
     ) : null;
 };
 

--- a/packages/venia-ui/lib/components/CartPage/PriceSummary/giftCardSummary.ee.js
+++ b/packages/venia-ui/lib/components/CartPage/PriceSummary/giftCardSummary.ee.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Price } from '@magento/peregrine';
 
 import { mergeClasses } from '../../../classify';
@@ -39,7 +39,7 @@ export default props => {
     const cards = getGiftCards(props.data);
 
     return cards.value ? (
-        <>
+        <Fragment>
             <span className={classes.lineItemLabel}>
                 {'Gift Card(s) applied'}
             </span>
@@ -47,6 +47,6 @@ export default props => {
                 {'-'}
                 <Price value={cards.value} currencyCode={cards.currency} />
             </span>
-        </>
+        </Fragment>
     ) : null;
 };

--- a/packages/venia-ui/lib/components/CartPage/cartPage.js
+++ b/packages/venia-ui/lib/components/CartPage/cartPage.js
@@ -33,6 +33,15 @@ const CartPage = props => {
         ) : null;
     }, [classes.sign_in, handleSignIn, isSignedIn]);
 
+    const productListing = hasItems ? (
+        <ProductListing />
+    ) : (
+        <h3>There are no items in your cart.</h3>
+    );
+
+    const priceAdjustments = hasItems ? <PriceAdjustments /> : null;
+    const priceSummary = hasItems ? <PriceSummary /> : null;
+
     return (
         <div className={classes.root}>
             <Title>{`Cart - ${STORE_NAME}`}</Title>
@@ -41,19 +50,13 @@ const CartPage = props => {
                 {signInDisplay}
             </div>
             <div className={classes.body}>
-                <div className={classes.items_container}>
-                    {hasItems ? (
-                        <ProductListing />
-                    ) : (
-                        <h3>There are no items in your cart.</h3>
-                    )}
-                </div>
+                <div className={classes.items_container}>{productListing}</div>
                 <div className={classes.price_adjustments_container}>
-                    {hasItems ? <PriceAdjustments /> : null}
+                    {priceAdjustments}
                 </div>
                 <div className={classes.summary_container}>
                     <div className={classes.summary_contents}>
-                        {hasItems ? <PriceSummary /> : null}
+                        {priceSummary}
                     </div>
                 </div>
                 <div className={classes.recently_viewed_container}>

--- a/packages/venia-ui/lib/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-ui/lib/components/Checkout/Receipt/receipt.js
@@ -25,6 +25,26 @@ const Receipt = props => {
 
     const classes = mergeClasses(defaultClasses, props.classes);
 
+    const content = isSignedIn ? (
+        <Fragment>
+            <div className={classes.textBlock}>
+                You can also visit your account page for more information.
+            </div>
+            <Button onClick={handleViewOrderDetails}>View Order Details</Button>
+        </Fragment>
+    ) : (
+        <Fragment>
+            <hr />
+            <div className={classes.textBlock}>
+                Track order status and earn rewards for your purchase by
+                creating an account.
+            </div>
+            <Button priority="high" onClick={handleCreateAccount}>
+                Create an Account
+            </Button>
+        </Fragment>
+    );
+
     return (
         <div className={classes.root}>
             <div className={classes.body}>
@@ -33,28 +53,7 @@ const Receipt = props => {
                     You will receive an order confirmation email with order
                     status and other details.
                 </div>
-                {isSignedIn ? (
-                    <Fragment>
-                        <div className={classes.textBlock}>
-                            You can also visit your account page for more
-                            information.
-                        </div>
-                        <Button onClick={handleViewOrderDetails}>
-                            View Order Details
-                        </Button>
-                    </Fragment>
-                ) : (
-                    <Fragment>
-                        <hr />
-                        <div className={classes.textBlock}>
-                            Track order status and earn rewards for your
-                            purchase by creating an account.
-                        </div>
-                        <Button priority="high" onClick={handleCreateAccount}>
-                            Create an Account
-                        </Button>
-                    </Fragment>
-                )}
+                {content}
             </div>
         </div>
     );

--- a/packages/venia-ui/lib/components/Checkout/addressForm.js
+++ b/packages/venia-ui/lib/components/Checkout/addressForm.js
@@ -49,6 +49,20 @@ const AddressForm = props => {
     } = talonProps;
 
     const classes = mergeClasses(defaultClasses, props.classes);
+
+    // hide email field if user is signed in; cart already has address
+    const emailField = !isSignedIn ? (
+        <div className={classes.email}>
+            <Field id={classes.email} label="Email">
+                <TextInput
+                    id={classes.email}
+                    field="email"
+                    validate={isRequired}
+                />
+            </Field>
+        </div>
+    ) : null;
+
     return (
         <Form
             className={classes.root}
@@ -78,19 +92,7 @@ const AddressForm = props => {
                         />
                     </Field>
                 </div>
-                {/* Hide this field if user is signed in. Cart already has address. */}
-                {!isSignedIn ? (
-                    <div className={classes.email}>
-                        <Field id={classes.email} label="Email">
-                            <TextInput
-                                id={classes.email}
-                                field="email"
-                                validate={isRequired}
-                            />
-                        </Field>
-                    </div>
-                ) : null}
-
+                {emailField}
                 <div className={classes.street0}>
                     <Field id={classes.street0} label="Street">
                         <TextInput

--- a/packages/venia-ui/lib/components/Checkout/paymentsFormItems.js
+++ b/packages/venia-ui/lib/components/Checkout/paymentsFormItems.js
@@ -44,6 +44,7 @@ const PaymentsFormItems = props => {
     });
 
     const anchorRef = useRef(null);
+
     // When the address checkbox is unchecked, additional fields are rendered.
     // This causes the form to grow, and potentially to overflow, so the new
     // fields may go unnoticed. To reveal them, we scroll them into view.
@@ -56,6 +57,20 @@ const PaymentsFormItems = props => {
             }
         }
     }, [addressDiffers]);
+
+    // hide email field if user is signed in; cart already has address
+    const emailField =
+        addressDiffers && !isSignedIn ? (
+            <div className={classes.email}>
+                <Field label="Email">
+                    <TextInput
+                        id={classes.email}
+                        field="email"
+                        validate={isRequired}
+                    />
+                </Field>
+            </div>
+        ) : null;
 
     const billingAddressFields = addressDiffers ? (
         <Fragment>
@@ -77,18 +92,7 @@ const PaymentsFormItems = props => {
                     />
                 </Field>
             </div>
-            {/* Hide this field if user is signed in. Cart already has address. */}
-            {!isSignedIn ? (
-                <div className={classes.email}>
-                    <Field label="Email">
-                        <TextInput
-                            id={classes.email}
-                            field="email"
-                            validate={isRequired}
-                        />
-                    </Field>
-                </div>
-            ) : null}
+            {emailField}
             <div className={classes.street0}>
                 <Field label="Street">
                     <TextInput


### PR DESCRIPTION
## Description
In this codebase, we avoid multiline statements in JSX because they defeat the main purpose of using JSX: readable trees. In practice, this only comes up when conditionally rendering JSX elements. We've established a pattern of first defining conditional elements as variables (constants), then inserting those variables into the final tree, and we've been pretty good about using this pattern. But we haven't been perfect, and that makes the pattern unclear.

This PR corrects all known cases in which we were not adhering to this pattern.

```jsx
// ❌
return (
  <div>
    {condition ? (
        <Foo />
      ) : (
        <Bar />
      )
    }
  </div>
)

// ✅
const element = condition ? (
  <Foo />
) : (
  <Bar />
)

return (
  <div>
    {element}
  </div>
)
```

## Related Issue
PWA-415

## Acceptance 

### Verification Steps
1. `yarn test`

## Screenshots / Screen Captures (if appropriate)

## Checklist
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
