### PR TITLE
Removed CHECKOUT_BRAINTREE_TOKEN buildpack check.

### DIFF
--- a/packages/pwa-buildpack/envVarDefinitions.json
+++ b/packages/pwa-buildpack/envVarDefinitions.json
@@ -186,18 +186,6 @@
     ],
     "changes": [
         {
-            "name": "CHECKOUT_BRAINTREE_TOKEN",
-            "type": "defaultChanged",
-            "reason": "confusion about whether developers should provide their own Braintree tokens for their own sites. An example value is provided instead for development purposes",
-            "original": "sandbox_8yrzsvtm_s2bg8fs563crhqzk"
-        },
-        {
-            "name": "CHECKOUT_BRAINTREE_TOKEN",
-            "type": "exampleChanged",
-            "reason": "confusion about the purpose of the previously provided default value. An example is provided instead for development purposes",
-            "original": "(none)"
-        },
-        {
             "name": "UPWARD_JS_UPWARD_PATH",
             "type": "defaultChanged",
             "reason": "a new requirement that UPWARD definition files have a standardized name, to enable extensibility. You may need to rename the UPWARD definition file in your project",


### PR DESCRIPTION
## Description

Removed `CHECKOUT_BRAINTREE_TOKEN` buildpack warning.

## Related Issue
Closes #2308.
Closes [PWA-502](https://jira.corp.magento.com/browse/PWA-502)

### Verification Stakeholders
@zetlen 
@brendanfalkowski 

### Specification
@zetlen should we update any docs for this? I did not find any docs related to this, just checking with you.

### Verification Steps
1. Run `yarn build` and you should not see the `CHECKOUT_BRAINTREE_TOKEN` default value warning.

## Screenshots / Screen Captures (if appropriate)

## Checklist
None