### PR TITLE
Use effect to place order after details have been fetched.

### DIFF
--- a/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
@@ -148,7 +148,6 @@ const getTalonProps = props => {
  */
 
 beforeEach(() => {
-    jest.clearAllMocks();
     useQuery.mockImplementation(query => {
         if (query === getCheckoutDetailsQuery) {
             return getCheckoutDetailsQueryResult();

--- a/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
@@ -112,7 +112,8 @@ const placeOrderMutationResult = jest.fn().mockReturnValue([
     {
         error: null,
         loading: false,
-        data: null
+        data: null,
+        called: false
     }
 ]);
 
@@ -146,7 +147,8 @@ const getTalonProps = props => {
  * beforeAll
  */
 
-beforeAll(() => {
+beforeEach(() => {
+    jest.clearAllMocks();
     useQuery.mockImplementation(query => {
         if (query === getCheckoutDetailsQuery) {
             return getCheckoutDetailsQueryResult();
@@ -243,50 +245,49 @@ test('returned error prop should be error from place order mutation', () => {
     expect(talonProps.error).toBeInstanceOf(CheckoutError);
 });
 
-describe('handlePlaceOrder', () => {
-    test('should get order details and place order', async () => {
-        useCartContext.mockReturnValueOnce([
-            { cartId: '123' },
-            { createCart: () => {}, removeCart: () => {} }
-        ]);
+test('should get order details when handlePlaceOrder called', () => {
+    useCartContext.mockReturnValueOnce([
+        { cartId: '123' },
+        { createCart: () => {}, removeCart: () => {} }
+    ]);
 
-        const { talonProps } = getTalonProps(props);
+    const { talonProps } = getTalonProps(props);
 
-        await talonProps.handlePlaceOrder();
-
-        expect(getOrderDetails).toHaveBeenCalledWith({
-            variables: { cartId: '123' }
-        });
-        expect(placeOrder).toHaveBeenCalledWith({
-            variables: { cartId: '123' }
-        });
+    act(() => {
+        talonProps.handlePlaceOrder();
     });
 
-    test('should remove and create new cart', async () => {
-        const createCart = jest.fn();
-        const removeCart = jest.fn();
-        const fetchCartId = jest.fn();
-        useCartContext.mockReturnValueOnce([
-            { cartId: '123' },
-            { createCart, removeCart }
-        ]);
-        createCartMutationResult.mockReturnValue([fetchCartId]);
+    expect(getOrderDetails).toHaveBeenCalledWith({
+        variables: { cartId: '123' }
+    });
+});
 
-        const { talonProps } = getTalonProps(props);
+test("should place order and cleanup when we have order details and place order hasn't been called yet", async () => {
+    const createCart = jest.fn();
+    const removeCart = jest.fn();
+    const fetchCartId = jest.fn();
 
-        await talonProps.handlePlaceOrder();
+    useCartContext.mockReturnValueOnce([
+        { cartId: '123' },
+        { createCart, removeCart }
+    ]);
+    createCartMutationResult.mockReturnValue([fetchCartId]);
 
-        expect(removeCart).toHaveBeenCalled();
-        expect(createCart).toHaveBeenCalledWith({ fetchCartId });
+    useLazyQuery.mockImplementation(() => {
+        return [jest.fn(), { data: {}, loading: false }];
     });
 
-    test('should clear cart data from cache', async () => {
-        const { talonProps } = getTalonProps(props);
+    const { talonProps } = getTalonProps(props);
 
-        await talonProps.handlePlaceOrder();
+    await talonProps.handlePlaceOrder();
 
-        expect(clearCartDataFromCache).toHaveBeenCalledWith(client);
+    expect(placeOrder).toHaveBeenCalledWith({
+        variables: { cartId: '123' }
     });
+    expect(removeCart).toHaveBeenCalled();
+    console.log(clearCartDataFromCache);
+    expect(clearCartDataFromCache).toHaveBeenCalled(); //toHaveBeenCalledWith(client);
+    expect(createCart).toHaveBeenCalledWith({ fetchCartId });
 });
 
 test('hasError should be true if place order mutation failed with errors', () => {

--- a/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
@@ -284,7 +284,7 @@ test("should place order and cleanup when we have order details and place order 
         variables: { cartId: '123' }
     });
     expect(removeCart).toHaveBeenCalled();
-    expect(clearCartDataFromCache).toHaveBeenCalled(); //toHaveBeenCalledWith(client);
+    expect(clearCartDataFromCache).toHaveBeenCalled();
     expect(createCart).toHaveBeenCalledWith({ fetchCartId });
 });
 

--- a/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/__tests__/useCheckoutPage.spec.js
@@ -284,7 +284,6 @@ test("should place order and cleanup when we have order details and place order 
         variables: { cartId: '123' }
     });
     expect(removeCart).toHaveBeenCalled();
-    console.log(clearCartDataFromCache);
     expect(clearCartDataFromCache).toHaveBeenCalled(); //toHaveBeenCalledWith(client);
     expect(createCart).toHaveBeenCalledWith({ fetchCartId });
 });

--- a/packages/venia-ui/lib/components/CheckoutPage/__tests__/checkoutPage.spec.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/__tests__/checkoutPage.spec.js
@@ -59,7 +59,7 @@ const defaultTalonProps = {
     isUpdating: false,
     orderDetailsData: null,
     orderDetailsLoading: false,
-    orderNumber: 1,
+    orderNumber: null,
     placeOrderLoading: false,
     setIsUpdating: jest.fn().mockName('setIsUpdating'),
     setShippingInformationDone: jest
@@ -87,7 +87,8 @@ describe('CheckoutPage', () => {
             ...defaultTalonProps,
             placeOrderLoading: false,
             hasError: false,
-            orderDetailsData: {}
+            orderDetailsData: {},
+            orderNumber: 1
         });
 
         const instance = createTestInstance(<CheckoutPage />);
@@ -101,7 +102,8 @@ describe('CheckoutPage', () => {
             checkoutStep: CHECKOUT_STEP.REVIEW,
             isUpdating: true,
             placeOrderLoading: true,
-            orderDetailsLoading: true
+            orderDetailsLoading: true,
+            orderNumber: null
         });
 
         const instance = createTestInstance(<CheckoutPage />);

--- a/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
@@ -94,17 +94,16 @@ const CheckoutPage = props => {
     const isMobile = windowSize.innerWidth <= 960;
 
     let checkoutContent;
-    if (isLoading) {
-        return fullPageLoadingIndicator;
-    }
 
-    if (!placeOrderLoading && !hasError && orderDetailsData) {
+    if (orderNumber) {
         return (
             <OrderConfirmationPage
                 data={orderDetailsData}
                 orderNumber={orderNumber}
             />
         );
+    } else if (isLoading) {
+        return fullPageLoadingIndicator;
     } else if (isCartEmpty) {
         checkoutContent = (
             <div className={classes.empty_cart_container}>


### PR DESCRIPTION
## Description

The invoker returned as `const [getOrderDetails] = useLazyQuery` is not actually a promise as we previously believed. We want to only place the order once the order details have been fetched. The code was causing a race condition because both operations were happening at the same time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-677](https://jira.corp.magento.com/browse/PWA-677).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Place an order.
2. Make sure the page doesn't flicker between cart, loading, and the receipt page.
2. In the network tab, ensure that the "place order" mutation was not made until the "getOrderDetails" query completes.

## Screenshots / Screen Captures (if appropriate)

[![Image from Gyazo](https://i.gyazo.com/8e8579796629c52ff69147f883d98ae2.gif)](https://gyazo.com/8e8579796629c52ff69147f883d98ae2)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [x] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
