### PR TITLE
Use region id when possible, otherwise use raw text value

### DIFF
--- a/packages/peregrine/lib/talons/CheckoutPage/AddressBook/useAddressCard.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/AddressBook/useAddressCard.js
@@ -29,15 +29,15 @@ export const useAddressCard = props => {
 
     const addressForEdit = useMemo(() => {
         const { country_code: countryCode, region, ...addressRest } = address;
-        const { region_id: regionId } = region;
-
+        const { region_id: regionId, region_code: regionCode } = region;
         return {
             ...addressRest,
             country: {
                 code: countryCode
             },
             region: {
-                id: regionId
+                id: regionId,
+                code: regionCode
             }
         };
     }, [address]);


### PR DESCRIPTION
## Description

The `createCustomerAddress` mutation requires different input for `region` depending on the `country`. If a country has `available_regions`, we should send the `region_id`. If it doesn't, we can send the raw text such as "Scotland".

To determine what to send we check the possible regions for the selected country at submission and send the formatted `region` input accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-874](https://jira.corp.magento.com/browse/PWA-874).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to Venia storefront and create an new account or Sign in to account which does not have address.
2. Add product to cart and go to checkout page.
3. Enter shipping address for United Kngdom.
4. Click on Save button.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
