### PR TITLE
[PWA-586] Country/Region Occasionally Resets initialValue

### DIFF
--- a/packages/peregrine/lib/talons/Region/__tests__/__snapshots__/useRegion.spec.js.snap
+++ b/packages/peregrine/lib/talons/Region/__tests__/__snapshots__/useRegion.spec.js.snap
@@ -2,12 +2,14 @@
 
 exports[`returns empty array if no available regions 1`] = `
 Object {
+  "loading": false,
   "regions": Array [],
 }
 `;
 
 exports[`returns formatted regions 1`] = `
 Object {
+  "loading": false,
   "regions": Array [
     Object {
       "disabled": true,
@@ -31,6 +33,7 @@ Object {
 
 exports[`returns formatted regions with id as the key 1`] = `
 Object {
+  "loading": false,
   "regions": Array [
     Object {
       "disabled": true,

--- a/packages/peregrine/lib/talons/Region/__tests__/useRegion.spec.js
+++ b/packages/peregrine/lib/talons/Region/__tests__/useRegion.spec.js
@@ -1,13 +1,18 @@
+import React from 'react';
+import { act } from 'react-test-renderer';
 import { useQuery } from '@apollo/react-hooks';
+import { useFieldApi, useFieldState } from 'informed';
 
+import createTestInstance from '../../../util/createTestInstance';
 import { useRegion } from '../useRegion';
 
 jest.mock('informed', () => {
     const useFieldState = jest.fn().mockReturnValue({
         value: 'US'
     });
+    const useFieldApi = jest.fn();
 
-    return { useFieldState };
+    return { useFieldApi, useFieldState };
 });
 
 jest.mock('@apollo/react-hooks', () => ({
@@ -25,17 +30,30 @@ jest.mock('@apollo/react-hooks', () => ({
     })
 }));
 
+const Component = props => {
+    const talonProps = useRegion(props);
+    return <i talonProps={talonProps} />;
+};
+
 const props = {
     queries: {}
 };
 
 test('returns formatted regions', () => {
-    const talonProps = useRegion(props);
+    const tree = createTestInstance(<Component {...props} />);
+    const { root } = tree;
+    const { talonProps } = root.findByType('i').props;
+
     expect(talonProps).toMatchSnapshot();
 });
 
 test('returns formatted regions with id as the key', () => {
-    const talonProps = useRegion({ ...props, optionValueKey: 'id' });
+    const tree = createTestInstance(
+        <Component {...props} optionValueKey={'id'} />
+    );
+    const { root } = tree;
+    const { talonProps } = root.findByType('i').props;
+
     expect(talonProps).toMatchSnapshot();
 });
 
@@ -50,6 +68,26 @@ test('returns empty array if no available regions', () => {
         loading: false
     });
 
-    const talonProps = useRegion(props);
+    const tree = createTestInstance(<Component {...props} />);
+    const { root } = tree;
+    const { talonProps } = root.findByType('i').props;
+
     expect(talonProps).toMatchSnapshot();
+});
+
+test('resets value on country change', () => {
+    const mockSetValue = jest.fn();
+
+    useFieldState.mockReturnValueOnce({ value: 'FR' });
+    useFieldApi.mockReturnValue({ setValue: mockSetValue });
+
+    const tree = createTestInstance(<Component {...props} />);
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+
+    act(() => {
+        tree.update(<Component {...props} />);
+    });
+
+    expect(mockSetValue).toHaveBeenCalledWith();
 });

--- a/packages/peregrine/lib/talons/Region/useRegion.js
+++ b/packages/peregrine/lib/talons/Region/useRegion.js
@@ -1,15 +1,31 @@
+import { useEffect, useRef } from 'react';
 import { useQuery } from '@apollo/react-hooks';
-import { useFieldState } from 'informed';
+import { useFieldApi, useFieldState } from 'informed';
 
 export const useRegion = props => {
     const {
         countryCodeField = 'country',
+        field = 'region',
         optionValueKey = 'code',
         queries: { getRegionsQuery }
     } = props;
 
+    const hasInitialized = useRef(false);
     const countryFieldState = useFieldState(countryCodeField);
     const { value: country } = countryFieldState;
+    const regionFieldApi = useFieldApi(field);
+
+    // Reset region value when country changes. Because of how Informed sets initialValues,
+    // we want to skip the first state change of the value being initialized.
+    useEffect(() => {
+        if (country) {
+            if (hasInitialized.current) {
+                regionFieldApi.setValue();
+            } else {
+                hasInitialized.current = true;
+            }
+        }
+    }, [country, regionFieldApi]);
 
     const { data, error, loading } = useQuery(getRegionsQuery, {
         variables: { countryCode: country }

--- a/packages/peregrine/lib/talons/Region/useRegion.js
+++ b/packages/peregrine/lib/talons/Region/useRegion.js
@@ -35,6 +35,7 @@ export const useRegion = props => {
     }
 
     return {
+        loading,
         regions: formattedRegionsData
     };
 };

--- a/packages/venia-ui/lib/components/Country/__tests__/__snapshots__/country.spec.js.snap
+++ b/packages/venia-ui/lib/components/Country/__tests__/__snapshots__/country.spec.js.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a disabled dropdown while loading 1`] = `
+<div
+  className="root"
+>
+  <label
+    className="label"
+    htmlFor="country"
+  >
+    Country
+  </label>
+  <span
+    className="root"
+    style={
+      Object {
+        "--iconsAfter": 1,
+        "--iconsBefore": 0,
+      }
+    }
+  >
+    <span
+      className="input"
+    >
+      <select
+        className="input"
+        disabled={true}
+        name="country"
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="US"
+      />
+    </span>
+    <span
+      className="before"
+    />
+    <span
+      className="after"
+    >
+      <span
+        className="root"
+      >
+        <svg
+          className="icon"
+          fill="none"
+          height={18}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={18}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="6 9 12 15 18 9"
+          />
+        </svg>
+      </span>
+    </span>
+  </span>
+  <p
+    className="root"
+  />
+</div>
+`;
+
+exports[`renders dropdown with country data 1`] = `
+<div
+  className="root"
+>
+  <label
+    className="label"
+    htmlFor="country"
+  >
+    Country
+  </label>
+  <span
+    className="root"
+    style={
+      Object {
+        "--iconsAfter": 1,
+        "--iconsBefore": 0,
+      }
+    }
+  >
+    <span
+      className="input"
+    >
+      <select
+        className="input"
+        disabled={false}
+        name="country"
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="US"
+      >
+        <option
+          disabled={null}
+          hidden={null}
+          value="US"
+        >
+          United State
+        </option>
+        <option
+          disabled={null}
+          hidden={null}
+          value="FR"
+        >
+          France
+        </option>
+      </select>
+    </span>
+    <span
+      className="before"
+    />
+    <span
+      className="after"
+    >
+      <span
+        className="root"
+      >
+        <svg
+          className="icon"
+          fill="none"
+          height={18}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={18}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="6 9 12 15 18 9"
+          />
+        </svg>
+      </span>
+    </span>
+  </span>
+  <p
+    className="root"
+  />
+</div>
+`;

--- a/packages/venia-ui/lib/components/Country/__tests__/country.spec.js
+++ b/packages/venia-ui/lib/components/Country/__tests__/country.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+import { useCountry } from '@magento/peregrine/lib/talons/Country/useCountry';
+
+import Country from '../country';
+
+jest.mock('@magento/peregrine/lib/talons/Country/useCountry');
+jest.mock('../../../classify');
+
+const mockProps = {
+    field: 'country',
+    initialValue: 'US',
+    label: 'Country',
+    validate: jest.fn()
+};
+
+test('renders a disabled dropdown while loading', () => {
+    useCountry.mockReturnValueOnce({
+        countries: [],
+        loading: true
+    });
+
+    const tree = createTestInstance(<Country {...mockProps} />);
+
+    expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('renders dropdown with country data', () => {
+    useCountry.mockReturnValueOnce({
+        countries: [
+            { label: 'United State', value: 'US' },
+            { label: 'France', value: 'FR' }
+        ],
+        loading: false
+    });
+
+    const tree = createTestInstance(<Country {...mockProps} />);
+
+    expect(tree.toJSON()).toMatchSnapshot();
+});

--- a/packages/venia-ui/lib/components/Country/country.js
+++ b/packages/venia-ui/lib/components/Country/country.js
@@ -15,14 +15,7 @@ const Country = props => {
         }
     });
     const { countries, loading } = talonProps;
-    const {
-        classes: propClasses,
-        field,
-        label,
-        validate,
-        initialValue,
-        ...inputProps
-    } = props;
+    const { classes: propClasses, field, label, ...inputProps } = props;
 
     const classes = mergeClasses(defaultClasses, propClasses);
     const selectProps = {
@@ -30,8 +23,6 @@ const Country = props => {
         disabled: loading,
         field,
         items: countries,
-        validate,
-        initialValue,
         ...inputProps
     };
 

--- a/packages/venia-ui/lib/components/Region/__tests__/__snapshots__/region.spec.js.snap
+++ b/packages/venia-ui/lib/components/Region/__tests__/__snapshots__/region.spec.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders disabled input while loading 1`] = `
+<div
+  className="root"
+>
+  <label
+    className="label"
+    htmlFor="region"
+  >
+    State
+  </label>
+  <span
+    className="root"
+    style={
+      Object {
+        "--iconsAfter": 0,
+        "--iconsBefore": 0,
+      }
+    }
+  >
+    <span
+      className="input"
+    >
+      <input
+        className="input"
+        disabled={true}
+        name="region"
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="TX"
+      />
+    </span>
+    <span
+      className="before"
+    />
+    <span
+      className="after"
+    />
+  </span>
+  <p
+    className="root"
+  />
+</div>
+`;
+
+exports[`renders dropdown with regions 1`] = `
+<div
+  className="root"
+>
+  <label
+    className="label"
+    htmlFor="region"
+  >
+    State
+  </label>
+  <span
+    className="root"
+    style={
+      Object {
+        "--iconsAfter": 1,
+        "--iconsBefore": 0,
+      }
+    }
+  >
+    <span
+      className="input"
+    >
+      <select
+        className="input"
+        disabled={false}
+        name="region"
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="TX"
+      >
+        <option
+          disabled={null}
+          hidden={null}
+          value="TX"
+        >
+          Texas
+        </option>
+        <option
+          disabled={null}
+          hidden={null}
+          value="NM"
+        >
+          New Mexico
+        </option>
+      </select>
+    </span>
+    <span
+      className="before"
+    />
+    <span
+      className="after"
+    >
+      <span
+        className="root"
+      >
+        <svg
+          className="icon"
+          fill="none"
+          height={18}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={18}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="6 9 12 15 18 9"
+          />
+        </svg>
+      </span>
+    </span>
+  </span>
+  <p
+    className="root"
+  />
+</div>
+`;
+
+exports[`renders input with no regions 1`] = `
+<div
+  className="root"
+>
+  <label
+    className="label"
+    htmlFor="region"
+  >
+    State
+  </label>
+  <span
+    className="root"
+    style={
+      Object {
+        "--iconsAfter": 0,
+        "--iconsBefore": 0,
+      }
+    }
+  >
+    <span
+      className="input"
+    >
+      <input
+        className="input"
+        disabled={false}
+        name="region"
+        onBlur={[Function]}
+        onChange={[Function]}
+        value="TX"
+      />
+    </span>
+    <span
+      className="before"
+    />
+    <span
+      className="after"
+    />
+  </span>
+  <p
+    className="root"
+  />
+</div>
+`;

--- a/packages/venia-ui/lib/components/Region/__tests__/region.spec.js
+++ b/packages/venia-ui/lib/components/Region/__tests__/region.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+import { useRegion } from '@magento/peregrine/lib/talons/Region/useRegion';
+
+import Region from '../region';
+
+jest.mock('@magento/peregrine/lib/talons/Region/useRegion');
+jest.mock('../../../classify');
+
+const mockProps = {
+    initialValue: 'TX',
+    validate: jest.fn()
+};
+
+test('renders disabled input while loading', () => {
+    useRegion.mockReturnValueOnce({
+        loading: true,
+        regions: []
+    });
+
+    const tree = createTestInstance(<Region {...mockProps} />);
+
+    expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('renders input with no regions', () => {
+    useRegion.mockReturnValueOnce({
+        loading: false,
+        regions: []
+    });
+
+    const tree = createTestInstance(<Region {...mockProps} />);
+
+    expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('renders dropdown with regions', () => {
+    useRegion.mockReturnValueOnce({
+        loading: false,
+        regions: [
+            { label: 'Texas', value: 'TX' },
+            { label: 'New Mexico', value: 'NM' }
+        ]
+    });
+
+    const tree = createTestInstance(<Region {...mockProps} />);
+
+    expect(tree.toJSON()).toMatchSnapshot();
+});

--- a/packages/venia-ui/lib/components/Region/region.js
+++ b/packages/venia-ui/lib/components/Region/region.js
@@ -24,6 +24,7 @@ const Region = props => {
     } = props;
 
     const talonProps = useRegion({
+        field,
         optionValueKey,
         queries: { getRegionsQuery: GET_REGIONS_QUERY }
     });

--- a/packages/venia-ui/lib/components/Region/region.js
+++ b/packages/venia-ui/lib/components/Region/region.js
@@ -19,8 +19,6 @@ const Region = props => {
         classes: propClasses,
         field,
         label,
-        validate,
-        initialValue,
         optionValueKey,
         ...inputProps
     } = props;
@@ -29,14 +27,14 @@ const Region = props => {
         optionValueKey,
         queries: { getRegionsQuery: GET_REGIONS_QUERY }
     });
-    const { regions } = talonProps;
+    const { loading, regions } = talonProps;
 
     const classes = mergeClasses(defaultClasses, propClasses);
     const regionProps = {
-        field,
-        validate,
-        initialValue,
         classes,
+        disabled: loading,
+        field,
+        keepState: true,
         ...inputProps
     };
 


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

There's an empty cache state for these components where the form they are attached to renders before the backend results for the list of available options in these dropdown components is returned. When that backend response arrives, the components re-render with those options, but the initialValue from the parent context doesn't apply, and the component renders an empty selection. I've more commonly seen this in the Region component, where State will be cleared out after an initial flash of the component.

Once this component has loaded once in the app, it's not reproducible, since the components first render now uses that immediate cached response.

Repro:

1. Add Simple item to cart and go to `/cart`
2. Open Estimate Shipping section and submit an estimate (State = TX)
3. Open Dev Tools > Local Storage > Delete `apollo-cache-persist` entry
4. Refresh the page and open Estimate Shipping section

Expected: State data entered is selected in dropdown
Actual: State is empty

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-586](https://jira.corp.magento.com/browse/PWA-586)] Country/Region Occasionally Resets initialValue

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
⬆️  Repro steps can be used for verification above ⬆️ 

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [x] I have updated/added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
