### PR TITLE
[PWA-562] Checkout (auth): Stored Address Follow Up

### DIFF
--- a/packages/peregrine/lib/talons/CheckoutPage/AddressBook/useAddressCard.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/AddressBook/useAddressCard.js
@@ -22,7 +22,7 @@ export const useAddressCard = props => {
 
     const addressForEdit = useMemo(() => {
         const { country_code: countryCode, region, ...addressRest } = address;
-        const { region_code: regionCode } = region;
+        const { region_id: regionId } = region;
 
         return {
             ...addressRest,
@@ -30,7 +30,7 @@ export const useAddressCard = props => {
                 code: countryCode
             },
             region: {
-                code: regionCode
+                id: regionId
             }
         };
     }, [address]);

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/useCustomerForm.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/useCustomerForm.js
@@ -47,12 +47,12 @@ export const useCustomerForm = props => {
 
     const { country, region } = shippingData;
     const { code: countryCode } = country;
-    const { code: regionCode } = region;
+    const { id: regionId } = region;
 
     let initialValues = {
         ...shippingData,
         country: countryCode,
-        region: regionCode
+        region: regionId
     };
 
     const hasDefaultShipping =
@@ -79,9 +79,7 @@ export const useCustomerForm = props => {
                     country_code: country,
                     // Hard-coding region data until MC-33854/MC-33948 is resolved
                     region: {
-                        region: 'Alabama',
-                        region_id: 1,
-                        region_code: region
+                        region_id: region
                     }
                 };
 

--- a/packages/peregrine/lib/talons/Region/useRegion.js
+++ b/packages/peregrine/lib/talons/Region/useRegion.js
@@ -4,6 +4,7 @@ import { useFieldState } from 'informed';
 export const useRegion = props => {
     const {
         countryCodeField = 'country',
+        optionValueKey,
         queries: { getRegionsQuery }
     } = props;
 
@@ -22,7 +23,7 @@ export const useRegion = props => {
             formattedRegionsData = availableRegions.map(region => ({
                 key: region.id,
                 label: region.name,
-                value: region.code
+                value: region[optionValueKey]
             }));
             formattedRegionsData.unshift({
                 disabled: true,

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/AddressForm/customerForm.gql.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/AddressForm/customerForm.gql.js
@@ -23,10 +23,8 @@ export const UPDATE_CUSTOMER_ADDRESS_MUTATION = gql`
         updateCustomerAddress(id: $addressId, input: $address)
             @connection(key: "updateCustomerAddress") {
             id
-            ...CustomerAddressFragment
         }
     }
-    ${CustomerAddressFragment}
 `;
 
 export const GET_CUSTOMER_QUERY = gql`

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/AddressForm/customerForm.gql.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/AddressForm/customerForm.gql.js
@@ -15,6 +15,13 @@ export const CREATE_CUSTOMER_ADDRESS_MUTATION = gql`
     ${CustomerAddressFragment}
 `;
 
+/**
+ * We would normally use the CustomerAddressFragment here for the response
+ * but due to GraphQL returning null region data, we return minimal data and
+ * rely on refetching after performing this mutation to get accurate data.
+ *
+ * Fragment will be added back after MC-33948 is resolved.
+ */
 export const UPDATE_CUSTOMER_ADDRESS_MUTATION = gql`
     mutation UpdateCustomerAddress(
         $addressId: Int!

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/AddressForm/customerForm.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/AddressForm/customerForm.js
@@ -155,7 +155,7 @@ const CustomerForm = props => {
                 </Field>
             </div>
             <div className={classes.region}>
-                <Region validate={isRequired} />
+                <Region validate={isRequired} optionValueKey="id" />
             </div>
             <div className={classes.postcode}>
                 <Field id="postcode" label="ZIP / Postal Code">
@@ -184,7 +184,7 @@ CustomerForm.defaultProps = {
             code: 'US'
         },
         region: {
-            code: ''
+            id: null
         }
     }
 };
@@ -223,7 +223,7 @@ CustomerForm.propTypes = {
         lastname: string,
         postcode: string,
         region: shape({
-            code: string.isRequired
+            id: number
         }).isRequired,
         street: arrayOf(string),
         telephone: string

--- a/packages/venia-ui/lib/components/Region/region.js
+++ b/packages/venia-ui/lib/components/Region/region.js
@@ -10,18 +10,21 @@ import defaultClasses from './region.css';
 import { GET_REGIONS_QUERY } from './region.gql';
 
 const Region = props => {
-    const talonProps = useRegion({
-        queries: { getRegionsQuery: GET_REGIONS_QUERY }
-    });
-    const { regions } = talonProps;
     const {
         classes: propClasses,
         field,
         label,
         validate,
         initialValue,
+        optionValueKey,
         ...inputProps
     } = props;
+
+    const talonProps = useRegion({
+        optionValueKey,
+        queries: { getRegionsQuery: GET_REGIONS_QUERY }
+    });
+    const { regions } = talonProps;
 
     const classes = mergeClasses(defaultClasses, propClasses);
     const regionProps = {
@@ -49,7 +52,8 @@ export default Region;
 
 Region.defaultProps = {
     field: 'region',
-    label: 'State'
+    label: 'State',
+    optionValueKey: 'code'
 };
 
 Region.propTypes = {

--- a/packages/venia-ui/lib/components/Region/region.js
+++ b/packages/venia-ui/lib/components/Region/region.js
@@ -9,6 +9,11 @@ import TextInput from '../TextInput';
 import defaultClasses from './region.css';
 import { GET_REGIONS_QUERY } from './region.gql';
 
+/**
+ * Form component for Region that is seeded with backend data.
+ *
+ * @param {string} props.optionValueKey - Key to use for returned option values. In a future release, this will be removed and hard-coded to use "id" once GraphQL has resolved MC-30886.
+ */
 const Region = props => {
     const {
         classes: propClasses,
@@ -62,6 +67,7 @@ Region.propTypes = {
     }),
     field: string,
     label: string,
+    optionValueKey: string,
     validate: func,
     initialValue: string
 };


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

In PWA-245 we ran into an issue where address information could not be stored due to a graphql bug: https://jira.corp.magento.com/browse/MC-33854

This story is meant to address delivering a workaround so that we're not hard coding the region to 'AL' 

### Approach ###
In this solution, I made the Region component support any key from the response data to be the values of the dropdown. This allows:

1. Backwards Compatibility - all components previously using `code` will continue to function with no change.
2. Working Customer Address Mutations - a few GraphQL bugs were requiring that region.id is passed in mutations, even though mutations would succeed without any error indicating this. 

It appears that GraphQL is backtracking on the deprecation of region.id, so once that work has been completed, I anticipate that we will need to re-factor Region to always use `id` as the value. Since Cart addresses do not return `region.id`, it would be impossible to preemptively replace `code` with `id` across the code base.

### Alternative ###
Another solution would be to leave the existing usage of `code` in place, but before sending the mutation, performing a lookup that maps that code to the corresponding `id`. While this data should already be in the cache for zero network cost to lookup, I thought it would be bad to make that the default behavior. Happy to explore if the current solution doesn't seem like an ideal state until we can solely rely on `id` in the future.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-562](https://jira.corp.magento.com/browse/PWA-562)] 

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Login, add product, navigate to `/checkout`
2. Edit an existing address, change the State selection
3. Verify that state selection actually persists and is no longer hard-coded to Alabama

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated the documentation accordingly, if necessary.
* I have added tests to cover my changes, if necessary.
