### PR TITLE
feat(targets): Add target for editing UPWARD definitions (DRAFT)

### DIFF
--- a/packages/pwa-buildpack/lib/BuildBus/declare-base.js
+++ b/packages/pwa-buildpack/lib/BuildBus/declare-base.js
@@ -138,7 +138,47 @@ module.exports = targets => {
          * @param {Object<(string, boolean)>} featureFlags
          * @memberof BuiltinTargets
          */
-        specialFeatures: new targets.types.Sync(['special'])
+        specialFeatures: new targets.types.Sync(['special']),
+
+        /**
+         * @callback transformUpwardIntercept
+         * @param {object} Parsed UPWARD definition object.
+         * @returns {Promise} - Interceptors do not need to return.
+         */
+
+        /**
+         * Exposes the fully merged UPWARD definition for fine tuning. The
+         * UpwardIncludePlugin does a simple shallow merge of the upward.yml
+         * files in every package which sets the `upward: true` flag in the
+         * `specialFeatures` object. After that is complete,
+         * UpwardIncludePlugin calls this target with the parsed and merged
+         * definition.
+         *
+         * @example <caption>Send empty responses in maintenance mode.</caption>
+         * targets.of('@magento/pwa-buildpack').transformUpward.tap(def => {
+         *   const guardMaintenanceMode = (prop, inline) => {
+         *     def[prop] = {
+         *       when: [
+         *         {
+         *           matches: 'env.MAINTENANCE_MODE',
+         *           pattern: '.',
+         *           use: { inline }
+         *         }
+         *       ],
+         *       default: def[prop]
+         *     }
+         *   }
+         *
+         *   guardMaintenanceMode('status', 503);
+         *   guardMaintenanceMode('body', '')
+         * })
+         *
+         *
+         * @type {tapable.AsyncSeriesHook}
+         * @param {transformUpwardIntercept} interceptor
+         * @memberof BuiltinTargets
+         */
+        transformUpward: new targets.types.AsyncSeries(['definitions'])
     };
 
     /**

--- a/packages/pwa-buildpack/lib/WebpackTools/configureWebpack/getClientConfig.js
+++ b/packages/pwa-buildpack/lib/WebpackTools/configureWebpack/getClientConfig.js
@@ -33,7 +33,8 @@ async function getClientConfig(opts) {
         vendor,
         projectConfig,
         stats,
-        resolver
+        resolver,
+        bus
     } = opts;
 
     let vendorTest = '[\\/]node_modules[\\/]';
@@ -82,6 +83,7 @@ async function getClientConfig(opts) {
             }),
             new webpack.EnvironmentPlugin(projectConfig.env),
             new UpwardIncludePlugin({
+                bus,
                 upwardDirs: [...hasFlag('upward'), context]
             }),
             new WebpackAssetsManifest({

--- a/packages/pwa-buildpack/lib/WebpackTools/plugins/UpwardIncludePlugin.js
+++ b/packages/pwa-buildpack/lib/WebpackTools/plugins/UpwardIncludePlugin.js
@@ -10,7 +10,8 @@ const jsYaml = require('js-yaml');
  * autodetects file assets relied on by those configurations
  */
 class UpwardIncludePlugin {
-    constructor({ upwardDirs }) {
+    constructor({ bus, upwardDirs }) {
+        this.bus = bus;
         this.upwardDirs = upwardDirs;
         this.definition = {};
         debug('created with dirs: %s', upwardDirs);
@@ -33,7 +34,12 @@ class UpwardIncludePlugin {
                 context,
                 from: './upward.yml',
                 to: './upward.yml',
-                transform: () => jsYaml.safeDump(this.definition)
+                transform: async () => {
+                    await this.bus
+                        .getTargetsOf('@magento/pwa-buildpack')
+                        .transformUpward.promise(this.definition);
+                    return jsYaml.safeDump(this.definition);
+                }
             }
         };
         this.dirs = new Set([...this.upwardDirs, context]);


### PR DESCRIPTION
## Description

- Add a builtin Target (i.e. a target declared by Buildpack) for convenient access to UPWARD logic at build time.

Currently, UPWARD is extensible via a very simple "shallow merge" behavior. In Webpack config, in the `special` flags, you can set `upward: true` for a package (e.g. `@magento/venia-ui`) to make Buildpack find an `upward.yml` in that package and merge it into the final UPWARD definition for the project.

This doesn't permit more sophisticated UPWARD transformations, which could get real real interesting.

It's possible to use low-level Webpack access to find and modify the UPWARD definition, but it's both inefficient and verbose. [Here is an example](https://github.com/magento-research/pwa-studio-target-experiments/blob/master/packages/upward-csp/intercept-upward-file.js) of such an implementation.

With the `transformUpward` Target implemented in this PR, we can do the same thing as the file above, but [much prettier](https://github.com/magento-research/pwa-studio-target-experiments/blob/master/packages/upward-csp/intercept-upward-target.js):

```js
const DEF_NAME = 'pwaExperimentContentSecurityPolicy';

module.exports = targets => {
    const builtins = targets.of('@magento/pwa-buildpack');

    builtins.specialFeatures.tap(features => {
        features[targets.name] = { upward: true };
    });

    builtins.transformUpward.tapPromise(async defs => {
        if (!defs[DEF_NAME]) {
            throw new Error(
                `${
                    targets.name
                } could not find its own definition in the emitted upward.yml`
            );
        }

        definitions.veniaAppShell.inline.headers.inline[
            'Content-Security-Policy'
        ] = DEF_NAME;
    });
};
```

## Related Issue
None. Do not merge yet: leave this PR in draft as an example of a PR to support a desired target.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
Community!

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Clone the https://github.com/magento-research/pwa-studio-target-experiments/ repository in a sibling directory to this branch.
1. In that repository root, run `yarn` and then `yarn studiolink </path/to/pwa-studio-branch>`
1. In that repo root, edit `packages/upward-csp/package.json` and change `"intercept": "./intercept-upward-file"` to `"intercept": "./intercept-upward-target"`.
1. In your PWA Studio repo run: `BUILDBUS_DEPS_ADDITIONAL=@magento-research/pwa-upward-csp yarn run build && yarn run stage:venia`
1. Inspect the response headers for HTML documents in the staging server. Confirm that the CSP is there!