### PR TITLE
Removed cart and checkout routes from 6.0 branch.

### DIFF
--- a/packages/venia-ui/lib/components/Routes/routes.js
+++ b/packages/venia-ui/lib/components/Routes/routes.js
@@ -4,8 +4,6 @@ import { Route, Switch } from 'react-router-dom';
 import { fullPageLoadingIndicator } from '../LoadingIndicator';
 import MagentoRoute from '../MagentoRoute';
 
-const CartPage = lazy(() => import('../CartPage'));
-const CheckoutPage = lazy(() => import('../CheckoutPage'));
 const CreateAccountPage = lazy(() => import('../CreateAccountPage'));
 const Search = lazy(() => import('../../RootComponents/Search'));
 
@@ -18,12 +16,6 @@ const Routes = () => {
                 </Route>
                 <Route exact path="/create-account">
                     <CreateAccountPage />
-                </Route>
-                <Route exact path="/cart">
-                    <CartPage />
-                </Route>
-                <Route exact path="/checkout">
-                    <CheckoutPage />
                 </Route>
                 <Route>
                     <MagentoRoute />


### PR DESCRIPTION
## Description

Deleted Cart and Checkout routes. We let webpack deal with not including cart and checkout code into the build.

Here are the build sizes before and after the changes for perspective:

Before

![image](https://user-images.githubusercontent.com/35203638/76879209-f0300d80-6843-11ea-9907-290e554f61f9.png)

After

![image](https://user-images.githubusercontent.com/35203638/76879235-f920df00-6843-11ea-9ab1-ac3ea6be77c1.png)

## Related Issue
Closes [PWA-429](https://jira.corp.magento.com/browse/PWA-429)

### Verification Stakeholders
@dpatil-magento 

### Verification Steps
1. Go to cart page. Should not render.
2. Go to checkout page. Should not render.

## Checklist
None