### PR TITLE
[PWA-929] PageBuilder slider buttons not visible and links are displaying as button.

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/ButtonItem/buttonItem.css
+++ b/packages/pagebuilder/lib/ContentTypes/ButtonItem/buttonItem.css
@@ -1,0 +1,3 @@
+.linkButton {
+    text-decoration: underline;
+}

--- a/packages/pagebuilder/lib/ContentTypes/ButtonItem/buttonItem.js
+++ b/packages/pagebuilder/lib/ContentTypes/ButtonItem/buttonItem.js
@@ -1,8 +1,11 @@
 import React, { useCallback } from 'react';
-import Button from '@magento/venia-ui/lib/components/Button/button';
 import { arrayOf, oneOf, string, bool } from 'prop-types';
-import resolveLinkProps from '../../resolveLinkProps';
 import { useHistory } from '@magento/venia-drivers';
+import { mergeClasses } from '@magento/venia-ui/lib/classify';
+import Button from '@magento/venia-ui/lib/components/Button/button';
+
+import resolveLinkProps from '../../resolveLinkProps';
+import defaultClasses from './buttonItem.css';
 
 /**
  * Page Builder ButtonItem component.
@@ -17,6 +20,8 @@ import { useHistory } from '@magento/venia-drivers';
  * @returns {React.Element} A React component that displays a button.
  */
 const ButtonItem = props => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
     const {
         buttonType,
         link,
@@ -92,16 +97,21 @@ const ButtonItem = props => {
         dynamicInnerStyles.textAlign = textAlign;
     }
 
+    const buttonProps = {
+        onClick: handleClick,
+        priority: typeToPriorityMapping[buttonType],
+        style: dynamicInnerStyles,
+        type: 'button'
+    };
+
+    // Custom style link type until PWA-937 adds link styled buttons
+    if (buttonType === 'link') {
+        buttonProps.className = classes.linkButton;
+    }
+
     return (
         <div className={cssClasses.length ? cssClasses.join(' ') : undefined}>
-            <Button
-                priority={typeToPriorityMapping[buttonType]}
-                type="button"
-                onClick={handleClick}
-                style={dynamicInnerStyles}
-            >
-                {text}
-            </Button>
+            <Button {...buttonProps}>{text}</Button>
         </div>
     );
 };

--- a/packages/pagebuilder/lib/ContentTypes/Slider/slider.css
+++ b/packages/pagebuilder/lib/ContentTypes/Slider/slider.css
@@ -184,7 +184,7 @@
 }
 .root :global .slick-dots li button {
     outline: none;
-    background: rgb(var(--venia-grey-dark));
+    background: rgb(var(--venia-global-color-gray-dark));
     filter: brightness(100%);
     border-radius: 10px;
     box-shadow: none;

--- a/packages/pagebuilder/lib/ContentTypes/Tabs/tabs.css
+++ b/packages/pagebuilder/lib/ContentTypes/Tabs/tabs.css
@@ -83,7 +83,7 @@ ul.navigation::-webkit-scrollbar {
 
 .root ul li.header {
     list-style: none;
-    background: rgb(var(--venia-grey));
+    background: rgb(var(--venia-global-color-gray));
     border: var(--tabs-border-width) var(--tabs-border) var(--tabs-border-color);
     border-bottom: 0;
     border-top-left-radius: var(--tabs-border-radius);
@@ -95,7 +95,7 @@ ul.navigation::-webkit-scrollbar {
     position: relative;
     word-wrap: break-word;
     z-index: 1;
-    color: rgb(var(--venia-text));
+    color: rgb(var(--venia-global-color-text));
     cursor: pointer !important;
     font-size: 14px;
     font-weight: 600;


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

URL - https://venia-smoketest-x3mnlqi-c5v7sxvquxwl4.eu-4.magentosite.cloud/

Steps - 

Go to home page 
Verify page UI
 

Expected -  Page UI elements should be visible and Link element should be displayed as links.

Actual - Slider buttons exists but not visible. And link elements are displaying as buttons. PFA screen (top one is 8.0 and bottom one is 7.0)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-929](https://jira.corp.magento.com/browse/PWA-929)] PageBuilder slider buttons not visible and links are displaying as button.

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Slider Icons
1. Go to Home
2. Verify inactive slider icons now render as expected
3. Additionally verify Tab background and font color is now in line with Venia style

Link Button
1. On a local, edit your Home Page to include a Link type Button
2. Go to home in PWA, verify that your button renders similar to "Edit Shopping Bag" in MiniCart

## Screenshots / Screen Captures (if appropriate)
![Screen Shot 2020-09-23 at 9 51 00 AM](https://user-images.githubusercontent.com/462953/94029348-54e39c00-fd82-11ea-8cb2-687b09300929.png)
![Screen Shot 2020-09-23 at 9 49 02 AM](https://user-images.githubusercontent.com/462953/94029355-56ad5f80-fd82-11ea-8524-1474400ffcfa.png)


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
