### PR TITLE
Remove max-height on code blocks in dev docs

### DIFF
--- a/pwa-devdocs/src/_scss/src/_code-block-style-overrides.scss
+++ b/pwa-devdocs/src/_scss/src/_code-block-style-overrides.scss
@@ -1,3 +1,7 @@
+.highlight {
+    max-height: none;
+}
+
 .highlight .gd,
 .highlight .gi {
     border: none;


### PR DESCRIPTION
## Description

In dev docs, code blocks have a max-height of 700px. I think this comes from Spectrum.

It's a bad default for dev docs, because it introduces multiple scrolling regions in long detailed technical documents. It causes code sample to "cut off" abruptly before the end of the sample. Depending on the OS there's no indication that content is missing due the inner scroll region.

For technical docs, it's better to just let code blocks have intrinsic height. Let the window scroll with no inner regions. It doesn't matter if the document is long or individual code blocks are long. Readability is most important.


## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the FOO page.
2. Verify the BAR shows up.
3. Make sure BAZ does a thing.

## Screenshots / Screen Captures (if appropriate)

### Before
Note: code is cut off with no visual indication that's happening.

<img width="1086" alt="Screen Shot 2020-09-18 at 3 53 33 PM" src="https://user-images.githubusercontent.com/214924/93651680-27d06b80-f9c7-11ea-8ddb-9b240c822b8d.png">

### After 

<img width="1077" alt="Screen Shot 2020-09-18 at 3 53 18 PM" src="https://user-images.githubusercontent.com/214924/93651672-1f783080-f9c7-11ea-8016-47c9df5ded58.png">


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
