### PR TITLE
Strict SW catalog image checking.

### DIFF
--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
@@ -97,8 +97,8 @@ describe('Testing findSameOrLargerImage', () => {
     });
 
     test('Should not return response if URL for same filename is not available', async () => {
-        const fileName1 = 'fileName1';
-        const fileName2 = 'fileName2';
+        const fileName1 = 'prefixed-file-name.jpg';
+        const fileName2 = 'file-name.jpg';
 
         mockMatchFn.mockReturnValue(
             Promise.resolve({

--- a/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/__tests__/imageCacheHandler.spec.js
@@ -96,6 +96,25 @@ describe('Testing findSameOrLargerImage', () => {
         expect(returnedResponse.url).toBe(expectedUrl);
     });
 
+    test('Should not return response if URL for same filename is not available', async () => {
+        const fileName1 = 'fileName1';
+        const fileName2 = 'fileName2';
+
+        mockMatchFn.mockReturnValue(
+            Promise.resolve({
+                url: `https://develop.pwa-venia.com/media/catalog/v/s/${fileName1}?auto=webp&format=pjpg&width=1600&height=2000`
+            })
+        );
+
+        const returnedResponse = await findSameOrLargerImage(
+            new URL(
+                `https://develop.pwa-venia.com/media/catalog/v/s/${fileName2}?auto=webp&format=pjpg&width=1600&height=2000`
+            )
+        );
+
+        expect(returnedResponse).toBeUndefined();
+    });
+
     test('Should return the closest high resolution image response from cache for a given width', async () => {
         const requestedUrl =
             'https://develop.pwa-venia.com/media/catalog/v/s/vsk12-la_main_3.jpg?auto=webp&format=pjpg&width=800&height=1000';

--- a/packages/venia-concept/src/ServiceWorker/Utilities/imageCacheHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/imageCacheHandler.js
@@ -34,9 +34,11 @@ export const findSameOrLargerImage = async url => {
 
     const cache = await caches.open(CATALOG_CACHE_NAME);
     const cachedURLs = await cache.keys();
-    const cachedSources = await cachedURLs.filter(({ url }) =>
-        url.includes(requestedFilename)
-    );
+    const cachedSources = await cachedURLs.filter(({ url: urlPathname }) => {
+        const cachedFileName = urlPathname.split('/').reverse()[0];
+
+        return cachedFileName === requestedFilename;
+    });
 
     // Find the cached version of this image that is closest to the requested
     // width without going under it.

--- a/packages/venia-concept/src/ServiceWorker/Utilities/imageCacheHandler.js
+++ b/packages/venia-concept/src/ServiceWorker/Utilities/imageCacheHandler.js
@@ -34,8 +34,8 @@ export const findSameOrLargerImage = async url => {
 
     const cache = await caches.open(CATALOG_CACHE_NAME);
     const cachedURLs = await cache.keys();
-    const cachedSources = await cachedURLs.filter(({ url: urlPathname }) => {
-        const cachedFileName = urlPathname.split('/').reverse()[0];
+    const cachedSources = await cachedURLs.filter(({ url }) => {
+        const cachedFileName = new URL(url).pathname.split('/').reverse()[0];
 
         return cachedFileName === requestedFilename;
     });


### PR DESCRIPTION
## Description

@Jordaneisenburger has explained the issue at hand very well in the related issue.

It is a fairly simple fix. All we have to do is to compare the file names instead of checking for text includes.

I could not replicate the issue at hand because could not find URLs like mentioned in the issue. But, I have tested the SW cache handling and it works fine.

@Jordaneisenburger it would be great if you can validate the issue against this PR.

## Related Issue
Closes #2332 

### Verification Stakeholders
@jimbo 
@Jordaneisenburger 

### Verification Steps
1. In Admin UI Create Category1 with Product image 5xb40.png.
2. In Admin UI Create Category2 with Product image xb40.png
3. Run Venia pointing to above Backend.
4. Load Category1 and verify the image.
5. Load category2 and verify the image 
6. Also verify product image loads correctly on Product page, Home page , mini cart, cart

(I was able to reproduce the issue so updated steps)

## Checklist
None