### PR TITLE
fix: offline homepage error

### DIFF
--- a/packages/peregrine/lib/talons/Cms/useCmsPage.js
+++ b/packages/peregrine/lib/talons/Cms/useCmsPage.js
@@ -21,7 +21,8 @@ export const useCmsPage = props => {
         variables: {
             id: Number(id)
         },
-        fetchPolicy: 'cache-and-network'
+        fetchPolicy: 'cache-and-network',
+        nextFetchPolicy: 'cache-first'
     });
 
     const [

--- a/packages/peregrine/lib/talons/Cms/useCmsPage.js
+++ b/packages/peregrine/lib/talons/Cms/useCmsPage.js
@@ -17,7 +17,7 @@ export const useCmsPage = props => {
         queries: { getCmsPage }
     } = props;
 
-    const { loading, data } = useQuery(getCmsPage, {
+    const { loading, error, data } = useQuery(getCmsPage, {
         variables: {
             id: Number(id)
         },
@@ -61,6 +61,7 @@ export const useCmsPage = props => {
     return {
         cmsPage,
         hasContent,
+        error,
         shouldShowLoadingIndicator
     };
 };

--- a/packages/peregrine/lib/talons/Cms/useCmsPage.js
+++ b/packages/peregrine/lib/talons/Cms/useCmsPage.js
@@ -17,7 +17,7 @@ export const useCmsPage = props => {
         queries: { getCmsPage }
     } = props;
 
-    const { loading, error, data } = useQuery(getCmsPage, {
+    const { loading, data } = useQuery(getCmsPage, {
         variables: {
             id: Number(id)
         },
@@ -61,7 +61,6 @@ export const useCmsPage = props => {
     return {
         cmsPage,
         hasContent,
-        error,
         shouldShowLoadingIndicator
     };
 };

--- a/packages/venia-ui/lib/RootComponents/CMS/cms.js
+++ b/packages/venia-ui/lib/RootComponents/CMS/cms.js
@@ -20,19 +20,10 @@ const CMSPage = props => {
         }
     });
 
-    const {
-        cmsPage,
-        hasContent,
-        error,
-        shouldShowLoadingIndicator
-    } = talonProps;
+    const { cmsPage, hasContent, shouldShowLoadingIndicator } = talonProps;
 
     if (shouldShowLoadingIndicator) {
         return fullPageLoadingIndicator;
-    }
-
-    if (error) {
-        return <div>Page Fetch Error</div>;
     }
 
     const classes = mergeClasses(defaultClasses, props.classes);


### PR DESCRIPTION
## Description

Network errors are always returned by `useQuery`, even if we use `cache-and-network`. Going offline and then navigating to a cached cms page results in the `data` from the query returning, but the network call being made. Since we're offline, a network error is returned by the hook, which was causing the `Page Fetch Error` to be rendered in the UI.

To be honest the error was really a bad UX anyways. We have better methods for handling page level errors such as toasts.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-708](https://jira.corp.magento.com/browse/PWA-708).

## Acceptance 
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Open PR/deployed home page.
2. Now got to category or products page.
3. Turn network to offline in devtools.
4. click Venia logo to go back to home page.
5. Wait for 3-5 secs.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
