### PR TITLE
Update home page route

### DIFF
--- a/packages/venia-ui/lib/components/Routes/routes.js
+++ b/packages/venia-ui/lib/components/Routes/routes.js
@@ -15,7 +15,7 @@ const Routes = () => {
             <Switch>
                 <Route>
                     <MagentoRoute />
-                    <Route exact path="/venia-new-home">
+                    <Route exact path="/">
                         <HomePage />
                     </Route>
                 </Route>


### PR DESCRIPTION
## Description

Update the home page route from `/venia-new-home` to `/`. This approach is still not ideal.

## Related Issue

PWA-769

## Acceptance 

### Verification Stakeholders

- @dpatil-magento 
- @soumya-ashok 

### Specification

### Verification Steps
1. Ensure the home page has been set on the backend.
1. Go to the home page.
1. Verify the page is styled correctly.

## Screenshots / Screen Captures (if appropriate)

## Checklist
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
