### PR TITLE
fix(scaffolding): get base envVarDefinitions if targets don't exist yet

### DIFF
--- a/packages/pwa-buildpack/lib/BuildBus/intercept-base.js
+++ b/packages/pwa-buildpack/lib/BuildBus/intercept-base.js
@@ -1,7 +1,8 @@
-module.exports = targets => {
-    targets.own.envVarDefinitions.tap(defs => {
-        const { sections, changes } = require('../../envVarDefinitions.json');
-        defs.sections.push(...sections);
-        defs.changes.push(...changes);
-    });
-};
+/**
+ * Builtin targets are called manually from inside Buildpack code. Buildpack
+ * can't rely on interceptors for all its base functionality, because it still
+ * has to work in projects that don't have targets installed yet, such as newly
+ * scaffolded projects.
+ */
+
+module.exports = () => {};

--- a/packages/pwa-buildpack/lib/Utilities/__tests__/getEnvVarDefinitions.spec.js
+++ b/packages/pwa-buildpack/lib/Utilities/__tests__/getEnvVarDefinitions.spec.js
@@ -1,0 +1,33 @@
+jest.mock('../../BuildBus');
+const BuildBus = require('../../BuildBus');
+
+const baseEnvVarDefs = require('../../../envVarDefinitions.json');
+
+const getEnvVarDefinitions = require('../getEnvVarDefinitions');
+
+test('runs targets to get env var defs', () => {
+    BuildBus.for.mockImplementationOnce(() => new BuildBus());
+    BuildBus.prototype.getTargetsOf.mockImplementationOnce(() => ({
+        envVarDefinitions: {
+            call: defs => {
+                defs.sections.push({ name: 'testSection', variables: [] });
+            }
+        }
+    }));
+
+    const returnedDefs = getEnvVarDefinitions('./project-dir');
+    const returnedSections = returnedDefs.sections.map(s => s.name);
+    expect(returnedSections).toContain('testSection');
+    expect(returnedSections).toContain('Connecting to a Magento store');
+
+    expect(BuildBus.for).toHaveBeenCalledWith('./project-dir');
+});
+
+test('uses base defs if targets fail or are unavailable', () => {
+    BuildBus.for.mockImplementationOnce(() => {
+        throw new Error('@magento/pwa-buildpack has not been declaredA;');
+    });
+    expect(getEnvVarDefinitions('./other-project-dir')).toMatchObject(
+        baseEnvVarDefs
+    );
+});

--- a/packages/pwa-buildpack/lib/Utilities/__tests__/loadEnvironment.spec.js
+++ b/packages/pwa-buildpack/lib/Utilities/__tests__/loadEnvironment.spec.js
@@ -410,11 +410,6 @@ test('augments with interceptors of envVarDefinitions target', () => {
     ]);
     pertain.mockReturnValueOnce([
         {
-            name: '@magento/pwa-buildpack',
-            path: './intercept-base',
-            subject: 'pwa-studio.targets.intercept'
-        },
-        {
             name: '@magento/fake-test',
             path: './fake-intercept',
             subject: 'pwa-studio.targets.intercept'

--- a/packages/pwa-buildpack/lib/Utilities/getEnvVarDefinitions.js
+++ b/packages/pwa-buildpack/lib/Utilities/getEnvVarDefinitions.js
@@ -1,15 +1,30 @@
-const BuildBus = require('../BuildBus');
+const debug = require('debug')('pwa-buildpack:getEnvVarDefinitions');
 
 function getEnvVarDefinitions(context) {
-    const definitions = { sections: [], changes: [] };
-
-    if (process.env.DEBUG && process.env.DEBUG.includes('BuildBus')) {
-        BuildBus.enableTracking();
-    }
-    const bus = BuildBus.for(context);
-    bus.getTargetsOf('@magento/pwa-buildpack').envVarDefinitions.call(
-        definitions
+    // Fastest way to copy a pure-JSON object.
+    const definitions = JSON.parse(
+        JSON.stringify(require('../../envVarDefinitions.json'))
     );
+    try {
+        const BuildBus = require('../BuildBus');
+        /* istanbul ignore next */
+        if (process.env.DEBUG && process.env.DEBUG.includes('BuildBus')) {
+            BuildBus.enableTracking();
+        }
+        const bus = BuildBus.for(context);
+        bus.getTargetsOf('@magento/pwa-buildpack').envVarDefinitions.call(
+            definitions
+        );
+        debug(
+            'BuildBus for %s augmented env var definitions from buildpack.envVarDefinitions interceptors',
+            context
+        );
+    } catch (e) {
+        debug(
+            'BuildBus for %s errored calling buildpack.envVarDefinitions. Proceeding with base definitions',
+            context
+        );
+    }
     return definitions;
 }
 


### PR DESCRIPTION
## Description

Since #2137 the scaffolding generator has been broken, because:
- it runs `getEnvVarDefinitions()` before it can install the dependencies
- `getEnvVarDefinitions()` enables extensions to update the env var definitions, by calling the Buildpack `envVarDefinitions` target
- Because the dependencies aren't installed yet, this fails

### Changes
- Buildpack no longer uses its own `envVarDefinitions` target to push the base env var definitions in `targets/intercept-base.js`. Instead they are built in to the `getEnvVarDefinitions()` utility
- The `getEnvVarDefinitions()` utility tries to run a BuildBus and target, and returns the base definitions if that fails
- `targets/intercept-base.js` becomes a stub file, but it should remain there for future implementations and self-documentation
- Added test for `lib/Utilities/getEnvVarDefinitions.js`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #2364

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
@dpatil-magento 
@tjwiebell 
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Follow the full repro first for comparison:
1. Check out the master branch

2. In a sibling directory to your `pwa-studio` repository, run the following command:
    ```
    DEBUG_PROJECT_CREATION=true ./pwa-studio/packages/pwa-buildpack/bin/buildpack create-project scaffold-test-1 --template "venia-concept" --name "scaffold-test-1" --author "jzetlen <jzetlen@adobe.com>" --backend-url "https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/" --braintree-token "sandbox_8yrzsvtm_s2bg8fs563crhqzk" --npm-client "yarn"
    ```

3. Observe that this fails, emitting ` @magento/pwa-buildpack has not yet declared`.

4. `rm -rf scaffold-test-1-`

5. Check out this branch and run `yarn`, then repeat the above steps. It should work this time.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
