### PR TITLE
refactor(targets): Organize CSS for targeting and add PostCSS transform

### DIFF
--- a/packages/peregrine/lib/targets/peregrine-intercept.js
+++ b/packages/peregrine/lib/targets/peregrine-intercept.js
@@ -13,7 +13,10 @@ function TalonWrapperConfig(addTransforms) {
         wrapWith: wrapperModule =>
             addTransforms({
                 type: 'source',
-                fileToTransform: path.join('./lib/talons/', talonFile),
+                fileToTransform: path.join(
+                    '@magento/peregrine/lib/talons/',
+                    talonFile
+                ),
                 transformModule:
                     '@magento/pwa-buildpack/lib/WebpackTools/loaders/wrap-esm-loader',
                 options: {

--- a/packages/pwa-buildpack/lib/WebpackTools/ModuleTransformConfig.js
+++ b/packages/pwa-buildpack/lib/WebpackTools/ModuleTransformConfig.js
@@ -126,6 +126,7 @@ class ModuleTransformConfig {
     async toLoaderOptions() {
         const byType = {
             babel: {},
+            postcss: {},
             source: {}
         };
         // Some reqs may still be outstanding!

--- a/packages/pwa-buildpack/package.json
+++ b/packages/pwa-buildpack/package.json
@@ -81,6 +81,8 @@
   "peerDependencies": {
     "babel-loader": "~8.0.5",
     "css-loader": "~2.1.1",
+    "postcss": "~7.0.26",
+    "postcss-loader": "~3.0.0",
     "terser-webpack-plugin": "~1.2.3",
     "webpack": "~4.38.0",
     "workbox-webpack-plugin": "5.1.3"

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -24,6 +24,8 @@
     "prettier:fix": "yarn run -s prettier -- --write",
     "start": "node server.js",
     "start:debug": "node --inspect-brk ./node_modules/.bin/webpack-dev-server --progress --color --env.mode development",
+    "storybook": "echo 'Venia component stories have moved to @magento/venia-ui. Trying to run in sibling directory...' && (cd ../venia-ui && yarn run storybook:build)",
+    "storybook:build": "yarn run storybook",
     "test": "yarn run -s prettier:check && yarn run -s lint && jest",
     "validate-queries": "yarn run download-schema && graphql validate-magento-pwa-queries --project venia",
     "watch": "webpack-dev-server --progress --color --env.mode development"
@@ -94,6 +96,8 @@
     "lodash.over": "~4.7.0",
     "memoize-one": "~5.0.0",
     "memory-fs": "~0.4.1",
+    "postcss": "~7.0.26",
+    "postcss-loader": "~3.0.0",
     "prettier": "~1.16.4",
     "prop-types": "~15.7.2",
     "react": "~16.9.0",

--- a/packages/venia-concept/src/index.css
+++ b/packages/venia-concept/src/index.css
@@ -8,7 +8,7 @@
     --venia-anim-out: cubic-bezier(0.4, 0, 1, 1);
     --venia-anim-standard: cubic-bezier(0.4, 0, 0.2, 1);
     --venia-background-color: 255, 255, 255;
-    --venia-border: 224, 224, 224;
+    --venia-foreground-color: 33, 33, 33;
     --venia-error: 192, 18, 63;
     --venia-error-alt: 255, 226, 234;
     --venia-font: Muli, -apple-system, BlinkMacSystemFont, sans-serif;
@@ -20,7 +20,10 @@
     --venia-teal-alt: 224, 240, 241;
     --venia-teal-dark: 0, 104, 108;
     --venia-teal-light: 212, 243, 238;
-    --venia-text: 33, 33, 33;
+    --venia-border: var(--venia-grey);
+    --venia-border-alt: var(--venia-grey-dark);
+    --venia-disabled: var(--venia-grey-dark);
+    --venia-text: var(--venia-foreground-color);
     --venia-text-alt: var(--venia-grey-darker);
     --venia-text-hint: 158, 158, 158;
     --venia-text-spot: 255, 99, 51;
@@ -29,7 +32,7 @@
 }
 
 html {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     font-size: 100%;
     font-weight: 400;
     line-height: 1;
@@ -38,7 +41,7 @@ html {
 }
 
 body {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     color: rgb(var(--venia-text));
     margin: 0;
     padding: 0;
@@ -102,6 +105,7 @@ dt {
 
 button {
     background: none;
+    color: rgb(var(--venia-foreground-color));
     border: 0;
     cursor: pointer;
     font-family: var(--venia-font);

--- a/packages/venia-ui/lib/RootComponents/Category/category.css
+++ b/packages/venia-ui/lib/RootComponents/Category/category.css
@@ -27,9 +27,9 @@
     margin-left: 0.5rem;
     display: inline-block;
     padding: 0.75rem 2rem;
-    border: 1px solid black;
+    border: 1px solid rgb(var(--venia-foreground-color));
     border-radius: 3px;
-    color: black;
+    color: rgb(var(--venia-foreground-color));
     outline: none;
 }
 

--- a/packages/venia-ui/lib/components/AuthBar/authBar.css
+++ b/packages/venia-ui/lib/components/AuthBar/authBar.css
@@ -1,6 +1,6 @@
 .root {
     align-items: center;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     display: grid;
     gap: 0.75rem;
     grid-auto-flow: column;

--- a/packages/venia-ui/lib/components/Button/button.css
+++ b/packages/venia-ui/lib/components/Button/button.css
@@ -17,7 +17,7 @@
 
 .filled {
     background-color: rgb(var(--color));
-    color: white;
+    color: rgb(var(--venia-background-color));
 }
 
 .root:hover {
@@ -39,7 +39,7 @@
 
 .root:disabled {
     pointer-events: none;
-    --color: var(--venia-grey-dark);
+    --color: var(--venia-disabled);
 }
 
 .content {

--- a/packages/venia-ui/lib/components/ButtonGroup/button.css
+++ b/packages/venia-ui/lib/components/ButtonGroup/button.css
@@ -1,7 +1,7 @@
 .root {
     composes: root from '../clickable.css';
-    background: none white;
-    border: 1px solid rgb(var(--venia-grey-dark));
+    background: none rgb(var(--venia-background-color));
+    border: 1px solid rgb(var(--venia-border-alt));
     color: rgb(var(--venia-text));
     font-size: 0.75rem;
     font-weight: 600;
@@ -30,8 +30,8 @@
 }
 
 .root:disabled {
-    border-color: rgb(var(--venia-grey-dark));
-    color: rgb(var(--venia-grey-dark));
+    border-color: rgb(var(--venia-disabled));
+    color: rgb(var(--venia-grey-disabled));
 }
 
 .root:nth-of-type(1) {

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/editModal.css
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/editModal.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     bottom: 0;
     display: grid;
     grid-template-rows: auto 1fr;

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/quantity.css
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/quantity.css
@@ -25,8 +25,8 @@
 
 .button {
     align-items: center;
-    background-color: white;
-    border: 1px solid rgb(var(--venia-grey-darker));
+    background-color: rgb(var(--venia-background-color));
+    border: 1px solid rgb(var(--venia-text-alt));
     border-radius: 50%;
     display: inline-flex;
     height: 2.25rem;
@@ -35,8 +35,8 @@
 }
 
 .button:disabled {
-    border-color: rgb(var(--venia-grey-darker)) !important;
-    background-color: #d0d0d0 !important;
+    border-color: rgb(var(--venia-text-alt)) !important;
+    background-color: rgb(var(--venia-disabled)) !important;
     opacity: 0.5;
     cursor: not-allowed;
 }

--- a/packages/venia-ui/lib/components/CategoryTree/categoryLeaf.css
+++ b/packages/venia-ui/lib/components/CategoryTree/categoryLeaf.css
@@ -21,4 +21,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: rgb(var(--venia-foreground-color));
 }

--- a/packages/venia-ui/lib/components/Checkout/Receipt/receipt.css
+++ b/packages/venia-ui/lib/components/Checkout/Receipt/receipt.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     display: grid;
     grid-template-rows: 1fr auto;
     height: 100vh;
@@ -29,7 +29,7 @@
 }
 
 .orderId {
-    color: #22a1a8;
+    color: rgb(var(--venia-teal-dark));
     text-decoration: underline;
 }
 

--- a/packages/venia-ui/lib/components/Checkout/addressForm.css
+++ b/packages/venia-ui/lib/components/Checkout/addressForm.css
@@ -15,7 +15,7 @@
 
 /* fields */
 .textInput {
-    background: white;
+    background: rgb(var(--venia-background-color));
     border: 1px solid rgb(var(--venia-text-alt));
     border-radius: 2px;
     color: rgb(var(--venia-text));

--- a/packages/venia-ui/lib/components/Checkout/checkoutButton.css
+++ b/packages/venia-ui/lib/components/Checkout/checkoutButton.css
@@ -1,4 +1,4 @@
 .icon {
     composes: root from '../Icon/icon.css';
-    --stroke: white;
+    --stroke: rgb(var(--venia-background-color));
 }

--- a/packages/venia-ui/lib/components/Checkout/flow.css
+++ b/packages/venia-ui/lib/components/Checkout/flow.css
@@ -3,7 +3,7 @@
 }
 
 .heading {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     font-size: 0.875rem;
     font-weight: 600;
     grid-column-end: span 2;
@@ -20,7 +20,7 @@
     animation-duration: 224ms;
     animation-iteration-count: 1;
     animation-name: enter;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     bottom: 5rem;
     box-shadow: 0 -1px rgb(var(--venia-border));
     display: grid;
@@ -35,7 +35,7 @@
 
 .footer {
     align-items: center;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     display: grid;
     grid-auto-columns: min-content;
     grid-auto-flow: column;

--- a/packages/venia-ui/lib/components/Checkout/form.css
+++ b/packages/venia-ui/lib/components/Checkout/form.css
@@ -18,7 +18,7 @@
 
 .disabledPrompt {
     composes: informationPrompt;
-    color: rgb(var(--venia-grey-dark));
+    color: rgb(var(--venia-disabled));
 }
 
 .paymentDisplayPrimary {

--- a/packages/venia-ui/lib/components/Checkout/paymentsForm.css
+++ b/packages/venia-ui/lib/components/Checkout/paymentsForm.css
@@ -15,7 +15,7 @@
 }
 
 .textInput {
-    background: white;
+    background: rgb(var(--venia-background-color));
     border: 1px solid rgb(var(--venia-text-alt));
     border-radius: 2px;
     color: rgb(var(--venia-text));

--- a/packages/venia-ui/lib/components/Checkout/section.css
+++ b/packages/venia-ui/lib/components/Checkout/section.css
@@ -1,7 +1,7 @@
 .root {
     display: block;
     width: 100%;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     border: none;
 }
 .root:focus {

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/editModal.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/editModal.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     display: grid;
     left: calc(50% - 370px);
     grid-template-rows: auto 1fr;

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/editModal.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingInformation/editModal.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     display: grid;
     left: calc(50% - 370px);
     grid-template-rows: auto 1fr;

--- a/packages/venia-ui/lib/components/Field/field.css
+++ b/packages/venia-ui/lib/components/Field/field.css
@@ -14,7 +14,7 @@
 }
 
 .input {
-    background: white;
+    background: rgb(var(--venia-background-color));
     border: 1px solid rgb(var(--venia-text-alt));
     border-radius: 2px;
     color: rgb(var(--venia-text));
@@ -37,7 +37,7 @@
 }
 
 .requiredSymbol {
-    background-color: black;
+    background-color: var(--venia-text);
     width: 0.4rem;
     height: 0.4rem;
     border-radius: 50%;

--- a/packages/venia-ui/lib/components/FilterModal/filterFooter.css
+++ b/packages/venia-ui/lib/components/FilterModal/filterFooter.css
@@ -1,6 +1,6 @@
 .root {
     align-items: center;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     display: grid;
     gap: 0.75rem;
     grid-auto-columns: min-content;

--- a/packages/venia-ui/lib/components/FilterModal/filterModal.css
+++ b/packages/venia-ui/lib/components/FilterModal/filterModal.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     bottom: 0;
     display: grid;
     grid-template-rows: 1fr 5rem;

--- a/packages/venia-ui/lib/components/Footer/footer.css
+++ b/packages/venia-ui/lib/components/Footer/footer.css
@@ -1,7 +1,7 @@
 .root {
     background-color: rgb(var(--venia-grey));
     border-top: 1px solid rgb(var(--venia-border));
-    color: black;
+    color: rgb(var(--venia-foreground-color));
     margin-top: 1rem;
     padding: 0 1rem;
 }

--- a/packages/venia-ui/lib/components/Header/header.css
+++ b/packages/venia-ui/lib/components/Header/header.css
@@ -75,7 +75,7 @@
 }
 
 .loader {
-    color: rgb(var(--venia-grey-dark));
+    color: rgb(var(--venia-disabled));
     font-size: var(--dot-font-size);
     margin: var(--dot-shadow-offset) auto 0;
     position: relative;

--- a/packages/venia-ui/lib/components/Mask/mask.css
+++ b/packages/venia-ui/lib/components/Mask/mask.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: black;
+    background-color: rgb(var(--venia-foreground-color));
     cursor: pointer;
     display: block;
     height: 100%;

--- a/packages/venia-ui/lib/components/MiniCart/emptyMiniCartBody.css
+++ b/packages/venia-ui/lib/components/MiniCart/emptyMiniCartBody.css
@@ -15,11 +15,11 @@
 
 .continue {
     composes: root from '../Button/button.css';
-    color: white;
+    color: rgb(var(--venia-background-color));
     background-color: rgb(var(--color));
 }
 
 .continue:hover {
-    color: white;
+    color: rgb(var(--venia-background-color));
     background-color: rgb(var(--venia-teal));
 }

--- a/packages/venia-ui/lib/components/MiniCart/footer.css
+++ b/packages/venia-ui/lib/components/MiniCart/footer.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     padding: 0;
 }
 

--- a/packages/venia-ui/lib/components/MiniCart/kebab.css
+++ b/packages/venia-ui/lib/components/MiniCart/kebab.css
@@ -10,7 +10,7 @@
 
 .dropdown {
     align-items: center;
-    box-shadow: 0 0 1px rgb(0, 0, 0, 0.2);
+    box-shadow: 0 0 1px rgb(var(--venia-foreground-color), 0.2);
     display: grid;
     position: absolute;
     right: 20px;
@@ -31,16 +31,16 @@
 .dropdown li {
     display: block;
     width: 100%;
-    background-color: #fff;
+    background-color: rgb(var(--venia-background-color));
     border-bottom: 1px solid rgb(var(--venia-border));
 }
 
 .dropdown li:hover {
-    background-color: #eee;
+    background-color: rgb(var(--venia-grey));
 }
 
 .kebab {
     outline: 0;
     border: none;
-    background-color: #fff;
+    background-color: rgb(var(--venia-background-color));
 }

--- a/packages/venia-ui/lib/components/MiniCart/miniCart.css
+++ b/packages/venia-ui/lib/components/MiniCart/miniCart.css
@@ -2,7 +2,7 @@
     --base-z-index: 4;
     --minicart-header-height: 3.5rem;
     align-content: start;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     bottom: 0;
     box-shadow: -1px 0 rgb(var(--venia-border));
     display: grid;

--- a/packages/venia-ui/lib/components/Navigation/navigation.css
+++ b/packages/venia-ui/lib/components/Navigation/navigation.css
@@ -24,7 +24,7 @@
 
 .root {
     composes: exit hidden;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     bottom: 0;
     display: grid;
     grid-template-rows: auto 1fr auto;
@@ -76,7 +76,7 @@
 
 .modal {
     composes: exit hidden;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     bottom: 0;
     left: 0;
     overflow: auto;

--- a/packages/venia-ui/lib/components/Pagination/pagination.css
+++ b/packages/venia-ui/lib/components/Pagination/pagination.css
@@ -1,5 +1,5 @@
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     border-top: 1px solid rgb(var(--venia-border));
     display: grid;
     gap: 0.25rem;

--- a/packages/venia-ui/lib/components/ProductImageCarousel/thumbnail.css
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/thumbnail.css
@@ -6,7 +6,7 @@
     border-radius: 50%;
     height: 0.875rem;
     width: 0.875rem;
-    box-shadow: 0 0 0 1px #ffffff;
+    box-shadow: 0 0 0 1px rgb(var(--venia-background-color));
     outline: none;
 }
 
@@ -36,7 +36,7 @@
     .image {
         background-color: rgb(var(--venia-grey));
         border-radius: 2px;
-        box-shadow: 0 0 0 1px white;
+        box-shadow: 0 0 0 1px rgb(var(--venia-background-color));
         display: block;
         height: 100%;
         object-fit: contain;

--- a/packages/venia-ui/lib/components/ProductOptions/swatch.css
+++ b/packages/venia-ui/lib/components/ProductOptions/swatch.css
@@ -2,7 +2,7 @@
     composes: root from './tile.css';
     background: var(--venia-swatch-bg);
     border-color: rgba(0, 0, 0, 0.1);
-    color: white;
+    color: rgb(var(--venia-background-color));
     width: 3rem;
     --venia-swatch-bg: var(--venia-grey);
 }

--- a/packages/venia-ui/lib/components/ProductOptions/tile.css
+++ b/packages/venia-ui/lib/components/ProductOptions/tile.css
@@ -10,7 +10,7 @@
 .root_selected {
     composes: root;
     background-color: rgb(var(--venia-text));
-    color: white;
+    color: rgb(var(--venia-background-color));
 }
 .root_focused {
     composes: root;

--- a/packages/venia-ui/lib/components/ProductSort/productSort.css
+++ b/packages/venia-ui/lib/components/ProductSort/productSort.css
@@ -6,9 +6,9 @@
     margin-left: 0.5rem;
     display: inline-block;
     padding: 0.75rem 2rem;
-    border: 1px solid black;
+    border: 1px solid rgb(var(--venia-foreground-color));
     border-radius: 3px;
-    color: black;
+    color: rgb(var(--venia-foreground-color));
     outline: none;
 }
 
@@ -20,18 +20,18 @@
     min-width: 10rem;
     margin: 0.125rem 0 0;
     font-size: 1rem;
-    color: black;
+    color: rgb(var(--venia-foreground-color));
     text-align: left;
     list-style: none;
-    background-color: #fff;
+    background-color: rgb(var(--venia-background-color));
     background-clip: padding-box;
-    border: 1px solid rgb(var(--venia-grey-dark));
+    border: 1px solid rgb(var(--venia-border-alt));
     border-radius: 0.25rem;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
 .menuItem {
-    border-bottom: 1px solid rgb(var(--venia-grey-dark));
+    border-bottom: 1px solid rgb(var(--venia-border-alt));
 }
 
 .menuItem:last-child {

--- a/packages/venia-ui/lib/components/SearchBar/autocomplete.css
+++ b/packages/venia-ui/lib/components/SearchBar/autocomplete.css
@@ -15,7 +15,7 @@
 }
 
 .root {
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     border: 1px solid rgb(var(--venia-border));
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
     display: grid;

--- a/packages/venia-ui/lib/components/SearchPage/searchPage.css
+++ b/packages/venia-ui/lib/components/SearchPage/searchPage.css
@@ -26,9 +26,9 @@
     margin-left: 0.5rem;
     display: inline-block;
     padding: 0.75rem 2rem;
-    border: 1px solid black;
+    border: 1px solid rgb(var(--venia-foreground-color));
     border-radius: 3px;
-    color: black;
+    color: rgb(var(--venia-foreground-color));
     outline: none;
 }
 

--- a/packages/venia-ui/lib/components/ToastContainer/toast.css
+++ b/packages/venia-ui/lib/components/ToastContainer/toast.css
@@ -1,13 +1,9 @@
-@value info: rgb(0, 104, 108);
-@value warning: rgb(var(--venia-orange));
-@value error: rgb(220, 20, 60);
-
 .root {
     align-items: start;
-    background-color: white;
+    background-color: rgb(var(--venia-background-color));
     border-radius: 2px;
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
-    color: rgb(33, 33, 33);
+    color: rgb(var(--venia-foreground-color));
     display: grid;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     font-size: 0.8rem;
@@ -22,7 +18,7 @@
     width: 20rem;
 
     border: 1px solid;
-    border-color: #d1d1d1;
+    border-color: rgb(var(--venia-border-alt));
     animation: toast-pulsate 0.5s 1s;
 }
 
@@ -48,25 +44,25 @@
 }
 
 .infoToast > .icon {
-    color: info;
+    color: rgb(var(--venia-teal-dark));
 }
 
 .warningToast {
     composes: root;
-    border-bottom: 4px solid warning;
+    border-bottom: 4px solid rgb(var(--venia-orange));
 }
 
 .warningToast > .icon {
-    color: warning;
+    color: rgb(var(--venia-orange));
 }
 
 .errorToast {
     composes: root;
-    border-bottom: 4px solid error;
+    border-bottom: 4px solid rgb(var(--venia-error));
 }
 
 .errorToast > .icon {
-    color: error;
+    color: rgb(var(--venia-error));
 }
 
 .message {
@@ -94,16 +90,16 @@
 
 .controls {
     grid-area: controls;
-    border-left: 1px solid rgb(224, 224, 224);
+    border-left: 1px solid rgb(var(--venia-border));
     padding-left: 0.75rem;
 }
 
 .actionButton {
     font-weight: 600;
     text-decoration: underline;
-    color: rgb(33, 33, 33);
+    color: rgb(var(--venia-foreground-color));
 }
 
 .dismissButton {
-    color: rgb(112, 112, 112);
+    color: rgb(var(--venia-gray-darker));
 }

--- a/packages/venia-ui/lib/targets/venia-ui-intercept.js
+++ b/packages/venia-ui/lib/targets/venia-ui-intercept.js
@@ -103,25 +103,25 @@ module.exports = targets => {
             name: 'Cart',
             pattern: '/cart',
             exact: true,
-            path: '../CartPage'
+            path: '@magento/venia-ui/lib/components/CartPage'
         },
         {
             name: 'Search',
             pattern: '/search.html',
             exact: true,
-            path: '../../RootComponents/Search'
+            path: '@magento/venia-ui/lib/RootComponents/Search'
         },
         {
             name: 'CreateAccountPage',
             pattern: '/create-account',
             exact: true,
-            path: '../CreateAccountPage'
+            path: '@magento/venia-ui/lib/components/CreateAccountPage'
         },
         {
             name: 'CheckoutPage',
             pattern: '/checkout',
             exact: true,
-            path: '../CheckoutPage'
+            path: '@magento/venia-ui/lib/components/CheckoutPage'
         }
     ]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12879,7 +12879,7 @@ postcss-load-config@^2.0.0:
     cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
 
-postcss-loader@^3.0.0:
+postcss-loader@^3.0.0, postcss-loader@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-3.0.0.tgz#6b97943e47c72d845fa9e03f273773d4e8dd6c2d"
   integrity sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==
@@ -12962,6 +12962,15 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
   integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@~7.0.26:
+  version "7.0.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.31.tgz#332af45cb73e26c0ee2614d7c7fb02dfcc2bd6dd"
+  integrity sha512-a937VDHE1ftkjk+8/7nj/mrjtmkn69xxzJgRETXdAUU+IgOYPQNJF17haGWbeDxSyk++HA14UA98FurvPyBJOA==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
## Description

- Change all hardcoded colors in Venia CSS stylesheets to use CSS Variables instead.
- Add a `postcss` transform type to the `transformModules` target, to enable third-party manipulation of CSS.

Together these changes enable large-scale CSS transformations like the [dark theme example shown here](https://github.com/magento-research/pwa-studio-target-experiments/tree/master/packages/venia-color-scheme), which integrates with the code in this PR.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
Community!

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Follow the [walkthrough](https://github.com/magento-research/pwa-studio-target-experiments#walkthrough) to test the color theme.


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
