### PR TITLE
Deprecate getUnionAndInterfaceTypes function

### DIFF
--- a/packages/pwa-buildpack/lib/Utilities/graphQL.js
+++ b/packages/pwa-buildpack/lib/Utilities/graphQL.js
@@ -45,7 +45,7 @@ const getSchemaTypes = () => {
 };
 
 /**
- * @deprecated use getPossibleTypes with ApolloClient v3.
+ * @deprecated use {@link getPossibleTypes} with ApolloClient v3.
  *
  * Get only the Union and Interface types in the schema.
  */

--- a/packages/pwa-buildpack/lib/Utilities/graphQL.js
+++ b/packages/pwa-buildpack/lib/Utilities/graphQL.js
@@ -45,6 +45,8 @@ const getSchemaTypes = () => {
 };
 
 /**
+ * @deprecated use getPossibleTypes with ApolloClient v3.
+ *
  * Get only the Union and Interface types in the schema.
  */
 const getUnionAndInterfaceTypes = () => {


### PR DESCRIPTION
## Description

Missed a deprecation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the FOO page.
2. Verify the BAR shows up.
3. Make sure BAZ does a thing.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
