### PR TITLE
fix: remove rimraf from security package

### DIFF
--- a/packages/extensions/upward-security-headers/package.json
+++ b/packages/extensions/upward-security-headers/package.json
@@ -15,12 +15,14 @@
   "peerDependencies": {
     "@magento/pwa-buildpack": "^5.1.1",
     "@magento/venia-ui": "^3.0.0",
-    "rimraf": "~2.6.3",
     "webpack": "~4.38.0"
   },
   "pwa-studio": {
     "targets": {
       "intercept": "./intercept"
     }
+  },
+  "devDependencies": {
+    "rimraf": "~2.6.3"
   }
 }

--- a/packages/extensions/upward-security-headers/package.json
+++ b/packages/extensions/upward-security-headers/package.json
@@ -21,8 +21,5 @@
     "targets": {
       "intercept": "./intercept"
     }
-  },
-  "devDependencies": {
-    "rimraf": "~2.6.3"
   }
 }


### PR DESCRIPTION
## Description

For some reason `rimraf` as a peer dependency in the upward security headers package was causing odd failures when trying to add a dependency to a package.

Moving rimraf to a `devDependency`, or just removing it entirely, fixed the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Check out this PR.
2. `yarn install`
3. `yarn workspace @magento/venia-concept add -D apollo-link-batch-http`
4. Verify that no error occurred when trying to add a dev dependency to venia-concept.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
