### PR TITLE
fix: storybook i18n

### DIFF
--- a/packages/venia-ui/.storybook/config.js
+++ b/packages/venia-ui/.storybook/config.js
@@ -4,6 +4,7 @@ import { Adapter } from '@magento/venia-drivers';
 import store from '@magento/venia-concept/src/store';
 import '../lib/index.css';
 import { PeregrineContextProvider } from '@magento/peregrine';
+import ContextProvider from '../lib/components/App/contextProvider';
 
 function loadStories() {
     const context = require.context('../lib', true, /__stories__\/.+\.js$/);
@@ -19,7 +20,7 @@ addDecorator(storyFn => (
         apollo={{ link: Adapter.apolloLink(apiBase) }}
         store={store}
     >
-        <PeregrineContextProvider>{storyFn()}</PeregrineContextProvider>
+        <ContextProvider>{storyFn()}</ContextProvider>
     </Adapter>
 ));
 

--- a/packages/venia-ui/.storybook/webpack.config.js
+++ b/packages/venia-ui/.storybook/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const {
-    graphQL: { getPossibleTypes },
+    graphQL: { getPossibleTypes, getStoreConfigData },
     Utilities: { loadEnvironment }
 } = require('@magento/pwa-buildpack');
 const baseWebpackConfig = require('@magento/venia-concept/webpack.config');
@@ -22,6 +22,8 @@ module.exports = async ({ config: storybookBaseConfig, mode }) => {
     }
 
     const possibleTypes = await getPossibleTypes();
+    const storeConfigData = await getStoreConfigData();
+    global.LOCALE = storeConfigData.locale.replace('_', '-');
 
     const webpackConfig = await baseWebpackConfig(mode);
 
@@ -33,7 +35,11 @@ module.exports = async ({ config: storybookBaseConfig, mode }) => {
         ...storybookBaseConfig.plugins,
         new DefinePlugin({
             POSSIBLE_TYPES: JSON.stringify(possibleTypes),
-            STORE_NAME: JSON.stringify('Storybook')
+            STORE_NAME: JSON.stringify('Storybook'),
+            STORE_VIEW_LOCALE: JSON.stringify(global.LOCALE),
+            STORE_VIEW_CODE: process.env.STORE_VIEW_CODE
+                ? JSON.stringify(process.env.STORE_VIEW_CODE)
+                : JSON.stringify(storeConfigData.code)
         }),
         new EnvironmentPlugin(projectConfig.env),
         new ReactRefreshWebpackPlugin()

--- a/packages/venia-ui/lib/components/Header/__stories__/header.js
+++ b/packages/venia-ui/lib/components/Header/__stories__/header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { useAppContext } from '@magento/peregrine/lib/context/app';
@@ -17,7 +17,9 @@ stories.add('Search Bar Open', () => {
         const { toggleSearch } = api;
 
         // Open the search
-        toggleSearch();
+        useEffect(() => {
+            toggleSearch();
+        }, [toggleSearch]);
 
         return <Header classes={defaultClasses} />;
     };


### PR DESCRIPTION
## Description

We added i18n stuff to the [venia webpack config](https://github.com/magento/pwa-studio/blob/develop/packages/venia-concept/webpack.config.js#L57-L60) but did not add it to the venia-ui storybook config.

We also did not wrap storybook entry in the venia-ui provider, which is where we connected the `LocaleProvider` among others.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-907](https://jira.corp.magento.com/browse/PWA-907).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. `yarn storybook:venia`
2. Verify each story loads and renders. You may see errors in console related to GQL but that is because the dummy backend doesn't return data. 
3. Verify that scaffolded storybook works.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
