### PR TITLE
PWA-722: Venia button follow up changes

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/__snapshots__/banner.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/__snapshots__/banner.spec.js.snap
@@ -59,6 +59,7 @@ exports[`on hover displays button and overlay 1`] = `
         >
           <button
             className="root_highPriority"
+            disabled={false}
             type="button"
           >
             <span
@@ -131,6 +132,7 @@ exports[`on hover displays button and overlay 2`] = `
         >
           <button
             className="root_highPriority"
+            disabled={false}
             type="button"
           >
             <span
@@ -208,6 +210,7 @@ exports[`renders a configured collage-left Banner component 1`] = `
         >
           <button
             className="root_highPriority"
+            disabled={false}
             type="button"
           >
             <span
@@ -288,6 +291,7 @@ exports[`renders a configured collage-left Banner component on mobile 1`] = `
         >
           <button
             className="root_highPriority"
+            disabled={false}
             type="button"
           >
             <span
@@ -373,6 +377,7 @@ exports[`renders a configured poster Banner component 1`] = `
         >
           <button
             className="root_highPriority"
+            disabled={false}
             type="button"
           >
             <span
@@ -447,6 +452,7 @@ exports[`renders an empty Banner component 1`] = `
       >
         <button
           className="root_normalPriority"
+          disabled={false}
           type="button"
         >
           <span

--- a/packages/pagebuilder/lib/ContentTypes/ButtonItem/__tests__/__snapshots__/buttonItem.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/ButtonItem/__tests__/__snapshots__/buttonItem.spec.js.snap
@@ -4,6 +4,7 @@ exports[`renders a ButtonItem component 1`] = `
 <div>
   <button
     className="root_normalPriority"
+    disabled={false}
     onClick={[Function]}
     style={
       Object {
@@ -37,6 +38,7 @@ exports[`renders a ButtonItem component with all properties configured 1`] = `
 >
   <button
     className="root_normalPriority"
