### PR TITLE
PWA-712: Fix Chrome prev / next carousel button placement

### DIFF
--- a/packages/venia-ui/lib/components/ProductImageCarousel/carousel.css
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/carousel.css
@@ -53,7 +53,7 @@
 
 .nextButton:focus > .chevron,
 .previousButton:focus > .chevron {
-    box-shadow: 0 0 4px 2px rgb(var(--venia-global-color-teal));
+    box-shadow: 0 0 4px 2px rgb(var(--venia-teal));
     border-radius: 0.5rem;
 }
 

--- a/packages/venia-ui/lib/components/ProductImageCarousel/carousel.css
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/carousel.css
@@ -31,6 +31,7 @@
     display: flex;
     outline: none;
     z-index: 1;
+    align-self: center;
 }
 
 .previousButton {

--- a/packages/venia-ui/lib/components/ProductImageCarousel/carousel.css
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/carousel.css
@@ -31,7 +31,6 @@
     display: flex;
     outline: none;
     z-index: 1;
-    align-self: center;
 }
 
 .previousButton {
@@ -44,6 +43,18 @@
     justify-content: flex-end;
     grid-area: 1 / 3 / 2 / 4;
     margin-right: 1.625rem;
+}
+
+.chevron {
+    composes: root from '../Icon/icon.css';
+    align-self: center;
+    border: 2px solid transparent;
+}
+
+.nextButton:focus > .chevron,
+.previousButton:focus > .chevron {
+    box-shadow: 0 0 4px 2px rgb(var(--venia-global-color-teal));
+    border-radius: 0.5rem;
 }
 
 .thumbnailList {

--- a/packages/venia-ui/lib/components/ProductImageCarousel/carousel.js
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/carousel.js
@@ -90,6 +90,7 @@ const ProductImageCarousel = props => {
         );
     }
 
+    const chevronClasses = { root: classes.chevron };
     return (
         <div className={classes.root}>
             <div className={classes.carouselContainer}>
@@ -97,11 +98,19 @@ const ProductImageCarousel = props => {
                     className={classes.previousButton}
                     onClick={handlePrevious}
                 >
-                    <Icon src={ChevronLeftIcon} size={40} />
+                    <Icon
+                        classes={chevronClasses}
+                        src={ChevronLeftIcon}
+                        size={40}
+                    />
                 </button>
                 {image}
                 <button className={classes.nextButton} onClick={handleNext}>
-                    <Icon src={ChevronRightIcon} size={40} />
+                    <Icon
+                        classes={chevronClasses}
+                        src={ChevronRightIcon}
+                        size={40}
+                    />
                 </button>
             </div>
             <div className={classes.thumbnailList}>{thumbnails}</div>


### PR DESCRIPTION
## Description
They should be in the center of the image but they are instead at the top of the image:
https://i.gyazo.com/98b75a0fb607669e627f2d1a3091b415.gif

## Related Issue
https://jira.corp.magento.com/browse/PWA-712

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
@jimbo 
@sirugh 

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
1. Check previous / next in Chrome mobile

## Screenshots / Screen Captures (if appropriate)
https://i.gyazo.com/98b75a0fb607669e627f2d1a3091b415.gif

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [x] I have added tests to cover my changes, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
