### PR TITLE
PWA-609: Nudges css in the right direction on the checkout page

### DIFF
--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/summary.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/summary.css
@@ -51,14 +51,9 @@
     padding-right: 5px;
 }
 
-.edit_button {
-    text-align: right;
-}
-
 .edit_text {
     line-height: 1;
     padding-left: 0.5rem;
-    text-decoration: underline;
     vertical-align: top;
 }
 

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/summary.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/summary.css
@@ -1,13 +1,13 @@
 .root {
     display: grid;
     gap: 2rem;
-    padding: 2rem 1rem;
+    padding: 1.5rem 1rem;
 }
 
 .heading_container {
     display: grid;
     grid-auto-flow: column;
-    grid-template-columns: auto 5rem;
+    justify-content: space-between;
 }
 
 .heading {

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/summary.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/summary.css
@@ -7,7 +7,7 @@
 .heading_container {
     display: grid;
     grid-auto-flow: column;
-    justify-content: space-between;
+    grid-template-columns: 1fr;
 }
 
 .heading {

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/shippingInformation.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/shippingInformation.css
@@ -15,7 +15,7 @@
 .cardHeader {
     display: grid;
     grid-auto-flow: column;
-    justify-content: space-between;
+    grid-template-columns: 1fr;
 }
 
 .cardTitle {

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/shippingInformation.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/shippingInformation.css
@@ -34,7 +34,6 @@
 .editText {
     line-height: 1;
     padding-left: 0.5rem;
-    text-decoration: underline;
     vertical-align: top;
 }
 

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/__tests__/__snapshots__/completedView.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/__tests__/__snapshots__/completedView.spec.js.snap
@@ -16,38 +16,34 @@ exports[`it renders an error when selectedShippingMethod is missing 1`] = `
         Shipping Method
       </h5>
       <button
-        className="button"
+        className="editButton"
         onClick={false}
       >
-        <div
-          className="editButton"
+        <span
+          className="root"
         >
-          <span
-            className="root"
+          <svg
+            className="icon"
+            fill="none"
+            height={16}
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              className="icon"
-              fill="none"
-              height={18}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={18}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"
-              />
-            </svg>
-          </span>
-          <span
-            className="editButtonText"
-          >
-            Edit
-          </span>
-        </div>
+            <path
+              d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"
+            />
+          </svg>
+        </span>
+        <span
+          className="editButtonText"
+        >
+          Edit
+        </span>
       </button>
     </span>
     <span
@@ -75,38 +71,34 @@ exports[`it renders correctly 1`] = `
         Shipping Method
       </h5>
       <button
-        className="button"
+        className="editButton"
         onClick={false}
       >
-        <div
-          className="editButton"
+        <span
+          className="root"
         >
-          <span
-            className="root"
+          <svg
+            className="icon"
+            fill="none"
+            height={16}
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              className="icon"
-              fill="none"
-              height={18}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={18}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"
-              />
-            </svg>
-          </span>
-          <span
-            className="editButtonText"
-          >
-            Edit
-          </span>
-        </div>
+            <path
+              d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"
+            />
+          </svg>
+        </span>
+        <span
+          className="editButtonText"
+        >
+          Edit
+        </span>
       </button>
     </span>
     <div

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.css
@@ -39,7 +39,7 @@
 .titleContainer {
     display: grid;
     grid-auto-flow: column;
-    justify-content: space-between;
+    grid-template-columns: 1fr;
 }
 
 /*

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.css
@@ -23,8 +23,7 @@
 
 .editButton {
     display: grid;
-    grid-template-columns: auto auto;
-    column-gap: 0.5rem;
+    grid-template-columns: auto;
 }
 
 .editButtonText {

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.css
@@ -2,10 +2,6 @@
     height: 100%;
 }
 
-.button {
-    height: 100%;
-}
-
 .container {
     display: grid;
     grid-template-rows: auto 1fr;
@@ -21,13 +17,10 @@
     text-align: left;
 }
 
-.editButton {
-    display: grid;
-    grid-template-columns: auto;
-}
-
 .editButtonText {
-    text-decoration: underline;
+    line-height: 1;
+    padding-left: 0.5rem;
+    vertical-align: top;
 }
 
 .error {
@@ -44,9 +37,9 @@
 }
 
 .titleContainer {
-    display: flex;
+    display: grid;
+    grid-auto-flow: column;
     justify-content: space-between;
-    width: 100%;
 }
 
 /*

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.js
@@ -46,13 +46,12 @@ const CompletedView = props => {
             <div className={classes.container}>
                 <span className={classes.titleContainer}>
                     <h5 className={classes.heading}>Shipping Method</h5>
-                    <button className={classes.button} onClick={showUpdateMode}>
-                        <div className={classes.editButton}>
-                            <Icon size={16} src={EditIcon} />
-                            <span className={classes.editButtonText}>
-                                {'Edit'}
-                            </span>
-                        </div>
+                    <button
+                        className={classes.editButton}
+                        onClick={showUpdateMode}
+                    >
+                        <Icon size={16} src={EditIcon} />
+                        <span className={classes.editButtonText}>{'Edit'}</span>
                     </button>
                 </span>
                 {contents}

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/completedView.js
@@ -48,7 +48,7 @@ const CompletedView = props => {
                     <h5 className={classes.heading}>Shipping Method</h5>
                     <button className={classes.button} onClick={showUpdateMode}>
                         <div className={classes.editButton}>
-                            <Icon size={18} src={EditIcon} />
+                            <Icon size={16} src={EditIcon} />
                             <span className={classes.editButtonText}>
                                 {'Edit'}
                             </span>

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/shippingMethod.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/shippingMethod.css
@@ -2,12 +2,7 @@
     border: none;
     border-radius: 0px;
     border-bottom: 1px solid rgb(var(--venia-border));
-    min-height: 10rem;
     padding: 1.5rem 0rem;
-
-    display: grid;
-    grid-template-rows: auto 1fr;
-    row-gap: 1rem;
 }
 
 .done {
@@ -25,6 +20,7 @@
     display: grid;
     grid-template-rows: 1fr auto;
     row-gap: 1.5rem;
+    padding-top: 1rem;
 }
 
 .formButtons {


### PR DESCRIPTION
## Description
CSS on the checkout page wasn't aligned for the cards. Headers and padding/gaps needed some touchups.

https://jira.corp.magento.com/browse/PWA-609

**Before**

Mobile:
[![Image from Gyazo](https://i.gyazo.com/33c0fe4a7cd13370baf35f9cb1b86671.png)](https://gyazo.com/33c0fe4a7cd13370baf35f9cb1b86671)

Desktop:
[![Image from Gyazo](https://i.gyazo.com/bdecc95b1117addb44dd29b15483916f.png)](https://gyazo.com/bdecc95b1117addb44dd29b15483916f)

**After**

Mobile:
[![Image from Gyazo](https://i.gyazo.com/a3091c5ad5311546aec0a0204fc3bc16.png)](https://gyazo.com/a3091c5ad5311546aec0a0204fc3bc16)

Desktop:
[![Image from Gyazo](https://i.gyazo.com/8e772f81882d5d2a226b75f978cf9756.png)](https://gyazo.com/8e772f81882d5d2a226b75f978cf9756)