### PR TITLE
feat(targets): Targets for navigable, externally injected content

### DIFF
--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -24,6 +24,8 @@
     "prettier:fix": "yarn run -s prettier -- --write",
     "start": "node server.js",
     "start:debug": "node --inspect-brk ./node_modules/.bin/webpack-dev-server --progress --color --env.mode development",
+    "storybook": "echo 'Venia component stories have moved to @magento/venia-ui. Trying to run in sibling directory...' && (cd ../venia-ui && yarn run storybook:build)",
+    "storybook:build": "yarn run storybook",
     "test": "yarn run -s prettier:check && yarn run -s lint && jest",
     "validate-queries": "yarn run download-schema && graphql validate-magento-pwa-queries --project venia",
     "watch": "webpack-dev-server --progress --color --env.mode development"
@@ -37,6 +39,7 @@
   "homepage": "https://github.com/magento/pwa-studio/tree/master/packages/venia-concept#readme",
   "devDependencies": {
     "@adobe/apollo-link-mutation-queue": "~1.0.0",
+    "@apollo/react-hooks": "~3.1.2",
     "@babel/core": "~7.3.4",
     "@babel/plugin-proposal-class-properties": "~7.3.4",
     "@babel/plugin-proposal-object-rest-spread": "~7.3.4",

--- a/packages/venia-concept/src/drivers.js
+++ b/packages/venia-concept/src/drivers.js
@@ -11,4 +11,7 @@ export {
     useParams
 } from '@magento/venia-ui/lib/drivers';
 export { default as resourceUrl } from '@magento/venia-ui/lib/util/makeUrl';
-export { default as Adapter } from '@magento/venia-ui/lib/drivers/adapter';
+export {
+    default as Adapter,
+    createApolloLink
+} from '@magento/venia-ui/lib/drivers/adapter';

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -6,7 +6,7 @@ import { RetryLink } from 'apollo-link-retry';
 import MutationQueueLink from '@adobe/apollo-link-mutation-queue';
 
 import { Util } from '@magento/peregrine';
-import { Adapter } from '@magento/venia-drivers';
+import { Adapter, createApolloLink } from '@magento/venia-drivers';
 import store from './store';
 import app from '@magento/peregrine/lib/store/actions/app';
 import App, { AppContextProvider } from '@magento/venia-ui/lib/components/App';
@@ -42,17 +42,8 @@ const apolloLink = ApolloLink.from([
     // by default, RetryLink will retry an operation five (5) times.
     new RetryLink(),
     authLink,
-    // With additive linking, we can use the same GraphQL client to talk to a
-    // totally different API. We'll use a naming convention to denote queries
-    // which should use the Contentful endpoint instead of the Magento endpoint.
-    ApolloLink.split(
-        // Return true to use Contentful, false to use Magento.
-        ({ operationName }) => operationName.startsWith('Contentful'),
-        // Contentful HTTP link.
-        Adapter.apolloLink('https://localhost/___graphql'),
-        // Magento HTTP link.
-        Adapter.apolloLink(apiBase)
-    )
+    // An apollo-link-http Link
+    createApolloLink(apiBase)
 ]);
 
 ReactDOM.render(

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -42,8 +42,17 @@ const apolloLink = ApolloLink.from([
     // by default, RetryLink will retry an operation five (5) times.
     new RetryLink(),
     authLink,
-    // An apollo-link-http Link
-    Adapter.apolloLink(apiBase)
+    // With additive linking, we can use the same GraphQL client to talk to a
+    // totally different API. We'll use a naming convention to denote queries
+    // which should use the Contentful endpoint instead of the Magento endpoint.
+    ApolloLink.split(
+        // Return true to use Contentful, false to use Magento.
+        ({ operationName }) => operationName.startsWith('Contentful'),
+        // Contentful HTTP link.
+        Adapter.apolloLink('https://localhost/___graphql'),
+        // Magento HTTP link.
+        Adapter.apolloLink(apiBase)
+    )
 ]);
 
 ReactDOM.render(

--- a/packages/venia-ui/lib/components/Navigation/__tests__/__snapshots__/navigation.spec.js.snap
+++ b/packages/venia-ui/lib/components/Navigation/__tests__/__snapshots__/navigation.spec.js.snap
@@ -13,6 +13,15 @@ exports[`authModal is rendered when hasModal is true 1`] = `
     className="body_masked"
   >
     <i />
+    <div
+      className="root"
+    >
+      <ul
+        className="list"
+      >
+         
+      </ul>
+    </div>
   </div>
   <div
     className="footer"
@@ -40,6 +49,15 @@ exports[`renders correctly when closed 1`] = `
     className="body"
   >
     <i />
+    <div
+      className="root"
+    >
+      <ul
+        className="list"
+      >
+         
+      </ul>
+    </div>
   </div>
   <div
     className="footer"
@@ -65,6 +83,15 @@ exports[`renders correctly when open 1`] = `
     className="body"
   >
     <i />
+    <div
+      className="root"
+    >
+      <ul
+        className="list"
+      >
+         
+      </ul>
+    </div>
   </div>
   <div
     className="footer"

--- a/packages/venia-ui/lib/components/Navigation/linkTree.css
+++ b/packages/venia-ui/lib/components/Navigation/linkTree.css
@@ -1,0 +1,34 @@
+.root {
+}
+
+.item {
+    align-items: center;
+    border-bottom: 1px solid rgb(var(--venia-border));
+    display: flex;
+    margin: 0 1.25rem;
+}
+
+.link {
+    align-items: center;
+    display: flex;
+    flex: auto;
+    height: 3.5rem;
+    line-height: 3.5rem;
+    justify-content: flex-start;
+    margin: 0 -1.25rem;
+    padding: 0 1.5rem;
+    width: 100%;
+}
+
+.active {
+    composes: link;
+    pointer-events: none;
+    opacity: 0.8;
+}
+
+.text {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/packages/venia-ui/lib/components/Navigation/linkTree.js
+++ b/packages/venia-ui/lib/components/Navigation/linkTree.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { mergeClasses } from '../../classify';
+import defaultClasses from './linkTree.css';
+import { NavLink } from 'react-router-dom'; // eslint-disable-line
+
+const LinkTree = props => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <div className={classes.root}>
+            <ul className={classes.list}> </ul>
+        </div>
+    );
+};
+
+export default LinkTree;

--- a/packages/venia-ui/lib/components/Navigation/navigation.js
+++ b/packages/venia-ui/lib/components/Navigation/navigation.js
@@ -5,6 +5,7 @@ import { useNavigation } from '@magento/peregrine/lib/talons/Navigation/useNavig
 import { mergeClasses } from '../../classify';
 import AuthBar from '../AuthBar';
 import CategoryTree from '../CategoryTree';
+import LinkTree from './linkTree';
 import LoadingIndicator from '../LoadingIndicator';
 import NavHeader from './navHeader';
 import defaultClasses from './navigation.css';
@@ -71,6 +72,7 @@ const Navigation = props => {
                     setCategoryId={setCategoryId}
                     updateCategories={catalogActions.updateCategories}
                 />
+                <LinkTree />
             </div>
             <div className={classes.footer}>
                 <AuthBar

--- a/packages/venia-ui/lib/drivers/adapter.js
+++ b/packages/venia-ui/lib/drivers/adapter.js
@@ -49,7 +49,7 @@ const VeniaAdapter = props => {
     const { apiBase, apollo = {}, children, store } = props;
 
     const cache = apollo.cache || preInstantiatedCache;
-    const link = apollo.link || VeniaAdapter.apolloLink(apiBase);
+    const link = apollo.link || createApolloLink(apiBase);
     const initialData = apollo.initialData || {};
 
     cache.writeData({
@@ -111,15 +111,11 @@ const VeniaAdapter = props => {
     );
 };
 
-/**
- * We attach this Link as a static method on VeniaAdapter because
- * other modules in the codebase need access to it.
- */
-VeniaAdapter.apolloLink = apiBase => {
+export function createApolloLink(apiBase) {
     return createHttpLink({
         uri: apiBase
     });
-};
+}
 
 VeniaAdapter.propTypes = {
     apiBase: string.isRequired,

--- a/packages/venia-ui/lib/drivers/index.js
+++ b/packages/venia-ui/lib/drivers/index.js
@@ -10,7 +10,7 @@ export {
     useRouteMatch
 } from 'react-router-dom';
 export { default as resourceUrl } from '../util/makeUrl';
-export { default as Adapter } from './adapter';
+export { default as Adapter, createApolloLink } from './adapter';
 export { connect } from 'react-redux';
 
 /**

--- a/packages/venia-ui/lib/targets/BabelNavItemInjectionPlugin.js
+++ b/packages/venia-ui/lib/targets/BabelNavItemInjectionPlugin.js
@@ -1,0 +1,68 @@
+const babelTemplate = require('@babel/template');
+
+function BabelNavItemInjectionPlugin() {
+    const linkTag = ({ name, to }) =>
+        babelTemplate.expression.ast(
+            `<li className={classes.item}>
+                <NavLink
+                    activeClassName={classes.active}
+                    className={classes.link}
+                    to="${to}"
+                >
+                    <span className={classes.text}>${name}</span>
+                </NavLink>
+            </li>`,
+            {
+                plugins: ['jsx']
+            }
+        );
+
+    return {
+        visitor: {
+            Program: {
+                enter(_, state) {
+                    state.navItems = [];
+                    const seenNames = new Map();
+                    const requests = this.opts.requestsByFile[this.filename];
+                    for (const request of requests) {
+                        const { requestor, options } = request;
+                        for (const navItem of options.navItems) {
+                            const seenName = seenNames.get(navItem.name);
+                            if (!seenName) {
+                                seenNames.set(navItem.name, {
+                                    requestor,
+                                    navItem
+                                });
+                            } else {
+                                throw new Error(
+                                    `@magento/venia-ui: Conflict in "navItems" target. "${
+                                        request.requestor
+                                    }" is trying to add a route ${JSON.stringify(
+                                        navItem
+                                    )}, but "${
+                                        seenName.requestor
+                                    }" has already declared that route pattern: ${JSON.stringify(
+                                        seenName.navItem
+                                    )}`
+                                );
+                            }
+                            state.navItems.push(navItem);
+                        }
+                    }
+                }
+            },
+            JSXElement: {
+                enter(path, state) {
+                    const { openingElement } = path.node;
+                    if (!openingElement || openingElement.name.name !== 'ul')
+                        return;
+                    while (state.navItems.length > 0) {
+                        path.node.children.push(linkTag(state.navItems.pop()));
+                    }
+                }
+            }
+        }
+    };
+}
+
+module.exports = BabelNavItemInjectionPlugin;

--- a/packages/venia-ui/lib/targets/venia-ui-declare.js
+++ b/packages/venia-ui/lib/targets/venia-ui-declare.js
@@ -120,6 +120,38 @@ module.exports = targets => {
          *   return routes;
          * })
          */
-        routes: new targets.types.SyncWaterfall(['routes'])
+        routes: new targets.types.SyncWaterfall(['routes']),
+
+        /**
+         * @callback apolloLinkIntercept
+         * @param {string[]} wrapperModules - Array of paths to wrapper modules, which export a function that will receive the apollo link factory and can return a wrapped version of it.
+         * @returns {string[]} - Interceptors of `apolloLinks` must return an array of wrapperModules, either the original or by constructing a new one.
+         */
+
+        /**
+         * Collects requests to intercept and "wrap" the function in VeniaAdapter that returns an Apollo Link.
+         * Use it to chain and compose Apollo Links together.
+         * @see https://www.apollographql.com/docs/link/composition/
+         *
+         * @type {tapable.SyncWaterfallHook}
+         * @param {apolloLinkIntercept}
+         *
+         * @example <caption>Add an apollo-link-schema link to the Venia Apollo client</caption>
+         * targets.of('@magento/venia-ui').apolloLinks.tap(
+         *   linkWrappers => [
+         *     ...linkWrappers,
+         *     './schema-link-wrapper.js'
+         *   ]);
+         *
+         * // log-wrapper.js:
+         * import { SchemaLink } from 'apollo-link-schema'
+         * import schema from './somewhere';
+         * export default function wrapLink(original) {
+         *   return function addSchemaLink(...args) {
+         *     return original(...args).concat(new SchemaLink({ schema }))
+         *   }
+         * }
+         */
+        apolloLinks: new targets.types.SyncWaterfall(['linkWrappers'])
     });
 };

--- a/packages/venia-ui/lib/targets/venia-ui-declare.js
+++ b/packages/venia-ui/lib/targets/venia-ui-declare.js
@@ -8,6 +8,36 @@
 module.exports = targets => {
     targets.declare({
         /**
+         * A description of a navigation item in the Venia app structure.
+         *
+         * @typedef {Object} VeniaNavItem
+         * @property {string} name - Name of the link.
+         * @property {string} to - Destination (href) of the link.
+         */
+
+        /**
+         * @callback navItemsIntercept
+         * @param {VeniaNavItem[]} navItems - Array of registered nav items.
+         * @returns {VeniaNavItem[]} - You must return the array, or a new
+         *   array you have constructed.
+         */
+
+        /**
+         * Registers custom client-side navigation items.
+         * They will appear below the category tree in the nav menu.
+         *
+         * @example <caption>Add a main nav link to the blog.</caption>
+         * targets.of('@magento/venia-ui').navItems.tap(navItems => {
+         *   navItems.push({
+         *     name: 'Blog',
+         *     to: '/blog/'
+         *   });
+         *   return navItems;
+         * })
+         */
+        navItems: new targets.types.SyncWaterfall(['navItems']),
+
+        /**
          * A file that implements the RichContentRenderer interface.
          *
          * @typedef {Object} RichContentRenderer

--- a/packages/venia-ui/lib/targets/venia-ui-intercept.js
+++ b/packages/venia-ui/lib/targets/venia-ui-intercept.js
@@ -105,6 +105,18 @@ module.exports = targets => {
                 navItems: targets.own.navItems.call([])
             }
         });
+        targets.own.apolloLinks.call([]).forEach(wrapperModule =>
+            addTransform({
+                type: 'source',
+                fileToTransform: '@magento/venia-ui/lib/drivers/adapter.js',
+                transformModule:
+                    '@magento/pwa-buildpack/lib/WebpackTools/loaders/wrap-esm-loader',
+                options: {
+                    wrapperModule,
+                    exportName: 'createApolloLink'
+                }
+            })
+        );
     });
 
     targets.own.routes.tap(routes => [

--- a/packages/venia-ui/lib/targets/venia-ui-intercept.js
+++ b/packages/venia-ui/lib/targets/venia-ui-intercept.js
@@ -95,6 +95,16 @@ module.exports = targets => {
                 routes: targets.own.routes.call([])
             }
         });
+        addTransform({
+            type: 'babel',
+            fileToTransform:
+                '@magento/venia-ui/lib/components/Navigation/linkTree.js',
+            transformModule:
+                '@magento/venia-ui/lib/targets/BabelNavItemInjectionPlugin',
+            options: {
+                navItems: targets.own.navItems.call([])
+            }
+        });
     });
 
     targets.own.routes.tap(routes => [


### PR DESCRIPTION
## Description

-   VeniaUI has an `apolloLink` target, exposing the already composable concept of Apollo Links to PWA Studio extensions
-   VeniaUI has a `navItems` target, exposing the main navigation menu in the same way that `routes` exposes the routing table

This draft PR is to enable https://github.com/magento-research/pwa-studio-target-experiments/tree/master/packages/contentful-blog though it should be seriously considered as new API.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
Community!

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Follow the walkthrough directions [here](https://github.com/magento-research/pwa-studio-target-experiments) for "contentful-blog"

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