+    disabled={false}
     onClick={[Function]}
     style={
       Object {

--- a/packages/venia-ui/lib/components/Button/button.css
+++ b/packages/venia-ui/lib/components/Button/button.css
@@ -34,7 +34,8 @@
     --stroke: var(--venia-brand-color-1-800);
 }
 
-.root:disabled {
+.root:disabled,
+.root:hover:disabled {
     pointer-events: none;
     --stroke: var(--venia-global-color-gray-400);
 }

--- a/packages/venia-ui/lib/components/Button/button.css
+++ b/packages/venia-ui/lib/components/Button/button.css
@@ -34,6 +34,10 @@
     --stroke: var(--venia-brand-color-1-800);
 }
 
+/**
+ * Some browsers retain the :hover state after a click, this ensures if a button becomes disabled after
+ * being clicked it will be visually disabled.
+ */
 .root:disabled,
 .root:hover:disabled {
     pointer-events: none;

--- a/packages/venia-ui/lib/components/Button/button.js
+++ b/packages/venia-ui/lib/components/Button/button.js
@@ -24,13 +24,19 @@ const Button = props => {
         priority,
         type,
         negative,
+        disabled,
         ...restProps
     } = props;
     const classes = mergeClasses(defaultClasses, propClasses);
     const rootClassName = classes[getRootClassName(priority, negative)];
 
     return (
-        <button className={rootClassName} type={type} {...restProps}>
+        <button
+            className={rootClassName}
+            type={type}
+            disabled={disabled}
+            {...restProps}
+        >
             <span className={classes.content}>{children}</span>
         </button>
     );
@@ -53,6 +59,8 @@ const Button = props => {
  * normal priority.
  * @property {string} priority the priority/importance of the Button
  * @property {string} type the type of the Button
+ * @property {bool} negative whether the button should be displayed in red for a negative action
+ * @property {bool} disabled is the button disabled
  */
 Button.propTypes = {
     classes: shape({
@@ -64,13 +72,15 @@ Button.propTypes = {
     }),
     priority: oneOf(['high', 'low', 'normal']).isRequired,
     type: oneOf(['button', 'reset', 'submit']).isRequired,
-    negative: bool
+    negative: bool,
+    disabled: bool
 };
 
 Button.defaultProps = {
     priority: 'normal',
     type: 'button',
-    negative: false
+    negative: false,
+    disabled: false
 };
 
 export default Button;

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/CouponCode/__tests__/__snapshots__/couponCode.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/CouponCode/__tests__/__snapshots__/couponCode.spec.js.snap
@@ -156,6 +156,7 @@ exports[`renders an error message if an error occurs on code entry 1`] = `
   <div>
     <label />
     <button
+      disabled={false}
       type="submit"
     >
       <span>

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/ShippingMethods/__tests__/__snapshots__/shippingForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/ShippingMethods/__tests__/__snapshots__/shippingForm.spec.js.snap
@@ -165,6 +165,7 @@ Array [
     </div>
     <button
       className="root_normalPriority"
+      disabled={false}
       type="submit"
     >
       <span
@@ -356,6 +357,7 @@ Array [
     </div>
     <button
       className="root_normalPriority"
+      disabled={false}
       type="submit"
     >
       <span
@@ -590,6 +592,7 @@ Array [
     </div>
     <button
       className="root_normalPriority"
+      disabled={false}
       type="submit"
     >
       <span

--- a/packages/venia-ui/lib/components/CartPage/PriceAdjustments/ShippingMethods/__tests__/__snapshots__/shippingMethods.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceAdjustments/ShippingMethods/__tests__/__snapshots__/shippingMethods.spec.js.snap
@@ -85,6 +85,7 @@ exports[`renders description and confirm link w/o shipping address set 1`] = `
   </p>
   <button
     className="root_normalPriority"
+    disabled={false}
     onClick={[Function]}
     type="button"
   >

--- a/packages/venia-ui/lib/components/CartPage/PriceSummary/__tests__/__snapshots__/priceSummary.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/PriceSummary/__tests__/__snapshots__/priceSummary.spec.js.snap
@@ -37,6 +37,7 @@ exports[`renders PriceSummary correctly on cart page 1`] = `
   >
     <button
       className="root_highPriority"
+      disabled={false}
       type="button"
     >
       <span

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/__tests__/__snapshots__/productForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/__tests__/__snapshots__/productForm.spec.js.snap
@@ -147,6 +147,7 @@ exports[`renders form with data 1`] = `
   >
     <button
       className="root_highPriority"
+      disabled={false}
       type="submit"
     >
       <span

--- a/packages/venia-ui/lib/components/CartPage/__tests__/__snapshots__/cartPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/__tests__/__snapshots__/cartPage.spec.js.snap
@@ -77,6 +77,7 @@ exports[`renders components if cart has items 1`] = `
       Cart
     </h1>
     <button
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >
@@ -114,6 +115,7 @@ exports[`renders empty cart text (no adjustments, list or summary) if cart is em
       Cart
     </h1>
     <button
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >

--- a/packages/venia-ui/lib/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
@@ -25,6 +25,7 @@ exports[`renders a Receipt component correctly 1`] = `
     </div>
     <button
       className="root_highPriority"
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/addressForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/addressForm.spec.js.snap
@@ -386,6 +386,7 @@ exports[`renders an AddressForm component 1`] = `
   >
     <button
       className="root_highPriority"
+      disabled={false}
       type="submit"
     >
       <span
@@ -396,6 +397,7 @@ exports[`renders an AddressForm component 1`] = `
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >
@@ -795,6 +797,7 @@ exports[`renders validation block with message if address is incorrect 1`] = `
   >
     <button
       className="root_highPriority"
+      disabled={false}
       type="submit"
     >
       <span
@@ -805,6 +808,7 @@ exports[`renders validation block with message if address is incorrect 1`] = `
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/checkoutButton.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/checkoutButton.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`renders a Checkout Button component 1`] = `
 <button
+  disabled={false}
   type="button"
 >
   <span>

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/overview.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/overview.spec.js.snap
@@ -145,6 +145,7 @@ Array [
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >
@@ -303,6 +304,7 @@ Array [
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >
@@ -461,6 +463,7 @@ Array [
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
@@ -90,6 +90,7 @@ exports[`renders a PaymentsForm component 1`] = `
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >
@@ -481,6 +482,7 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
     </button>
     <button
       className="root_lowPriority"
+      disabled={false}
       onClick={[Function]}
       type="button"
     >

--- a/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/shippingform.spec.js.snap
+++ b/packages/venia-ui/lib/components/Checkout/__tests__/__snapshots__/shippingform.spec.js.snap
@@ -18,6 +18,7 @@ exports[`renders a shipping form 1`] = `
   </div>
   <div>
     <button
+      disabled={false}
       type="submit"
     >
       <span>
@@ -25,6 +26,7 @@ exports[`renders a shipping form 1`] = `
       </span>
     </button>
     <button
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >
@@ -54,6 +56,7 @@ exports[`renders no initial value and no shipping methods if no availableShippin
   </div>
   <div>
     <button
+      disabled={false}
       type="submit"
     >
       <span>
@@ -61,6 +64,7 @@ exports[`renders no initial value and no shipping methods if no availableShippin
       </span>
     </button>
     <button
+      disabled={false}
       onClick={[MockFunction]}
       type="button"
     >

--- a/packages/venia-ui/lib/components/CheckoutPage/__tests__/__snapshots__/checkoutPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/__tests__/__snapshots__/checkoutPage.spec.js.snap
@@ -187,6 +187,7 @@ exports[`CheckoutPage renders checkout content for guest 1`] = `
     >
       <button
         className="sign_in"
+        disabled={false}
         onClick={[MockFunction handleSignIn]}
         type="button"
       >

--- a/packages/venia-ui/lib/components/Dialog/__tests__/__snapshots__/dialog.spec.js.snap
+++ b/packages/venia-ui/lib/components/Dialog/__tests__/__snapshots__/dialog.spec.js.snap
@@ -50,6 +50,7 @@ exports[`does not render a close X button in modal mode 1`] = `
             </button>
             <button
               className="root_highPriority"
+              disabled={false}
               type="submit"
             >
               <span
@@ -253,6 +254,7 @@ exports[`renders a basic Dialog 1`] = `
             </button>
             <button
               className="root_highPriority"
+              disabled={false}
               type="submit"
             >
               <span
@@ -456,6 +458,7 @@ exports[`supports modifying title and button texts 1`] = `
             </button>
             <button
               className="root_highPriority"
+              disabled={false}
               type="submit"
             >
               <span

--- a/packages/venia-ui/lib/components/ForgotPassword/ForgotPasswordForm/__tests__/__snapshots__/forgotPasswordForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/ForgotPassword/ForgotPasswordForm/__tests__/__snapshots__/forgotPasswordForm.spec.js.snap
@@ -35,6 +35,7 @@ exports[`renders correctly 1`] = `
   </div>
   <div>
     <button
+      disabled={false}
       type="submit"
     >
       <span>

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/cartOptions.spec.js.snap
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/cartOptions.spec.js.snap
@@ -29,16 +29,6 @@ exports[`it renders the correct tree 1`] = `
   </div>
   <div>
     <Button
-      negative={false}
-      onClick={[Function]}
-      priority="normal"
-      type="button"
-    >
-      <span>
-        Cancel
-      </span>
-    </Button>
-    <Button
       disabled={true}
       negative={false}
       onClick={[Function]}
@@ -47,6 +37,17 @@ exports[`it renders the correct tree 1`] = `
     >
       <span>
         Update Cart
+      </span>
+    </Button>
+    <Button
+      disabled={false}
+      negative={false}
+      onClick={[Function]}
+      priority="low"
+      type="button"
+    >
+      <span>
+        Cancel
       </span>
     </Button>
   </div>

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/emptyMiniCartBody.spec.js.snap
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/emptyMiniCartBody.spec.js.snap
@@ -6,6 +6,7 @@ exports[`renders a "no items" message 1`] = `
     There are no items in your shopping cart
   </h3>
   <Button
+    disabled={false}
     negative={false}
     onClick={[Function]}
     priority="normal"

--- a/packages/venia-ui/lib/components/MiniCart/cartOptions.js
+++ b/packages/venia-ui/lib/components/MiniCart/cartOptions.js
@@ -88,15 +88,15 @@ const CartOptions = props => {
                 </section>
             </div>
             <div className={classes.save}>
-                <Button onClick={handleCancel}>
-                    <span>Cancel</span>
-                </Button>
                 <Button
                     priority="high"
                     onClick={handleUpdate}
                     disabled={isUpdateDisabled}
                 >
                     <span>Update Cart</span>
+                </Button>
+                <Button onClick={handleCancel} priority="low">
+                    <span>Cancel</span>
                 </Button>
             </div>
         </Form>

--- a/packages/venia-ui/lib/components/ProductSort/__tests__/__snapshots__/productSort.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductSort/__tests__/__snapshots__/productSort.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`renders correctly 1`] = `
 <div>
   <button
+    disabled={false}
     onClick={[Function]}
     type="button"
   >


### PR DESCRIPTION
## Description
Resolve remaining issues with Buttons implementation 

## Related Issue
https://jira.corp.magento.com/browse/PWA-722

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
@sirugh 
@jimbo 
@dpatil-magento 

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
Issue 1 - In Mobile view "Reset Filter" button does not get disabled after first tap.
Steps - 
1. Go any category in mobile view
2. Hit filter button and apply a filter
3. Tap on Reset filter button
Issue 2 - Mini Cart Edit product Cancel button UI and order of display is not consistent with other buttons of Venia.
Steps- 
1. Add any product to cart.
2. In mini cart go to edit product window

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
