### PR TITLE
[PWA-411] Updating quantity value when initialValue changes.

### DIFF
--- a/packages/peregrine/lib/talons/CartPage/ProductListing/__tests__/useQuantity.spec.js
+++ b/packages/peregrine/lib/talons/CartPage/ProductListing/__tests__/useQuantity.spec.js
@@ -194,3 +194,35 @@ test('maskInput callback masks input to minimum value', () => {
 
     expect(tree.root.findByProps({ id: 'target' }).props.maskInput(-1)).toBe(0);
 });
+
+test('quantity should update if initialValue prop changes', () => {
+    let formApi;
+
+    const tree = createTestInstance(
+        <Form
+            getApi={api => {
+                formApi = api;
+            }}
+        >
+            <Text field="quantity" />
+            <Component min={0} initialValue={0} />
+        </Form>
+    );
+
+    expect(formApi.getValue('quantity')).toBe(0);
+
+    act(() => {
+        tree.update(
+            <Form
+                getApi={api => {
+                    formApi = api;
+                }}
+            >
+                <Text field="quantity" />
+                <Component min={0} initialValue={5} />
+            </Form>
+        );
+    });
+
+    expect(formApi.getValue('quantity')).toBe(5);
+});

--- a/packages/peregrine/lib/talons/CartPage/ProductListing/useQuantity.js
+++ b/packages/peregrine/lib/talons/CartPage/ProductListing/useQuantity.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { useFieldState, useFieldApi } from 'informed';
 import debounce from 'lodash.debounce';
 
@@ -70,6 +70,13 @@ export const useQuantity = props => {
         },
         [min, prevQuantity]
     );
+
+    /**
+     * Everytime initialValue changes, update the quantity field state.
+     */
+    useEffect(() => {
+        quantityFieldApi.setValue(initialValue);
+    }, [initialValue, quantityFieldApi]);
 
     return {
         isDecrementDisabled,


### PR DESCRIPTION
## Description
The quantity stepper field in ProductListing retrieves its initial state from Apollo, but when that data is updated via other mutations on the page, the new value is not being synced with form state. This is because the `initialValue` is not used to update the internal value when initialValue changes.

Ideally, I wouldn't have called it `initialValue`, because truly initialValue should only be used while initializing the component but in this case, it changes every time. In this case, it actually is the quantity value on the product. Maybe we should consider calling it form value or something appropriate instead.

Let me know what you guys think.

## Related Issue
Closes [PWA-411](https://jira.corp.magento.com/browse/PWA-411)

### Verification Stakeholders
@jimbo 
@tjwiebell 

### Verification Steps
1. Add Configurable Product to cart and go to Cart Page.
2. Edit that item and adjust the quantity.
3. Quantity should be updated on the cart page as well.

## Checklist
None