### PR TITLE
fix: Continue to Payment Information button gets enabled even before Payment section starts loading.

### DIFF
--- a/packages/peregrine/lib/talons/CheckoutPage/__tests__/useShippingMethod.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/__tests__/useShippingMethod.spec.js
@@ -133,6 +133,31 @@ test('returns Apollo error', () => {
     expect(talonProps.formErrors).toMatchSnapshot();
 });
 
+test('should setPageIsUpdating to mutation loading state', () => {
+    const setShippingMethod = jest.fn();
+    useMutation.mockReturnValueOnce([
+        setShippingMethod,
+        {
+            loading: false
+        }
+    ]);
+
+    createTestInstance(<Component {...props} />);
+
+    expect(setPageIsUpdating.mock.calls[0][0]).toEqual(false);
+
+    useMutation.mockReturnValueOnce([
+        setShippingMethod,
+        {
+            loading: true
+        }
+    ]);
+
+    createTestInstance(<Component {...props} />);
+
+    expect(setPageIsUpdating.mock.calls[1][0]).toEqual(true);
+});
+
 test('handleSubmit fires necessary mutations and callbacks', async () => {
     const setShippingMethod = jest.fn();
     useMutation.mockReturnValueOnce([setShippingMethod, {}]);
@@ -159,8 +184,6 @@ test('handleSubmit fires necessary mutations and callbacks', async () => {
     talonProps = log.mock.calls[2][0];
 
     expect(mutationProps).toMatchSnapshot();
-    expect(setPageIsUpdating.mock.calls[0][0]).toEqual(true);
-    expect(setPageIsUpdating.mock.calls[1][0]).toEqual(false);
     expect(talonProps.isUpdateMode).toEqual(false);
 });
 
@@ -184,8 +207,6 @@ test('handleSubmit bails on thrown exception', async () => {
         await handleSubmit({ shipping_method: 'usps|flatrate' });
     });
 
-    expect(setPageIsUpdating.mock.calls[0][0]).toEqual(true);
-    expect(setPageIsUpdating.mock.calls[1][0]).toEqual(false);
     // a bit fragile, but the only check we can do is that our component state
     // didn't change because of the caught exception and has not rendered again
     expect(log).toHaveBeenCalledTimes(2);

--- a/packages/peregrine/lib/talons/CheckoutPage/useShippingMethod.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/useShippingMethod.js
@@ -128,8 +128,6 @@ export const useShippingMethod = props => {
                 value.shipping_method
             );
 
-            setPageIsUpdating(true);
-
             try {
                 await setShippingMethodCall({
                     variables: {
@@ -142,13 +140,11 @@ export const useShippingMethod = props => {
                 });
             } catch {
                 return;
-            } finally {
-                setPageIsUpdating(false);
             }
 
             setIsUpdateMode(false);
         },
-        [cartId, setIsUpdateMode, setPageIsUpdating, setShippingMethodCall]
+        [cartId, setIsUpdateMode, setShippingMethodCall]
     );
 
     const handleCancelUpdate = useCallback(() => {
@@ -170,6 +166,10 @@ export const useShippingMethod = props => {
             onSave();
         }
     }, [hasData, onSave]);
+
+    useEffect(() => {
+        setPageIsUpdating(isSettingShippingMethod);
+    }, [isLoadingShippingMethods, isSettingShippingMethod, setPageIsUpdating]);
 
     // If an authenticated user does not have a preferred shipping method,
     // auto-select the least expensive one for them.
@@ -218,7 +218,7 @@ export const useShippingMethod = props => {
         errors,
         handleCancelUpdate,
         handleSubmit,
-        isLoading: isLoadingShippingMethods,
+        isLoading: isLoadingShippingMethods || isSettingShippingMethod,
         isUpdateMode,
         selectedShippingMethod: derivedSelectedShippingMethod,
         shippingMethods: derivedShippingMethods,

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/shippingMethod.gql.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/shippingMethod.gql.js
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client';
 
 import { PriceSummaryFragment } from '@magento/venia-ui/lib/components/CartPage/PriceSummary/priceSummaryFragments';
+import { ShippingInformationFragment } from '../ShippingInformation/shippingInformationFragments.gql';
 
 import {
     AvailableShippingMethodsCheckoutFragment,
@@ -13,10 +14,16 @@ export const GET_SELECTED_AND_AVAILABLE_SHIPPING_METHODS = gql`
             id
             ...AvailableShippingMethodsCheckoutFragment
             ...SelectedShippingMethodCheckoutFragment
+            # We include the following fragments to avoid extra requeries
+            # after this mutation completes. This all comes down to not
+            # having ids for shipping address objects. With ids we could
+            # merge results.
+            ...ShippingInformationFragment
         }
     }
     ${AvailableShippingMethodsCheckoutFragment}
     ${SelectedShippingMethodCheckoutFragment}
+    ${ShippingInformationFragment}
 `;
 
 export const SET_SHIPPING_METHOD = gql`
@@ -36,14 +43,19 @@ export const SET_SHIPPING_METHOD = gql`
                 }
                 ...SelectedShippingMethodCheckoutFragment
                 ...PriceSummaryFragment
-                # Intentionally do not re-fetch available shipping methods because
-                #  a) they are wrong in the mutation response
-                #  b) it is expensive to recalculate.
+                # We include the following fragments to avoid extra requeries
+                # after this mutation completes. This all comes down to not
+                # having ids for shipping address objects. With ids we could
+                # merge results.
+                ...ShippingInformationFragment
+                ...AvailableShippingMethodsCheckoutFragment
             }
         }
     }
+    ${AvailableShippingMethodsCheckoutFragment}
     ${SelectedShippingMethodCheckoutFragment}
     ${PriceSummaryFragment}
+    ${ShippingInformationFragment}
 `;
 
 export default {

--- a/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/shippingMethod.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ShippingMethod/shippingMethod.js
@@ -91,14 +91,14 @@ const ShippingMethod = props => {
                     onSubmit={handleSubmit}
                 >
                     <ShippingRadios
-                        disabled={pageIsUpdating}
+                        disabled={pageIsUpdating || isLoading}
                         shippingMethods={shippingMethods}
                     />
                     <div className={classes.formButtons}>
                         <Button
                             priority="normal"
                             type="submit"
-                            disabled={pageIsUpdating}
+                            disabled={pageIsUpdating || isLoading}
                         >
                             {'Continue to Payment Information'}
                         </Button>


### PR DESCRIPTION
## Description

There is a bug due to either:

a) A bug in @apollo/client that makes refetches due to cache invalidations have `loading: false` **or**
b) Our inability to use `id` in our GQL `shipping_address` type 

When you click on the "Proceed to payment info" button, the button temporarily disables while the mutation for "selecting payment method" is in flight, but then re-enables before navigating to the next step.

To solve this we simply prevent the refetches from occurring, trusting that the data necessary will come back from the mutation.

If/when we finally get an `id` for each shipping address we can revert this change (and probably other changes related to type policy/merging).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-915](https://jira.corp.magento.com/browse/PWA-915).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Clear cache
2. Go to first item in tops, and add to cart.
3. Proceed to checkout and enter address. Click to go to method.
4. Select a non free method and click "proceed to payment info".
5. The button should disable immediately and never re-enable before you are navigated to the payment information view.
6. Verify that editing/changing the method once submitted also works.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
