### PR TITLE
fix(pagebuilder): Html content type unescapes when GraphQL does not

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Html/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Html/configAggregator.js
@@ -1,12 +1,23 @@
 import { getAdvanced } from '../../utils';
 
 export default node => {
-    const dom = new DOMParser().parseFromString(
-        '<!doctype html><body>' + node.textContent,
-        'text/html'
-    );
+    let html;
+    if (node.dataset.decoded) {
+        html = node.innerHTML;
+        if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+                'PageBuilder HTML content was unescaped! This may be a Magento configuration error.'
+            );
+        }
+    } else {
+        const dom = new DOMParser().parseFromString(
+            '<!doctype html><body>' + node.textContent,
+            'text/html'
+        );
+        html = dom.body.innerHTML;
+    }
     return {
-        html: dom.body.innerHTML,
+        html,
         ...getAdvanced(node)
     };
 };


### PR DESCRIPTION
## Description

Due to an apparent regression in M2.3.5, the GraphQL API now passes HTML content (in CMS blocks, anyway) through at least one PageBuilder-related render. The effect is that HTML content nodes, whose content itself was HTML encoded (`<div>` became `&lt;div&gt;`), was no longer HTML encoded. This broke the PageBuilder Html content type by stripping all HTML tags from it.

The Html "config aggregator" was using `node.textContent` to get and unescape its HTML, but when GraphQL has already unescaped it, we must use innerHTML instead. This PR updates the config aggregator with that logic.

Because the bug in MC-32787 may indicate a misconfiguration, the config aggregator logs a message in development mode.


<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes https://jira.corp.magento.com/browse/MC-32787.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
@sirugh 
@davemacaulay 
@dpatil-magento 
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Set your `MAGENTO_BACKEND_URL=https://pwa-test1-scjyl6a-vqnoqmbf7mivy.us-4.magentosite.cloud/` a 2.3.4 instance.
2. `yarn run watch:venia`
3. Visit homepage.
4. Verify it looks normal.
1. Set your `MAGENTO_BACKEND_URL=https://magento232-qwt7c3a-vqnoqmbf7mivy.us-4.magentosite.cloud/` a **2.3.5** instance
2. `yarn run watch:venia`
3. Visit homepage.
4. Verify it still looks normal, whereas in `develop` this formatting is bonkers.


* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
