### PR TITLE
Fixing css var in the checkbox.css

### DIFF
--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/GiftOptions/__tests__/__snapshots__/giftOptions.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/GiftOptions/__tests__/__snapshots__/giftOptions.spec.js.snap
@@ -6,6 +6,15 @@ exports[`it renders gift options in venia cart page 1`] = `
     <label
       htmlFor="includeGiftReceipt"
     >
+      <input
+        checked={true}
+        id="includeGiftReceipt"
+        name="includeGiftReceipt"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        type="checkbox"
+      />
       <span>
         <span>
           <svg
@@ -25,15 +34,6 @@ exports[`it renders gift options in venia cart page 1`] = `
           </svg>
         </span>
       </span>
-      <input
-        checked={true}
-        id="includeGiftReceipt"
-        name="includeGiftReceipt"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        type="checkbox"
-      />
       <span>
         Include gift receipt
       </span>
@@ -44,7 +44,6 @@ exports[`it renders gift options in venia cart page 1`] = `
     <label
       htmlFor="includePrintedCard"
     >
-      <span />
       <input
         checked={false}
         id="includePrintedCard"
@@ -54,6 +53,7 @@ exports[`it renders gift options in venia cart page 1`] = `
         onClick={[Function]}
         type="checkbox"
       />
+      <span />
       <span>
         Include printed card
       </span>

--- a/packages/venia-ui/lib/components/Checkbox/__tests__/__snapshots__/checkbox.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkbox/__tests__/__snapshots__/checkbox.spec.js.snap
@@ -9,9 +9,6 @@ exports[`renders the correct tree 1`] = `
   <label
     className="root"
   >
-    <span
-      className="icon"
-    />
     <input
       checked={false}
       className="input"
@@ -19,6 +16,9 @@ exports[`renders the correct tree 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       type="checkbox"
+    />
+    <span
+      className="icon"
     />
     <span
       className="label"

--- a/packages/venia-ui/lib/components/Checkbox/checkbox.css
+++ b/packages/venia-ui/lib/components/Checkbox/checkbox.css
@@ -20,7 +20,7 @@
     height: 1.25rem;
     justify-content: center;
     width: 1.25rem;
-    z-index: var(--base-z-index + 1, 1);
+    z-index: var(--base-z-index, 1);
 }
 
 .input {

--- a/packages/venia-ui/lib/components/Checkbox/checkbox.css
+++ b/packages/venia-ui/lib/components/Checkbox/checkbox.css
@@ -20,7 +20,6 @@
     height: 1.25rem;
     justify-content: center;
     width: 1.25rem;
-    z-index: var(--base-z-index, 1);
 }
 
 .input {

--- a/packages/venia-ui/lib/components/Checkbox/checkbox.js
+++ b/packages/venia-ui/lib/components/Checkbox/checkbox.js
@@ -37,15 +37,15 @@ export class Checkbox extends Component {
         return (
             <Fragment>
                 <label className={classes.root} htmlFor={id}>
-                    <span className={classes.icon}>
-                        {checked && <Icon src={CheckIcon} size={18} />}
-                    </span>
                     <BasicCheckbox
                         {...rest}
                         className={classes.input}
                         fieldState={fieldState}
                         id={id}
                     />
+                    <span className={classes.icon}>
+                        {checked && <Icon src={CheckIcon} size={18} />}
+                    </span>
                     <span className={classes.label}>{label}</span>
                 </label>
                 <Message fieldState={fieldState}>{message}</Message>

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
@@ -31,6 +31,14 @@ exports[`renders a PaymentsForm component 1`] = `
       <label
         className="root"
       >
+        <input
+          checked={true}
+          className="input"
+          name="addresses_same"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="checkbox"
+        />
         <span
           className="icon"
         >
@@ -55,14 +63,6 @@ exports[`renders a PaymentsForm component 1`] = `
             </svg>
           </span>
         </span>
-        <input
-          checked={true}
-          className="input"
-          name="addresses_same"
-          onBlur={[Function]}
-          onChange={[Function]}
-          type="checkbox"
-        />
         <span
           className="label"
         >
@@ -134,9 +134,6 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
       <label
         className="root"
       >
-        <span
-          className="icon"
-        />
         <input
           checked={false}
           className="input"
@@ -144,6 +141,9 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
           onBlur={[Function]}
           onChange={[Function]}
           type="checkbox"
+        />
+        <span
+          className="icon"
         />
         <span
           className="label"

--- a/packages/venia-ui/lib/components/CreateAccount/__tests__/__snapshots__/createAccount.spec.js.snap
+++ b/packages/venia-ui/lib/components/CreateAccount/__tests__/__snapshots__/createAccount.spec.js.snap
@@ -147,7 +147,6 @@ exports[`renders the correct tree 1`] = `
   </div>
   <div>
     <label>
-      <span />
       <input
         checked={false}
         name="subscribe"
@@ -155,6 +154,7 @@ exports[`renders the correct tree 1`] = `
         onChange={[Function]}
         type="checkbox"
       />
+      <span />
       <span>
         Subscribe to news and updates
       </span>


### PR DESCRIPTION
## Description

Small fix on the usage of CSS variable in the checkbox.css file

## Related Issue
Closes #2306.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Use a Checkbox in somewhere in the page.
2. Click in the checkbox to be checked.
3. Inspect the span that wraps the check Icon.
4. Check this `z-index` property

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
