### PR TITLE
[PWA-940] Forgot Password - Remove email from reset link

### DIFF
--- a/packages/peregrine/lib/talons/MyAccount/__tests__/__snapshots__/useResetPassword.spec.js.snap
+++ b/packages/peregrine/lib/talons/MyAccount/__tests__/__snapshots__/useResetPassword.spec.js.snap
@@ -2,7 +2,6 @@
 
 exports[`should render properly 1`] = `
 Object {
-  "email": "gooseton@adobe.com",
   "formErrors": Array [
     null,
   ],

--- a/packages/peregrine/lib/talons/MyAccount/__tests__/useResetPassword.spec.js
+++ b/packages/peregrine/lib/talons/MyAccount/__tests__/useResetPassword.spec.js
@@ -13,8 +13,7 @@ jest.mock('@apollo/client', () => ({
 }));
 jest.mock('react-router-dom', () => ({
     useLocation: jest.fn().mockReturnValue({
-        search:
-            '?email=gooseton%40adobe.com&token=eUokxamL1kiElLDjo6AQHYFO4XlK3'
+        search: '?token=eUokxamL1kiElLDjo6AQHYFO4XlK3'
     })
 }));
 
@@ -65,7 +64,10 @@ test('should set hasCompleted to true if submission is successful', async () => 
         }
     });
 
-    await talonProps.handleSubmit({ newPassword: 'NEW_PASSWORD' });
+    await talonProps.handleSubmit({
+        email: 'gooseton@adobe.com',
+        newPassword: 'NEW_PASSWORD'
+    });
     const newTalonProps = update();
 
     expect(newTalonProps.hasCompleted).toBeTruthy();
@@ -93,7 +95,10 @@ test('should set hasCompleted to false if submission is not successful', async (
         }
     });
 
-    await talonProps.handleSubmit({ newPassword: 'NEW_PASSWORD' });
+    await talonProps.handleSubmit({
+        email: 'gooseton@adobe.com',
+        newPassword: 'NEW_PASSWORD'
+    });
     const newTalonProps = update();
 
     expect(newTalonProps.hasCompleted).toBeFalsy();

--- a/packages/peregrine/lib/talons/MyAccount/useResetPassword.js
+++ b/packages/peregrine/lib/talons/MyAccount/useResetPassword.js
@@ -25,11 +25,10 @@ export const useResetPassword = props => {
     const searchParams = useMemo(() => new URLSearchParams(location.search), [
         location
     ]);
-    const email = searchParams.get('email');
     const token = searchParams.get('token');
 
     const handleSubmit = useCallback(
-        async ({ newPassword }) => {
+        async ({ email, newPassword }) => {
             try {
                 if (email && token && newPassword) {
                     await resetPassword({
@@ -42,11 +41,10 @@ export const useResetPassword = props => {
                 setHasCompleted(false);
             }
         },
-        [resetPassword, email, token]
+        [resetPassword, token]
     );
 
     return {
-        email,
         formErrors: [resetPasswordErrors],
         handleSubmit,
         hasCompleted,
@@ -75,7 +73,6 @@ export const useResetPassword = props => {
  *
  * @typedef {Object} ResetPasswordProps
  *
- * @property {String} email email address of the user whose password is beeing reset
  * @property {Array} formErrors A list of form errors
  * @property {Function} handleSubmit Callback function to handle form submission
  * @property {Boolean} hasCompleted True if password reset mutation has completed. False otherwise

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/__tests__/__snapshots__/resetPassword.spec.js.snap
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/__tests__/__snapshots__/resetPassword.spec.js.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should render error message if email is falsy 1`] = `
-<div>
-  <div>
-    Head Component
-  </div>
-  <h1>
-    Reset Password
-  </h1>
-  <div>
-    <div>
-      Uh oh, something went wrong. Check the link or try again.
-    </div>
-  </div>
-</div>
-`;
-
 exports[`should render error message if token is falsy 1`] = `
 <div>
   <div>
@@ -46,7 +30,32 @@ exports[`should render formErrors 1`] = `
     onSubmit={[Function]}
   >
     <div>
-      Please enter your new password.
+      Please enter your email address and new password.
+    </div>
+    <div>
+      <label>
+        Email address
+      </label>
+      <span
+        style={
+          Object {
+            "--iconsAfter": 0,
+            "--iconsBefore": 0,
+          }
+        }
+      >
+        <span>
+          <input
+            name="email"
+            onBlur={[Function]}
+            onChange={[Function]}
+            value=""
+          />
+        </span>
+        <span />
+        <span />
+      </span>
+      <p />
     </div>
     <div>
       <label>
