### PR TITLE
fix: use URL constructor and no-cors in #2213

### DIFF
--- a/packages/peregrine/lib/talons/ProductImageCarousel/useProductImageCarousel.js
+++ b/packages/peregrine/lib/talons/ProductImageCarousel/useProductImageCarousel.js
@@ -4,8 +4,7 @@ import { useCarousel } from '@magento/peregrine';
 
 import {
     sendMessageToSW,
-    VALID_SERVICE_WORKER_ENVIRONMENT,
-    isAbsoluteUrl
+    VALID_SERVICE_WORKER_ENVIRONMENT
 } from '@magento/venia-ui/lib/util/swUtils';
 import { PREFETCH_IMAGES } from '@magento/venia-ui/lib/constants/swMessageTypes';
 import { generateUrlFromContainerWidth } from '@magento/venia-ui/lib/util/images';
@@ -30,21 +29,13 @@ export const useProductImageCarousel = props => {
 
     useEffect(() => {
         if (VALID_SERVICE_WORKER_ENVIRONMENT) {
-            const urls = images.map(({ file }) => {
-                let url = generateUrlFromContainerWidth(file, imageWidth, type);
-                if (isAbsoluteUrl(url)) {
-                    /**
-                     * In case of `IMAGE_OPTIMIZING_ORIGIN` set to `backend`,
-                     * `resourceUrl` of `venia-driver` returns absolute URL with
-                     * backend URL set as origin, but SW does not accept that
-                     * origin because of CORS rules. Origin should be same as
-                     * the SW's origin which is `location.origin`.
-                     */
-                    const baseURL = new URL(url);
-                    url = baseURL.href.slice(baseURL.origin.length);
-                }
-                return `${location.origin}${url}`;
-            });
+            const urls = images.map(
+                ({ file }) =>
+                    new URL(
+                        generateUrlFromContainerWidth(file, imageWidth, type),
+                        location.origin
+                    ).href
+            );
             sendMessageToSW(PREFETCH_IMAGES, {
                 urls
             }).catch(err => {

--- a/packages/venia-concept/src/ServiceWorker/Utilities/imageCacheHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/imageCacheHandler.js
@@ -93,7 +93,7 @@ export const findSameOrLargerImage = async url => {
 };
 
 const fetchAndCacheImage = imageURL =>
-    fetch(imageURL).then(response =>
+    fetch(imageURL, { mode: 'no-cors' }).then(response =>
         caches
             .open(CATALOG_CACHE_NAME)
             .then(cache => cache.put(imageURL, response.clone()))

--- a/packages/venia-ui/lib/util/swUtils.js
+++ b/packages/venia-ui/lib/util/swUtils.js
@@ -126,5 +126,3 @@ export const sendMessageToSW = (type, payload) =>
             channel.port1.close();
         }
     });
-
-export const isAbsoluteUrl = url => /^(data|http|https)?:/i.test(url);


### PR DESCRIPTION
## Description
🚨 ONLY MERGE INTO #2213 

Per my comment internally on PWA-392 and externally [here](https://github.com/magento/pwa-studio/pull/2213#issuecomment-595454575), we can fix the swatch pre-cache issue by building URLs with the URL constructor and using `mode: 'no-cors'` on fetch requests that we only use to cache responses.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-392](https://jira.corp.magento.com/browse/PWA-392)
Branched from #2213 

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
@revanth0212 and @tjwiebell 

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Same as in #2213

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
