### PR TITLE
feat: core team can scaffold new modules quick

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,22 @@
   "name": "@magento/pwa-studio",
   "version": "5.0.1",
   "private": true,
-  "workspaces": [
-    "packages/babel-preset-peregrine",
-    "packages/create-pwa",
-    "packages/graphql-cli-validate-magento-pwa-queries",
-    "packages/pagebuilder",
-    "packages/peregrine",
-    "packages/pwa-buildpack",
-    "packages/upward-js",
-    "packages/upward-spec",
-    "packages/venia-concept",
-    "packages/venia-styleguide",
-    "packages/venia-ui"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "jestProjectConfig": {
+      "node": {
+        "babel-preset-peregrine": "Babel Preset",
+        "upward-js": "Upward JS"
+      },
+      "react": {
+        "pagebuilder": "PageBuilder",
+        "venia-concept": "Venia Storefront",
+        "venia-ui": "Venia UI"
+      }
+    }
+  },
   "author": "Magento Commerce",
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/magento/pwa-studio",
@@ -82,6 +85,7 @@
   },
   "resolutions": {
     "graphql": "~14.3.1",
+    "react": "~16.9.0",
     "**/graphql-cli/npm-run": "~5.0.0"
   },
   "engines": {

--- a/scripts/make-new-package.js
+++ b/scripts/make-new-package.js
@@ -1,0 +1,217 @@
+const execa = require('execa');
+const path = require('path');
+const readline = require('readline');
+const chalk = require('chalk');
+const figures = require('figures');
+
+const { promisify } = require('util');
+const _fs = require('fs');
+const fs = {
+    readdir: promisify(_fs.readdir),
+    readFile: promisify(_fs.readFile),
+    mkdir: promisify(_fs.mkdir),
+    writeFile: promisify(_fs.writeFile)
+};
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+async function run() {
+    const prototypePackages = {
+        base: path.resolve(__dirname, '../'),
+        node: path.resolve(__dirname, '../packages/pwa-buildpack'),
+        react: path.resolve(__dirname, '../packages/peregrine')
+    };
+
+    const getPackageFile = async dir =>
+        JSON.parse(
+            await fs.readFile(path.resolve(dir, 'package.json'), 'utf8')
+        );
+
+    const packageFiles = {
+        base: await getPackageFile(prototypePackages.base),
+        node: await getPackageFile(prototypePackages.node),
+        react: await getPackageFile(prototypePackages.react)
+    };
+
+    const basePkg = () => ({
+        version: '0.0.1',
+        publishConfig: {
+            access: 'public'
+        },
+        main: 'lib/index.js',
+        scripts: {
+            clean: ' '
+        },
+        repository: packageFiles.base.repository,
+        author: packageFiles.base.author,
+        license: packageFiles.base.license,
+        bugs: packageFiles.base.bugs,
+        homepage: packageFiles.base.homepage,
+        devDependencies: {
+            '@magento/eslint-config':
+                packageFiles.base.devDependencies['@magento/eslint-config']
+        },
+        'pwa-studio': {
+            targets: {}
+        },
+        engines: {
+            node: packageFiles.base.engines.node
+        }
+    });
+
+    const packageTemplate = {
+        node(props) {
+            return Object.assign(basePkg(), props);
+        },
+        react(props) {
+            return Object.assign(
+                basePkg(),
+                {
+                    peerDependencies: {
+                        '@magento/babel-preset-peregrine':
+                            packageFiles.react.peerDependencies[
+                                '@magento/babel-preset-peregrine'
+                            ],
+                        react: packageFiles.base.resolutions.react
+                    },
+                    module: 'lib/index.js',
+                    'jsnext:main': 'lib/index.js',
+                    es2015: 'lib/index.js',
+                    sideEffects: false
+                },
+                props
+            );
+        }
+    };
+
+    const ask = (question, validate = x => x.length === 0 && 'Required') =>
+        new Promise(function asker(res, rej) {
+            try {
+                rl.question(`${figures.arrowRight} ${question}`, ans => {
+                    const answer = ans.trim();
+                    const validation = validate(answer);
+                    if (typeof validation === 'string') {
+                        console.error(
+                            chalk.redBright(`${figures.cross} ${validation}`)
+                        );
+                        asker(res, rej);
+                    } else {
+                        res(answer);
+                    }
+                });
+            } catch (e) {
+                rej(e);
+            }
+        });
+
+    console.log(
+        chalk.greenBright(
+            `\n${
+                figures.smiley
+            } Congratulations on your decision to add new functionality to PWA Studio the ${chalk.bold(
+                'Right Way™'
+            )}: with a new, separate module.\n`
+        )
+    );
+
+    const dir = await ask(
+        `Project name? ${chalk.yellowBright('@magento/')}`,
+        answer =>
+            /^[a-z][a-z0-9\-]*$/.test(answer) ||
+            'Bad package name. Package names must be lowercased, dash-separated alphanumeric.'
+    );
+    const packagePath = path.resolve(__dirname, '../packages', dir);
+
+    let ls;
+    try {
+        ls = await fs.readdir(packagePath);
+    } catch (e) {
+        if (e.code !== 'ENOENT') {
+            throw e;
+        }
+    }
+    if (ls) {
+        throw new Error(`Directory ${packagePath} already exists!`);
+    }
+
+    const packageType = await ask(
+        `Package type? ${chalk.yellowBright('node')} or ${chalk.yellowBright(
+            'react'
+        )} `,
+        answer =>
+            answer === 'node' ||
+            answer === 'react' ||
+            'Must be "node" or "react"'
+    );
+
+    const projectName = await ask(`Project friendly name for test labeling? `);
+
+    const description = await ask('Package description? ');
+
+    const files = Object.entries({
+        'package.json': JSON.stringify(
+            packageTemplate[packageType]({
+                name: `@magento/${dir}`,
+                description
+            }),
+            null,
+            2
+        ),
+        '.npmignore': `.eslintrc.js
+/lib/**/__{docs,helpers,mocks,tests}__/**
+`,
+        '.eslintrc.js': await fs.readFile(
+            path.resolve(prototypePackages[packageType], '.eslintrc.js'),
+            'utf8'
+        ),
+        'README.md': `Documentation for Magento PWA Studio packages is located at [https://pwastudio.io](https://pwastudio.io).
+`
+    });
+
+    packageFiles.base.workspaces.jestProjectConfig[packageType][
+        dir
+    ] = projectName;
+
+    await ask(
+        chalk.yellowBright(`\n${figures.warning} OK to do the following?
+    - Update root package.json jestProjectConfig
+    - Create the following files:
+      ${files.map(([file]) => `packages/${dir}/${file}`).join('\n      ')}
+
+    Press enter to confirm, Ctrl-C to cancel`),
+        () => true
+    );
+
+    console.log('Writing root package.json');
+    await fs.writeFile(
+        path.resolve(prototypePackages.base, 'package.json'),
+        JSON.stringify(packageFiles.base, null, 2)
+    );
+    await fs.mkdir(packagePath);
+    await Promise.all(
+        files.map(([name, contents]) =>
+            fs.writeFile(path.resolve(packagePath, name), contents, 'utf8')
+        )
+    );
+
+    rl.close();
+    console.log('Formatting files...');
+    await execa(`eslint`, [`packages/${dir}/{*.js,package.json}`, '--fix'], {
+        cwd: path.resolve(__dirname, '../')
+    });
+
+    console.log(
+        `${chalk.greenBright(
+            figures.tick + ' Done!'
+        )} Enjoy your new project, ${chalk.yellowBright('@magento/' + dir)}.`
+    );
+}
+
+run().catch(e => {
+    rl.close();
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
## Description

As the BuildBus extension framework gains functionality, new features of Venia should be implemented as separate modules as much as possible.

This is the way of Magento, and it serves what partners desperately need:

 - A less monolithic, more maintainable Venia
 - Mix and match functionality
 - A Magento-like ability to enhance store functionality with a simple `npm install`
 - Examples of extensions, for extension developers to follow, so they start building/porting extensions and growing our ecosystem
 - Marketplace integration so extension developers can sell their stuff

For now, the script is intended for core contributor use only; use it if you want to add a package to the PWA Studio monorepo.

It creates a new module, adds it to the workspaces, and configures it for unit testing.

## Related Issue
TODO: Retcon an issue for this

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
Core team members, @jimbo @supernova-at @tjwiebell @sirugh @revanth0212 @dpatil-magento @jcalcaben 
Community maintainers, @Jordaneisenburger 

### Verification Steps
1. From the repo root directory:
  
  ```sh
  node scripts/make-new-package.js
  ```

2. Answer the questionnaire and behold!


## Screenshots / Screen Captures (if appropriate)

![image](https://user-images.githubusercontent.com/1643758/76007873-5af05900-5ed4-11ea-9b1d-c70c932a05c5.png)


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
