### PR TITLE
[Doc] Fix Modal/Portal reference docs

### DIFF
--- a/pwa-devdocs/scripts/create-reference-docs/config/venia.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/venia.js
@@ -24,7 +24,7 @@ module.exports = [
         type: 'function'
     },
     {
-        target: 'venia-ui/lib/components/Modal/modal.js',
+        target: 'venia-ui/lib/components/Portal/portal.js',
         type: 'function'
     },
     {

--- a/pwa-devdocs/src/_data/venia-api.yml
+++ b/pwa-devdocs/src/_data/venia-api.yml
@@ -13,8 +13,8 @@ entries:
     - label: Mask
       url: /venia-ui/reference/components/Mask/
 
-    - label: Modal
-      url: /venia-ui/reference/components/Modal/
+    - label: Portal
+      url: /venia-ui/reference/components/Portal/
 
     - label: ProductImageCarousel
       url: /venia-ui/reference/components/ProductImageCarousel/

--- a/pwa-devdocs/src/venia-ui/reference/components/Portal/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Portal/index.md
@@ -1,5 +1,5 @@
 ---
-title: Modal
+title: Portal
 ---
 
 <!--
@@ -7,4 +7,4 @@ The reference doc content is generated automatically from the source code.
 To update this section, update the doc blocks in the source code
 -->
 
-{% include auto-generated/venia-ui/lib/components/Modal/modal.md %}
+{% include auto-generated/venia-ui/lib/components/Portal/portal.md %}


### PR DESCRIPTION
## Description

This PR fixes the reference doc generation for the Modal component, which has been renamed to Portal.

## Related Issue

Closes PWA-641

## Acceptance 

any developer

### Verification Stakeholders

any developer

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps

1. Navigate to the `pwa-devdocs` directory: `cd pwa-devdocs`
1. Build the preview site `yarn develop`
1. Verify build succeeds without any errors
1. Use the top nav to navigate to the Venia UI API section
1. Verify Portal topic is listed on the left nav and points to the correct topic
1. Verify Modal topic is not listed on the left nav


## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