@@ -109,7 +118,7 @@ exports[`should render formErrors 1`] = `
       type="submit"
     >
       <span>
-        SAVE
+        Save Password
       </span>
     </button>
   </form>
@@ -130,7 +139,32 @@ exports[`should render properly 1`] = `
     onSubmit={[Function]}
   >
     <div>
-      Please enter your new password.
+      Please enter your email address and new password.
+    </div>
+    <div>
+      <label>
+        Email address
+      </label>
+      <span
+        style={
+          Object {
+            "--iconsAfter": 0,
+            "--iconsBefore": 0,
+          }
+        }
+      >
+        <span>
+          <input
+            name="email"
+            onBlur={[Function]}
+            onChange={[Function]}
+            value=""
+          />
+        </span>
+        <span />
+        <span />
+      </span>
+      <p />
     </div>
     <div>
       <label>
@@ -193,7 +227,7 @@ exports[`should render properly 1`] = `
       type="submit"
     >
       <span>
-        SAVE
+        Save Password
       </span>
     </button>
   </form>

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/__tests__/resetPassword.spec.js
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/__tests__/resetPassword.spec.js
@@ -13,10 +13,9 @@ jest.mock('@magento/peregrine/lib/talons/MyAccount/useResetPassword', () => ({
     useResetPassword: jest.fn().mockReturnValue({
         hasCompleted: false,
         loading: false,
-        email: 'gooseton@goosemail.com',
         token: '********',
         formErrors: [],
-        handleSubmit: jest.fn()
+        handleSubmit: jest.fn().mockName('handleSubmit')
     })
 }));
 jest.mock('../../../Head', () => ({
@@ -33,23 +32,7 @@ test('should render error message if token is falsy', () => {
     useResetPassword.mockReturnValueOnce({
         hasCompleted: false,
         loading: false,
-        email: 'gooseton@goosemail.com',
         token: null,
-        formErrors: [],
-        handleSubmit: jest.fn()
-    });
-
-    const tree = createTestInstance(<ResetPassword />);
-
-    expect(tree.toJSON()).toMatchSnapshot();
-});
-
-test('should render error message if email is falsy', () => {
-    useResetPassword.mockReturnValueOnce({
-        hasCompleted: false,
-        loading: false,
-        email: null,
-        token: '**********',
         formErrors: [],
         handleSubmit: jest.fn()
     });
@@ -63,7 +46,6 @@ test('should render formErrors', () => {
     useResetPassword.mockReturnValueOnce({
         hasCompleted: false,
         loading: false,
-        email: 'gooseton@goosemail.com',
         token: '**********',
         formErrors: [
             {
@@ -84,7 +66,6 @@ test('should render success message if hasCompleted is true', () => {
     useResetPassword.mockReturnValueOnce({
         hasCompleted: true,
         loading: false,
-        email: 'gooseton@goosemail.com',
         token: '**********',
         formErrors: [],
         handleSubmit: jest.fn()
@@ -101,7 +82,6 @@ test('should render toast if hasCompleted is true', () => {
     useResetPassword.mockReturnValueOnce({
         hasCompleted: true,
         loading: false,
-        email: 'gooseton@goosemail.com',
         token: '**********',
         formErrors: [],
         handleSubmit: jest.fn()

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.css
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.css
@@ -5,16 +5,16 @@
 }
 
 .heading {
-    text-transform: capitalize;
+    font-family: var(--venia-global-fontFamily-serif);
     line-height: 1.25em;
     margin-bottom: 2.5rem;
     text-align: center;
+    text-transform: capitalize;
 }
 
 .container {
     display: grid;
     gap: 1.5rem;
-    grid-template-columns: 2fr auto;
     margin: 2rem 7rem;
     padding: 3rem;
     border: 2px solid rgb(var(--venia-global-color-gray-400));
@@ -22,25 +22,14 @@
 }
 
 .description {
-    grid-row: 1 / span 1;
-    grid-column: 1 / span 2;
-    padding-bottom: 0.5rem;
     font-size: var(--venia-global-typography-heading-M-fontSize);
     line-height: var(--venia-global-typography-heading-lineHeight);
-}
-
-.password {
-    grid-row: 2 / span 1;
-    grid-column: 1 / span 1;
+    padding-bottom: 0.5rem;
 }
 
 .submitButton {
     composes: root_highPriority from '../../Button/button.css';
-
-    grid-row: 2 / span 1;
-    grid-column: 2 / span 1;
-    margin: auto;
-    margin-top: 2rem;
+    justify-self: center;
 }
 
 .invalidTokenContainer {
@@ -88,37 +77,19 @@
     }
 
     .container {
-        display: grid;
         border: none;
-        margin: 0rem;
-        padding: 0rem;
-    }
-
-    .description {
-        grid-row: 1 / span 1;
-        grid-column: 1 / span 2;
-        padding-bottom: 0.5rem;
+        margin: 0;
+        padding: 0;
     }
 
     .password {
-        grid-row: 2 / span 1;
-        grid-column: 1 / span 2;
         min-height: 5rem;
-    }
-
-    .submitButton {
-        composes: root_highPriority from '../../Button/button.css';
-
-        grid-row: 3 / span 1;
-        grid-column: 1 / span 2;
-        margin: auto;
-        margin-top: 1rem;
     }
 
     .invalidTokenContainer {
         border: none;
         margin: auto;
-        padding: 0rem;
+        padding: 0;
     }
 
     .invalidToken {
@@ -130,6 +101,6 @@
     .successMessageContainer {
         border: none;
         margin: auto;
-        padding: 0rem;
+        padding: 0;
     }
 }

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
@@ -4,17 +4,17 @@ import { Form } from 'informed';
 
 import { useToasts } from '@magento/peregrine';
 import { useResetPassword } from '@magento/peregrine/lib/talons/MyAccount/useResetPassword';
-import { mergeClasses } from '@magento/venia-ui/lib/classify';
 
-import { Title } from '../../Head';
-
+import { mergeClasses } from '../../../classify';
+import { isRequired } from '../../../util/formValidators';
 import Button from '../../Button';
+import Field from '../../Field';
 import FormErrors from '../../FormError';
-
-import resetPasswordOperations from './resetPassword.gql';
-
-import defaultClasses from './resetPassword.css';
+import { Title } from '../../Head';
 import Password from '../../Password';
+import TextInput from '../../TextInput';
+import defaultClasses from './resetPassword.css';
+import resetPasswordOperations from './resetPassword.gql';
 
 const PAGE_TITLE = `Reset Password`;
 
@@ -27,7 +27,6 @@ const ResetPassword = props => {
     const {
         hasCompleted,
         loading,
-        email,
         token,
         formErrors,
         handleSubmit
@@ -64,8 +63,11 @@ const ResetPassword = props => {
     ) : (
         <Form className={classes.container} onSubmit={handleSubmit}>
             <div className={classes.description}>
-                Please enter your new password.
+                Please enter your email address and new password.
             </div>
+            <Field label={'Email address'}>
+                <TextInput field={'email'} validate={isRequired} />
+            </Field>
             <Password
                 classes={{ root: classes.password }}
                 label={'New Password'}
@@ -78,7 +80,7 @@ const ResetPassword = props => {
                 priority="high"
                 disabled={loading}
             >
-                {'SAVE'}
+                {'Save Password'}
             </Button>
             <FormErrors
                 classes={{ root: classes.errorMessage }}
@@ -91,7 +93,7 @@ const ResetPassword = props => {
         <div className={classes.root}>
             <Title>{`${PAGE_TITLE} - ${STORE_NAME}`}</Title>
             <h1 className={classes.heading}>{PAGE_TITLE}</h1>
-            {token && email ? recoverPassword : tokenMissing}
+            {token ? recoverPassword : tokenMissing}
         </div>
     );
 };


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Using this PR as reference, make the necessary changes that would allow removal of email address from the reset link URL. Since this can potentially expose PII, we'll instead rely on manual entry for now, while we discuss with the GraphQL team if requesting email again in this mutation is necessary.

Spike PR: https://github.com/magento/pwa-studio/pull/2719

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-940](https://jira.corp.magento.com/browse/PWA-940)] Forgot Password - Remove email from reset link

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Easiest to test this on a local, but you can do manual replacement of storefront URL if you don't want to bother with proper Store View setup.
1. (Optional) Add Store View and configure base URLs with your PWA URL
2. Initiate password reset, check your email/Mailhog (alternatively you can just manually navigate to `/customer/account/createPassword/?token=woof` to see new UX, but the form will not submit)
3. Follow link or manually replace URL in link to go to new password form
4. Verify that email field exists now
5. Enter email and new password, submit.
6. Verify you can sign in with new password

## Screenshots / Screen Captures (if appropriate)
![Screen Shot 2020-09-24 at 2 15 40 PM](https://user-images.githubusercontent.com/462953/94189665-a5392780-fe70-11ea-8eac-0812dc1e6e7f.png)
![Screen Shot 2020-09-24 at 2 15 54 PM](https://user-images.githubusercontent.com/462953/94189674-a79b8180-fe70-11ea-8158-6daccb0cc0d0.png)


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [x] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
