### PR TITLE
#2204 Shipping form fields shown as not required (UI), whereas they are from the code

### DIFF
--- a/packages/venia-ui/lib/components/Checkout/addressForm.js
+++ b/packages/venia-ui/lib/components/Checkout/addressForm.js
@@ -53,7 +53,7 @@ const AddressForm = props => {
     // hide email field if user is signed in; cart already has address
     const emailField = !isSignedIn ? (
         <div className={classes.email}>
-            <Field id={classes.email} label="Email">
+            <Field id={classes.email} label="Email" required>
                 <TextInput
                     id={classes.email}
                     field="email"
@@ -75,7 +75,7 @@ const AddressForm = props => {
                     {error && error.toString()}
                 </div>
                 <div className={classes.firstname}>
-                    <Field id={classes.firstname} label="First Name">
+                    <Field id={classes.firstname} label="First Name" required>
                         <TextInput
                             id={classes.firstname}
                             field="firstname"
@@ -84,7 +84,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.lastname}>
-                    <Field id={classes.lastname} label="Last Name">
+                    <Field id={classes.lastname} label="Last Name" required>
                         <TextInput
                             id={classes.lastname}
                             field="lastname"
@@ -94,7 +94,7 @@ const AddressForm = props => {
                 </div>
                 {emailField}
                 <div className={classes.street0}>
-                    <Field id={classes.street0} label="Street">
+                    <Field id={classes.street0} label="Street" required>
                         <TextInput
                             id={classes.street0}
                             field="street[0]"
@@ -103,7 +103,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.city}>
-                    <Field id={classes.city} label="City">
+                    <Field id={classes.city} label="City" required>
                         <TextInput
                             id={classes.city}
                             field="city"
@@ -112,7 +112,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.region_code}>
-                    <Field id={classes.region_code} label="State">
+                    <Field id={classes.region_code} label="State" required>
                         <TextInput
                             id={classes.region_code}
                             field="region_code"
@@ -125,7 +125,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.postcode}>
-                    <Field id={classes.postcode} label="ZIP">
+                    <Field id={classes.postcode} label="ZIP" required>
                         <TextInput
                             id={classes.postcode}
                             field="postcode"
@@ -134,7 +134,7 @@ const AddressForm = props => {
                     </Field>
                 </div>
                 <div className={classes.telephone}>
-                    <Field id={classes.telephone} label="Phone">
+                    <Field id={classes.telephone} label="Phone" required>
                         <TextInput
                             id={classes.telephone}
                             field="telephone"

--- a/packages/venia-ui/lib/components/Field/field.css
+++ b/packages/venia-ui/lib/components/Field/field.css
@@ -36,9 +36,6 @@
 }
 
 .requiredSymbol {
-    background-color: black;
-    width: 0.4rem;
-    height: 0.4rem;
-    border-radius: 50%;
+    color: red;
     margin-right: 0.4rem;
 }

--- a/packages/venia-ui/lib/components/Field/field.js
+++ b/packages/venia-ui/lib/components/Field/field.js
@@ -8,7 +8,7 @@ const Field = props => {
     const { children, id, label, required } = props;
     const classes = mergeClasses(defaultClasses, props.classes);
     const requiredSymbol = required ? (
-        <span className={classes.requiredSymbol} />
+        <span className={classes.requiredSymbol}>*</span>
     ) : null;
 
     return (


### PR DESCRIPTION
# Description

This PR fixes the bug reported in #2204 - Adds visual representation for the shopping form fields to let the customer know that they are required fields before pressing the "Use Address" button.

## Related Issue
Closes #2204.

## Acceptance 

### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps

1. Go to a product page
2. Add the product to the cart
3. Open the cart
4. Click on the "Checkout" button
5. Press the button to add the shipping information
6. See that field labels contain the `*` (asterisk) hint that they are required

## Screenshots / Screen Captures (if appropriate)
![shipping-form-fields-has-required-symbol](https://user-images.githubusercontent.com/13456702/75756942-247ed680-5d3a-11ea-8351-31157171b286.jpg)


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->

