### PR TITLE
[PWA-881] Reset Password follow up

### DIFF
--- a/packages/peregrine/lib/talons/MyAccount/useResetPassword.js
+++ b/packages/peregrine/lib/talons/MyAccount/useResetPassword.js
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 
@@ -25,11 +25,20 @@ export const useResetPassword = props => {
     const searchParams = useMemo(() => new URLSearchParams(location.search), [
         location
     ]);
-    const email = searchParams.get('email');
     const token = searchParams.get('token');
 
+    // We could fetch email from session cookie and pre-fill form, but likely
+    // still need the input there just in case.
+    useEffect(() => {
+        console.log('Retrieving email from session cookie: ', document.cookie);
+
+        // We would likely destroy the cookie after retrieval here making it one time use
+        // and limiting the XSS vector, though it is open between the time reset is initiated
+        // to reset link is clicked (or browser is closed).
+    }, []);
+
     const handleSubmit = useCallback(
-        async ({ newPassword }) => {
+        async ({ email, newPassword }) => {
             try {
                 if (email && token && newPassword) {
                     await resetPassword({
@@ -42,11 +51,10 @@ export const useResetPassword = props => {
                 setHasCompleted(false);
             }
         },
-        [resetPassword, email, token]
+        [resetPassword, token]
     );
 
     return {
-        email,
         formErrors: [resetPasswordErrors],
         handleSubmit,
         hasCompleted,

--- a/packages/venia-ui/lib/components/ForgotPassword/forgotPassword.js
+++ b/packages/venia-ui/lib/components/ForgotPassword/forgotPassword.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import { func, shape, string } from 'prop-types';
 
 import { useForgotPassword } from '@magento/peregrine/lib/talons/ForgotPassword/useForgotPassword';
@@ -33,6 +33,10 @@ const ForgotPassword = props => {
     } = talonProps;
 
     const classes = mergeClasses(defaultClasses, props.classes);
+
+    useEffect(() => {
+        document.cookie = 'email_in_session_cookie=fry@planetexpress.com';
+    }, []);
 
     const children = hasCompleted ? (
         <FormSubmissionSuccessful email={forgotPasswordEmail} />

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.css
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.css
@@ -14,7 +14,7 @@
 .container {
     display: grid;
     gap: 1.5rem;
-    grid-template-columns: 2fr auto;
+    grid-template-columns: 1fr 1fr;
     margin: 2rem 7rem;
     padding: 3rem;
     border: 2px solid rgb(var(--venia-global-color-gray-400));
@@ -22,25 +22,20 @@
 }
 
 .description {
-    grid-row: 1 / span 1;
-    grid-column: 1 / span 2;
-    padding-bottom: 0.5rem;
     font-size: var(--venia-global-typography-heading-M-fontSize);
+    grid-column-end: span 2;
     line-height: var(--venia-global-typography-heading-lineHeight);
+    padding-bottom: 0.5rem;
 }
 
-.password {
-    grid-row: 2 / span 1;
-    grid-column: 1 / span 1;
+.email {
+    grid-column-end: span 2;
 }
 
 .submitButton {
     composes: root_highPriority from '../../Button/button.css';
-
-    grid-row: 2 / span 1;
-    grid-column: 2 / span 1;
-    margin: auto;
-    margin-top: 2rem;
+    grid-column-end: span 2;
+    justify-self: center;
 }
 
 .invalidTokenContainer {
@@ -88,31 +83,21 @@
     }
 
     .container {
-        display: grid;
         border: none;
-        margin: 0rem;
-        padding: 0rem;
+        display: grid;
+        grid-template-columns: none;
+        margin: 0;
+        padding: 0;
     }
 
-    .description {
-        grid-row: 1 / span 1;
-        grid-column: 1 / span 2;
-        padding-bottom: 0.5rem;
+    .description,
+    .email,
+    .submitButton {
+        grid-column-end: auto;
     }
 
     .password {
-        grid-row: 2 / span 1;
-        grid-column: 1 / span 2;
         min-height: 5rem;
-    }
-
-    .submitButton {
-        composes: root_highPriority from '../../Button/button.css';
-
-        grid-row: 3 / span 1;
-        grid-column: 1 / span 2;
-        margin: auto;
-        margin-top: 1rem;
     }
 
     .invalidTokenContainer {

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
@@ -6,15 +6,15 @@ import { useToasts } from '@magento/peregrine';
 import { useResetPassword } from '@magento/peregrine/lib/talons/MyAccount/useResetPassword';
 import { mergeClasses } from '@magento/venia-ui/lib/classify';
 
-import { Title } from '../../Head';
-
 import Button from '../../Button';
 import FormErrors from '../../FormError';
-
-import resetPasswordOperations from './resetPassword.gql';
-
-import defaultClasses from './resetPassword.css';
+import { Title } from '../../Head';
 import Password from '../../Password';
+import defaultClasses from './resetPassword.css';
+import resetPasswordOperations from './resetPassword.gql';
+import TextInput from '../../TextInput/textInput';
+import Field from '../../Field';
+import { isRequired } from '../../../util/formValidators';
 
 const PAGE_TITLE = `Reset Password`;
 
@@ -27,7 +27,6 @@ const ResetPassword = props => {
     const {
         hasCompleted,
         loading,
-        email,
         token,
         formErrors,
         handleSubmit
@@ -66,6 +65,9 @@ const ResetPassword = props => {
             <div className={classes.description}>
                 Please enter your new password.
             </div>
+            <Field label={'Email'}>
+                <TextInput field={'email'} validate={isRequired} />
+            </Field>
             <Password
                 classes={{ root: classes.password }}
                 label={'New Password'}
@@ -91,7 +93,7 @@ const ResetPassword = props => {
         <div className={classes.root}>
             <Title>{`${PAGE_TITLE} - ${STORE_NAME}`}</Title>
             <h1 className={classes.heading}>{PAGE_TITLE}</h1>
-            {token && email ? recoverPassword : tokenMissing}
+            {token ? recoverPassword : tokenMissing}
         </div>
     );
 };


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Issues -
1. Explore ways to configure storefront domains in reset email link.
2. Remove Email from reset pwd URL (I have checked in multiple websites but non shows email in url)

## Solution
1. Using our new `STORE_VIEW_CODE` functionality created for i18n, this solution is really simple. For each storefront that you need to support with your backend, create a new Store View and configure the appropriate URLs. On my local I created a Store View `vanity`, and then configured base and secure URLs to my local Venia storefront URL; this resulted in correct links in password reset emails.

This bundled with appropriate CI/CD changes, a single backend can support multiple deployed storefronts, as long as they are deployed with the correct `STORE_VIEW_CODE` environment variable.

![Screen Shot 2020-09-21 at 12 14 01 PM](https://user-images.githubusercontent.com/462953/93799163-60a95400-fc04-11ea-9518-35e9703f626b.png)

2. This Draft PR includes the required changes to use the stock password reset URL and parameters by adding a manual entry email input. This would need some UX treatment, but a working example that this is possible.

I've additionally included a PoC for using a session cookie to temporarily store the email address entered, to help avoid the need for manual entry. We would still likely include the field as we can't guarantee the user returns to the same browser or doesn't open the link in a private session, but we pre-fill/hide when we can. This solution is not 100% secure, but I feel could be acceptable given:
- We add `Secure` and `SameSite` restrictions to prevent CSRF
- We do not add an expiration so the cookie is destroyed automatically when the browser is closed (covers abandoned reset request)
- We destroy the cookie as soon as the value is retrieved

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-881](https://jira.corp.magento.com/browse/PWA-881)] Reset Password follow up

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the FOO page.
2. Verify the BAR shows up.
3. Make sure BAZ does a thing.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
