### PR TITLE
Added firefox specific css.

### DIFF
--- a/packages/venia-ui/lib/components/Accordion/__tests__/__snapshots__/accordion.spec.js.snap
+++ b/packages/venia-ui/lib/components/Accordion/__tests__/__snapshots__/accordion.spec.js.snap
@@ -11,29 +11,33 @@ exports[`it renders a closed Section correctly 1`] = `
       className="title_container"
       onClick={[Function]}
     >
-      <div
-        className="title"
-      >
-        The Section Title is always visible
-      </div>
       <span
-        className="root"
+        className="title_wrapper"
       >
-        <svg
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="title"
         >
-          <polyline
-            points="6 9 12 15 18 9"
-          />
-        </svg>
+          The Section Title is always visible
+        </span>
+        <span
+          className="root"
+        >
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polyline
+              points="6 9 12 15 18 9"
+            />
+          </svg>
+        </span>
       </span>
     </button>
     <div
@@ -53,32 +57,36 @@ exports[`it renders an open Section correctly 1`] = `
     className="root"
   >
     <button
-      className="title_container_open"
+      className="title_container"
       onClick={[Function]}
     >
-      <div
-        className="title"
-      >
-        The Section Title is always visible
-      </div>
       <span
-        className="root"
+        className="title_wrapper"
       >
-        <svg
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="title"
         >
-          <polyline
-            points="18 15 12 9 6 15"
-          />
-        </svg>
+          The Section Title is always visible
+        </span>
+        <span
+          className="root"
+        >
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polyline
+              points="18 15 12 9 6 15"
+            />
+          </svg>
+        </span>
       </span>
     </button>
     <div

--- a/packages/venia-ui/lib/components/Accordion/section.css
+++ b/packages/venia-ui/lib/components/Accordion/section.css
@@ -34,3 +34,14 @@
 .title_container_open {
     composes: title_container;
 }
+
+/**
+  * Firefox needs line-height set to same value as height of div
+  * to center align text inside the accordion.
+*/
+@-moz-document url-prefix() {
+    .title_container {
+        composes: title_container;
+        line-height: 4.5rem;
+    }
+}

--- a/packages/venia-ui/lib/components/Accordion/section.css
+++ b/packages/venia-ui/lib/components/Accordion/section.css
@@ -10,11 +10,12 @@
     padding: 0 1.5rem 1.5rem;
 }
 
-.contents_container_closed {
+.contents_container:empty {
     display: none;
 }
 
-.contents_container:empty {
+.contents_container_closed {
+    composes: contents_container;
     display: none;
 }
 
@@ -24,24 +25,17 @@
 
 .title_container {
     cursor: pointer;
-    display: flex;
-    height: 4.5rem;
-    justify-content: space-between;
-    padding: 0 1.5rem;
+    display: block;
     width: 100%;
 }
 
-.title_container_open {
-    composes: title_container;
-}
-
-/**
-  * Firefox needs line-height set to same value as height of div
-  * to center align text inside the accordion.
-*/
-@-moz-document url-prefix() {
-    .title_container {
-        composes: title_container;
-        line-height: 4.5rem;
-    }
+.title_wrapper {
+    align-items: center;
+    display: grid;
+    gap: 1.5rem;
+    grid-auto-flow: column;
+    grid-template-columns: 1fr;
+    height: 4.5rem;
+    justify-items: start;
+    padding: 0 1.5rem;
 }

--- a/packages/venia-ui/lib/components/Accordion/section.js
+++ b/packages/venia-ui/lib/components/Accordion/section.js
@@ -25,18 +25,17 @@ const Section = props => {
     const contentsContainerClass = isOpen
         ? classes.contents_container
         : classes.contents_container_closed;
-    const titleContainerClass = isOpen
-        ? classes.title_container_open
-        : classes.title_container;
 
     return (
         <div className={classes.root}>
             <button
-                className={titleContainerClass}
+                className={classes.title_container}
                 onClick={handleSectionToggleWithId}
             >
-                <div className={classes.title}>{title}</div>
-                {titleIcon}
+                <span className={classes.title_wrapper}>
+                    <span className={classes.title}>{title}</span>
+                    {titleIcon}
+                </span>
             </button>
             <div className={contentsContainerClass}>{children}</div>
         </div>

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/__tests__/__snapshots__/priceAdjustments.spec.js.snap
@@ -7,25 +7,27 @@ exports[`it renders Venia price adjustments 1`] = `
       <button
         onClick={[Function]}
       >
-        <div>
-          Estimate your Shipping
-        </div>
         <span>
-          <svg
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polyline
-              points="6 9 12 15 18 9"
-            />
-          </svg>
+          <span>
+            Estimate your Shipping
+          </span>
+          <span>
+            <svg
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polyline
+                points="6 9 12 15 18 9"
+              />
+            </svg>
+          </span>
         </span>
       </button>
       <div>
@@ -36,25 +38,27 @@ exports[`it renders Venia price adjustments 1`] = `
       <button
         onClick={[Function]}
       >
-        <div>
-          Enter Coupon Code
-        </div>
         <span>
-          <svg
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polyline
-              points="6 9 12 15 18 9"
-            />
-          </svg>
+          <span>
+            Enter Coupon Code
+          </span>
+          <span>
+            <svg
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polyline
+                points="6 9 12 15 18 9"
+              />
+            </svg>
+          </span>
         </span>
       </button>
       <div>
@@ -66,25 +70,27 @@ exports[`it renders Venia price adjustments 1`] = `
       <button
         onClick={[Function]}
       >
-        <div>
-          See Gift Options
-        </div>
         <span>
-          <svg
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polyline
-              points="6 9 12 15 18 9"
-            />
-          </svg>
+          <span>
+            See Gift Options
+          </span>
+          <span>
+            <svg
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polyline
+                points="6 9 12 15 18 9"
+              />
+            </svg>
+          </span>
         </span>
       </button>
       <div>


### PR DESCRIPTION
## Description

Accordion text is not center-aligned in firefox. This is probably because of the way firefox interprets `height` on div. Giving `line-height` for divs in firefox fixes the problem.

## Related Issue
Closes [PWA-384](https://jira.corp.magento.com/browse/PWA-384)

### Verification Stakeholders
@jimbo 

### Verification Steps
1. Go to cart in firefox.
2. Text in accordions should be vertically center aligned.

## Screenshots / Screen Captures (if appropriate)
![image](https://user-images.githubusercontent.com/35203638/76350005-ff114000-62d8-11ea-9a0a-c860231d60fb.png)

![image](https://user-images.githubusercontent.com/35203638/76350080-1a7c4b00-62d9-11ea-9718-e6a9bbc6f22d.png)

## Checklist
* No functionality should have changed. This is just a css change.
* Change should not effect css in chrome and safari. This is specific to firefox.
