### PR TITLE
Use credentials on service worker revalidation

### DIFF
--- a/packages/venia-concept/src/ServiceWorker/registerRoutes.js
+++ b/packages/venia-concept/src/ServiceWorker/registerRoutes.js
@@ -79,6 +79,9 @@ export default function() {
     registerRoute(
         ({ url }) => isHTMLRoute(url),
         new StaleWhileRevalidate({
+            fetchOptions: {
+                credentials: 'same-origin',
+            },
             plugins: [
                 {
                     cacheKeyWillBeUsed: () => 'index.html'


### PR DESCRIPTION
## Description
Precache already includes credentials - revalidation should too.

https://github.com/GoogleChrome/workbox/blob/v6/packages/workbox-precaching/src/PrecacheController.ts#L358

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the FOO page.
2. Verify the BAR shows up.
3. Make sure BAZ does a thing.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
