### PR TITLE
[Owls] PB-375: Align video background with embedded video

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Video/__tests__/__snapshots__/video.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Video/__tests__/__snapshots__/video.spec.js.snap
@@ -96,6 +96,54 @@ exports[`renders a Video component with all props configured 1`] = `
 </div>
 `;
 
+exports[`renders a Video component with all props configured for local video 1`] = `
+<div
+  className=" test-class"
+  style={
+    Object {
+      "marginBottom": "10px",
+      "marginLeft": "10px",
+      "marginRight": "10px",
+      "marginTop": "10px",
+      "textAlign": "right",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "maxWidth": "500px",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "border": "solid",
+          "borderColor": "red",
+          "borderRadius": "15px",
+          "borderWidth": "10px",
+          "paddingBottom": "10px",
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
+          "paddingTop": "10px",
+        }
+      }
+    >
+      <div>
+        <video
+          autoPlay={true}
+          controls={true}
+          frameBorder="0"
+          muted={true}
+          src="https://example.com/video.mp4"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders an empty Video component 1`] = `
 <div
   className=""

--- a/packages/pagebuilder/lib/ContentTypes/Video/__tests__/configAggregator.spec.js
+++ b/packages/pagebuilder/lib/ContentTypes/Video/__tests__/configAggregator.spec.js
@@ -1,6 +1,6 @@
 import configAggregator from '../configAggregator';
 
-test('video config aggregator retrieves content', () => {
+test('video config aggregator retrieves content with youtube', () => {
     const node = document.createElement('div');
     node.innerHTML = `<div data-content-type="video" data-appearance="default" data-element="main" style="margin: 0px;"><div class="pagebuilder-video-inner" data-element="inner" style="max-width: 1000px;"><div class="pagebuilder-video-wrapper" data-element="wrapper" style="border-style: none; border-width: 1px; border-radius: 0px; padding: 0px;"><div class="pagebuilder-video-container"><iframe frameborder="0" allowfullscreen="" src="https://www.youtube.com/embed/N0bYol6ax8Y" data-element="video"></iframe></div></div></div></div>`;
 
@@ -12,6 +12,24 @@ test('video config aggregator retrieves content', () => {
         expect.objectContaining({
             maxWidth: '1000px',
             url: 'https://www.youtube.com/embed/N0bYol6ax8Y'
+        })
+    );
+});
+
+test('video config aggregator retrieves content with local video', () => {
+    const node = document.createElement('div');
+    node.innerHTML = `<div data-content-type="video" data-appearance="default" data-element="main" style="margin: 0px;"><div class="pagebuilder-video-inner" data-element="inner" style="max-width: 1000px;"><div class="pagebuilder-video-wrapper" data-element="wrapper" style="border-style: none; border-width: 1px; border-radius: 0px; padding: 0px;"><div class="pagebuilder-video-container"><video frameborder="0" controls="" src="https://example.com//video.mp4" autoplay="true" muted="true" data-element="video"></video></div></div></div></div>`;
+
+    const aggregatedConfig = configAggregator(node.childNodes[0], {
+        appearance: 'default'
+    });
+
+    expect(aggregatedConfig).toEqual(
+        expect.objectContaining({
+            maxWidth: '1000px',
+            url: 'https://example.com//video.mp4',
+            autoplay: true,
+            muted: true
         })
     );
 });

--- a/packages/pagebuilder/lib/ContentTypes/Video/__tests__/video.spec.js
+++ b/packages/pagebuilder/lib/ContentTypes/Video/__tests__/video.spec.js
@@ -40,3 +40,29 @@ test('renders a Video component with all props configured', () => {
 
     expect(component.toJSON()).toMatchSnapshot();
 });
+
+test('renders a Video component with all props configured for local video', () => {
+    const videoProps = {
+        url: 'https://example.com/video.mp4',
+        muted: true,
+        autoplay: true,
+        maxWidth: '500px',
+        textAlign: 'right',
+        border: 'solid',
+        borderColor: 'red',
+        borderWidth: '10px',
+        borderRadius: '15px',
+        marginTop: '10px',
+        marginRight: '10px',
+        marginBottom: '10px',
+        marginLeft: '10px',
+        paddingTop: '10px',
+        paddingRight: '10px',
+        paddingBottom: '10px',
+        paddingLeft: '10px',
+        cssClasses: ['test-class']
+    };
+    const component = createTestInstance(<Video {...videoProps} />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+});

--- a/packages/pagebuilder/lib/ContentTypes/Video/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Video/configAggregator.js
@@ -9,10 +9,16 @@ import {
 
 export default node => {
     const iframe = node.querySelector('iframe');
+    const video = node.querySelector('video');
     const wrapper = node.querySelector('[data-element="wrapper"]');
 
     return {
-        url: iframe ? iframe.getAttribute('src') || null : null,
+        url:
+            (iframe && iframe.getAttribute('src')) ||
+            (video && video.getAttribute('src')) ||
+            null,
+        autoplay: !!(video && video.getAttribute('autoplay') === 'true'),
+        muted: !!(video && video.getAttribute('muted') === 'true'),
         maxWidth: node.childNodes[0].style.maxWidth || null,
         ...getTextAlign(node),
         ...getMargin(node),

--- a/packages/pagebuilder/lib/ContentTypes/Video/video.js
+++ b/packages/pagebuilder/lib/ContentTypes/Video/video.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import defaultClasses from './video.css';
 import { mergeClasses } from '@magento/venia-ui/lib/classify';
-import { arrayOf, shape, string } from 'prop-types';
+import { arrayOf, shape, string, bool } from 'prop-types';
 
 /**
  * Page Builder Video component.
@@ -18,7 +18,9 @@ import { arrayOf, shape, string } from 'prop-types';
 const Video = props => {
     const classes = mergeClasses(defaultClasses, props.classes);
     const {
-        url,
+        url = '',
+        autoplay,
+        muted,
         maxWidth,
         textAlign,
         border,
@@ -56,9 +58,19 @@ const Video = props => {
         paddingBottom,
         paddingLeft
     };
+    const youtubeRegExp = new RegExp(
+        '^(?:https?://|//)?(?:www\\.|m\\.)?' +
+            '(?:youtu\\.be/|youtube\\.com/(?:embed/|v/|watch\\?v=|watch\\?.+&v=))([\\w-]{11})(?![\\w-])'
+    );
+    const vimeoRegExp = new RegExp(
+        'https?://(?:www\\.|player\\.)?vimeo.com/(?:channels/' +
+            '(?:\\w+/)?|groups/([^/]*)/videos/|album/(\\d+)/video/|video/|)(\\d+)(?:$|/|\\?)'
+    );
 
-    const Video =
-        url && url.length ? (
+    let Video = '';
+
+    if (url.length && (youtubeRegExp.test(url) || vimeoRegExp.test(url))) {
+        Video = (
             <div className={classes.container}>
                 <iframe
                     className={classes.video}
@@ -69,9 +81,23 @@ const Video = props => {
                     src={url}
                 />
             </div>
-        ) : (
-            ''
         );
+    } else if (url.length) {
+        /* eslint-disable jsx-a11y/media-has-caption */
+        Video = (
+            <div className={classes.container}>
+                <video
+                    className={classes.video}
+                    src={url}
+                    autoPlay={autoplay}
+                    muted={muted}
+                    frameBorder="0"
+                    controls={true}
+                />
+            </div>
+        );
+        /* eslint-enable jsx-a11y/media-has-caption */
+    }
 
     return (
         <div
@@ -98,7 +124,9 @@ const Video = props => {
  * @property {String} classes.wrapper CSS classes for the wrapper container element
  * @property {String} classes.container CSS classes for the container element
  * @property {String} classes.video CSS classes for the video element
- * @property {String} url Embed URL to render the video from an external provider (YouTube, Vimeo etc)
+ * @property {String} url URL to render the video from an external provider (YouTube, Vimeo etc)
+ * @property {Boolean} autoplay Video autoplay
+ * @property {Boolean} muted Video muted
  * @property {String} maxWidth Maximum width of the video
  * @property {String} textAlign Alignment of the video within the parent container
  * @property {String} border CSS border property
@@ -124,6 +152,8 @@ Video.propTypes = {
         video: string
     }),
     url: string,
+    autoplay: bool,
+    muted: bool,
     maxWidth: string,
     textAlign: string,
     border: string,

--- a/packages/pagebuilder/lib/ContentTypes/Video/video.js
+++ b/packages/pagebuilder/lib/ContentTypes/Video/video.js
@@ -69,7 +69,7 @@ const Video = props => {
 
     let Video = '';
 
-    if (url.length && (youtubeRegExp.test(url) || vimeoRegExp.test(url))) {
+    if (url && url.length && (youtubeRegExp.test(url) || vimeoRegExp.test(url))) {
         Video = (
             <div className={classes.container}>
                 <iframe
@@ -82,7 +82,7 @@ const Video = props => {
                 />
             </div>
         );
-    } else if (url.length) {
+    } else if (url && url.length) {
         /* eslint-disable jsx-a11y/media-has-caption */
         Video = (
             <div className={classes.container}>

--- a/packages/pagebuilder/lib/ContentTypes/Video/video.js
+++ b/packages/pagebuilder/lib/ContentTypes/Video/video.js
@@ -69,7 +69,11 @@ const Video = props => {
 
     let Video = '';
 
-    if (url && url.length && (youtubeRegExp.test(url) || vimeoRegExp.test(url))) {
+    if (
+        url &&
+        url.length &&
+        (youtubeRegExp.test(url) || vimeoRegExp.test(url))
+    ) {
         Video = (
             <div className={classes.container}>
                 <iframe


### PR DESCRIPTION
## Description
Added support for videos from external sources into PageBuilder content so that I can store video assets on CDN or web-server along with other media assets 

## Related Issue
[PB-375](https://jira.corp.magento.com/browse/PB-375) Align video background with embedded video

## Acceptance 
* User sees CDN or web-server video playing on the page

### Verification Steps
1. Create Video content type with video from CDN or web-server 
3. Make sure Video playing on the page

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
