### PR TITLE
Order Summary - Fix font size unit

### DIFF
--- a/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/orderSummary.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/orderSummary.css
@@ -12,6 +12,6 @@
     }
 
     .title {
-        font-size: 20px;
+        font-size: 1.25rem;
     }
 }


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Revert change that originated from [this comment](https://github.com/magento/pwa-studio/pull/2271#discussion_r396763577). We should be using `rem`'s, I think this was a misunderstanding.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Add items to cart
2. Verify order summary title on mobile is still 20px

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
