### PR TITLE
PDPs show intended Product only

### DIFF
--- a/packages/peregrine/lib/talons/RootComponents/Product/__tests__/useProduct.spec.js
+++ b/packages/peregrine/lib/talons/RootComponents/Product/__tests__/useProduct.spec.js
@@ -96,12 +96,12 @@ test('product is null when items array is empty', () => {
     expect(product).toBeNull();
 });
 
-test('product is null when items array contains unsupported product types only', () => {
+test('product is null when items array doesnt contain requested urlKey', () => {
     // Arrange.
     useQuery.mockReturnValueOnce({
         data: {
             products: {
-                items: [{ name: 'INVALID', __typename: 'GroupedProduct' }]
+                items: [{ name: 'INVALID', url_key: 'INVALID' }]
             }
         },
         error: null,
@@ -117,15 +117,14 @@ test('product is null when items array contains unsupported product types only',
     expect(product).toBeNull();
 });
 
-test('product is the first supported product type', () => {
+test('product is correct when included in items array', () => {
     // Arrange.
     useQuery.mockReturnValueOnce({
         data: {
             products: {
                 items: [
-                    { name: 'INVALID', __typename: 'GroupedProduct' },
-                    { name: 'VALID', __typename: 'SimpleProduct' },
-                    { name: 'VALID', __typename: 'ConfigurableProduct' }
+                    { name: 'INVALID', url_key: 'INVALID' },
+                    { name: 'VALID', url_key: props.urlKey }
                 ]
             }
         },
@@ -139,5 +138,5 @@ test('product is the first supported product type', () => {
     // Assert.
     const talonProps = log.mock.calls[0][0];
     const { product } = talonProps;
-    expect(product).toEqual({ name: 'VALID', __typename: 'SimpleProduct' });
+    expect(product).toEqual({ name: 'VALID', url_key: props.urlKey });
 });

--- a/packages/peregrine/lib/talons/RootComponents/Product/__tests__/useProduct.spec.js
+++ b/packages/peregrine/lib/talons/RootComponents/Product/__tests__/useProduct.spec.js
@@ -1,0 +1,143 @@
+import React, { useEffect } from 'react';
+import { useQuery } from '@apollo/client';
+import { createTestInstance } from '@magento/peregrine';
+
+import { useProduct } from '../useProduct';
+
+jest.mock('@apollo/client', () => {
+    const queryResult = {
+        loading: false,
+        error: null,
+        data: null
+    };
+    const useQuery = jest.fn(() => {
+        queryResult;
+    });
+
+    return { useQuery };
+});
+
+const log = jest.fn();
+const Component = props => {
+    const talonProps = useProduct({ ...props });
+
+    useEffect(() => {
+        log(talonProps);
+    }, [talonProps]);
+
+    return null;
+};
+
+const props = {
+    mapProduct: jest.fn(product => product),
+    queries: {
+        getProductQuery: 'getProductQuery'
+    },
+    urlKey: 'unit_test'
+};
+
+test('it returns the proper shape', () => {
+    // Arrange.
+    useQuery.mockReturnValueOnce({
+        data: {
+            products: {
+                items: []
+            }
+        },
+        error: null,
+        loading: false
+    });
+
+    // Act.
+    createTestInstance(<Component {...props} />);
+
+    // Assert.
+    const talonProps = log.mock.calls[0][0];
+    const actualKeys = Object.keys(talonProps);
+    const expectedKeys = ['error', 'loading', 'product'];
+    expect(actualKeys.sort()).toEqual(expectedKeys.sort());
+});
+
+test('product is null when data is falsy', () => {
+    // Arrange.
+    useQuery.mockReturnValueOnce({
+        data: null,
+        error: null,
+        loading: false
+    });
+
+    // Act.
+    createTestInstance(<Component {...props} />);
+
+    // Assert.
+    const talonProps = log.mock.calls[0][0];
+    const { product } = talonProps;
+    expect(product).toBeNull();
+});
+
+test('product is null when items array is empty', () => {
+    // Arrange.
+    useQuery.mockReturnValueOnce({
+        data: {
+            products: {
+                items: []
+            }
+        },
+        error: null,
+        loading: false
+    });
+
+    // Act.
+    createTestInstance(<Component {...props} />);
+
+    // Assert.
+    const talonProps = log.mock.calls[0][0];
+    const { product } = talonProps;
+    expect(product).toBeNull();
+});
+
+test('product is null when items array contains unsupported product types only', () => {
+    // Arrange.
+    useQuery.mockReturnValueOnce({
+        data: {
+            products: {
+                items: [{ name: 'INVALID', __typename: 'GroupedProduct' }]
+            }
+        },
+        error: null,
+        loading: false
+    });
+
+    // Act.
+    createTestInstance(<Component {...props} />);
+
+    // Assert.
+    const talonProps = log.mock.calls[0][0];
+    const { product } = talonProps;
+    expect(product).toBeNull();
+});
+
+test('product is the first supported product type', () => {
+    // Arrange.
+    useQuery.mockReturnValueOnce({
+        data: {
+            products: {
+                items: [
+                    { name: 'INVALID', __typename: 'GroupedProduct' },
+                    { name: 'VALID', __typename: 'SimpleProduct' },
+                    { name: 'VALID', __typename: 'ConfigurableProduct' }
+                ]
+            }
+        },
+        error: null,
+        loading: false
+    });
+
+    // Act.
+    createTestInstance(<Component {...props} />);
+
+    // Assert.
+    const talonProps = log.mock.calls[0][0];
+    const { product } = talonProps;
+    expect(product).toEqual({ name: 'VALID', __typename: 'SimpleProduct' });
+});

--- a/packages/peregrine/lib/talons/RootComponents/Product/useProduct.js
+++ b/packages/peregrine/lib/talons/RootComponents/Product/useProduct.js
@@ -1,11 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { useMemo } from 'react';
 
-const VENIA_SUPPORTED_PRODUCT_TYPES = ['SimpleProduct', 'ConfigurableProduct'];
-const isSupportedProductType = product => {
-    return VENIA_SUPPORTED_PRODUCT_TYPES.includes(product.__typename);
-};
-
 /**
  * A [React Hook]{@link https://reactjs.org/docs/hooks-intro.html} that
  * controls the logic for the Product Root Component.
@@ -39,19 +34,20 @@ export const useProduct = props => {
             return null;
         }
 
-        const supportedProducts = data.products.items.filter(
-            isSupportedProductType
-        );
-        // If a product is out of stock _and_ the backend specifies not to
+        // Note: if a product is out of stock _and_ the backend specifies not to
         // display OOS items, the items array will be empty.
-        // Additionally, we may have an empty array after filtering out unsupported product types.
-        if (!supportedProducts.length) {
+
+        // Only return the product that we queried for.
+        const product = data.products.items.find(
+            item => item.url_key === urlKey
+        );
+
+        if (!product) {
             return null;
         }
 
-        // Pick the first supported product.
-        return mapProduct(supportedProducts[0]);
-    }, [data, mapProduct]);
+        return mapProduct(product);
+    }, [data, mapProduct, urlKey]);
 
     return {
         error,


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Venia does not support Grouped, Bundled, or Virtual products yet, but the Venia sample data does include them.
This PR adds a bit of filtering logic into the `useProduct` root component talon to only return the `product` we requested (by `url_key`).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes PWA-895.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->

1. Set your `MAGENTO_BACKEND_URL` to a `2.4.1+` backend (this PR deployment may be that already)
1. Go to the `/gold-veritas-cuff-set.html` page
1. See that you are presented with the simple product, not the bundled product set

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [x] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
