### PR TITLE
[bug]: Fix (remove) OOTB tests from scaffold

### DIFF
--- a/packages/venia-concept/_buildpack/__tests__/__snapshots__/create.spec.js.snap
+++ b/packages/venia-concept/_buildpack/__tests__/__snapshots__/create.spec.js.snap
@@ -12,7 +12,7 @@ Object {
   "name": "whee",
   "private": true,
   "scripts": Object {
-    "test": "yarn run do test this",
+    "watch": "yarn run do watch this",
   },
   "version": "0.0.1",
 }
@@ -30,7 +30,7 @@ Object {
   "name": "whee",
   "private": true,
   "scripts": Object {
-    "test": "npm run do test this",
+    "watch": "npm run do watch this",
   },
   "version": "0.0.1",
 }

--- a/packages/venia-concept/_buildpack/__tests__/create.spec.js
+++ b/packages/venia-concept/_buildpack/__tests__/create.spec.js
@@ -94,7 +94,7 @@ test('outputs custom package.json', async () => {
             },
             scripts: {
                 'do-not-copy': 'this',
-                test: 'yarn run do test this'
+                watch: 'yarn run do watch this'
             }
         })
     });
@@ -115,7 +115,7 @@ test('outputs npm package.json', async () => {
             },
             scripts: {
                 'do-not-copy': 'this',
-                test: 'yarn run do test this'
+                watch: 'yarn run do watch this'
             }
         })
     });

--- a/packages/venia-concept/_buildpack/create.js
+++ b/packages/venia-concept/_buildpack/create.js
@@ -25,7 +25,6 @@ function createProjectFromVenia({ fs, tasks, options }) {
         'prettier:fix',
         'start',
         'start:debug',
-        'test',
         'validate-queries',
         'watch'
     ];
@@ -105,7 +104,8 @@ function createProjectFromVenia({ fs, tasks, options }) {
                 delete config.projects.venia;
                 fs.outputJsonSync(targetPath, config, { spaces: 2 });
             },
-            '{CHANGELOG*,LICENSE*,_buildpack/*}': tasks.IGNORE,
+            '{CHANGELOG*,LICENSE*,_buildpack,_buildpack/*,**/__tests__,**/__tests__/*}':
+                tasks.IGNORE,
             '**/*': tasks.COPY
         }
     };

--- a/packages/venia-concept/_buildpack/create.js
+++ b/packages/venia-concept/_buildpack/create.js
@@ -29,6 +29,19 @@ function createProjectFromVenia({ fs, tasks, options }) {
         'watch'
     ];
     const scriptsToInsert = {};
+
+    const filesToIgnore = [
+        'CHANGELOG*',
+        'LICENSE*',
+        '_buildpack',
+        '_buildpack/**',
+        // These tests are teporarily removed until we can implement a test
+        // harness for the scaffolded app. See PWA-508.
+        '**/__tests__',
+        '**/__tests__/**'
+    ];
+    const ignoresGlob = `{${filesToIgnore.join(',')}}`;
+
     return {
         after({ options }) {
             // The venia-concept directory doesn't have its own babel.config.js
@@ -104,8 +117,8 @@ function createProjectFromVenia({ fs, tasks, options }) {
                 delete config.projects.venia;
                 fs.outputJsonSync(targetPath, config, { spaces: 2 });
             },
-            '{CHANGELOG*,LICENSE*,_buildpack,_buildpack/**,**/__tests__,**/__tests__/**}':
-                tasks.IGNORE,
+            // These tasks are sequential so we must ignore before we copy.
+            [ignoresGlob]: tasks.IGNORE,
             '**/*': tasks.COPY
         }
     };

--- a/packages/venia-concept/_buildpack/create.js
+++ b/packages/venia-concept/_buildpack/create.js
@@ -104,7 +104,7 @@ function createProjectFromVenia({ fs, tasks, options }) {
                 delete config.projects.venia;
                 fs.outputJsonSync(targetPath, config, { spaces: 2 });
             },
-            '{CHANGELOG*,LICENSE*,_buildpack,_buildpack/*,**/__tests__,**/__tests__/*}':
+            '{CHANGELOG*,LICENSE*,_buildpack,_buildpack/**,**/__tests__,**/__tests__/**}':
                 tasks.IGNORE,
             '**/*': tasks.COPY
         }


### PR DESCRIPTION
## Description

The out of the box tests were failing to run. The tests that were copied were really internal tests for venia-concept components and were not intended to be scaffolded. There will be a follow-up ticket to add a proper test suite to the scaffolded app.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-476](https://jira.corp.magento.com/browse/PWA-476) and closes #2244.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
@luke-denton-aligent @zetlen 

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Check out this PR locally.
2. In a sibling directory from where you checked out pwa-studio, run the following command to mimic a scaffold: 

```
../pwa-studio/packages/pwa-buildpack/bin/buildpack create-project . --template "venia-concept" --name "example" --author "example <example@example.com>" --backend-url "https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/" --braintree-token "sandbox_8yrzsvtm_s2bg8fs563crhqzk" --npm-client "yarn"
```
3. Once the command completes (it may throw an error, but thats ok) your directory should have the scaffolded app but there should be no tests copied from `venia-concept` and there should be no `test` script in the scaffolded `package.json`. As a bonus I also removed the `_buildpack` directory.

## Screenshots / Screen Captures (if appropriate)

[![Image from Gyazo](https://i.gyazo.com/b7989e5c6dbb9eee22094cb5acc9cfda.png)](https://gyazo.com/b7989e5c6dbb9eee22094cb5acc9cfda)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
