### PR TITLE
[bug] fix data sort error

### DIFF
--- a/packages/peregrine/lib/talons/Breadcrumbs/__tests__/useBreadcrumbs.spec.js
+++ b/packages/peregrine/lib/talons/Breadcrumbs/__tests__/useBreadcrumbs.spec.js
@@ -103,10 +103,12 @@ test('returns sorted data', () => {
         hasError: false,
         normalizedData: [
             {
+                category_level: 1,
                 path: '/tiki/shopee.html',
                 text: 'Shopee'
             },
             {
+                category_level: 2,
                 path: '/tiki/shopee/foo.html',
                 text: 'Foo'
             }

--- a/packages/peregrine/lib/talons/Breadcrumbs/useBreadcrumbs.js
+++ b/packages/peregrine/lib/talons/Breadcrumbs/useBreadcrumbs.js
@@ -44,10 +44,16 @@ export const useBreadcrumbs = props => {
 
             return (
                 breadcrumbData &&
-                breadcrumbData.sort(sortCrumbs).map(category => ({
-                    text: category.category_name,
-                    path: getPath(category.category_url_path, categoryUrlSuffix)
-                }))
+                breadcrumbData
+                    .map(category => ({
+                        category_level: category.category_level,
+                        text: category.category_name,
+                        path: getPath(
+                            category.category_url_path,
+                            categoryUrlSuffix
+                        )
+                    }))
+                    .sort(sortCrumbs)
             );
         }
     }, [categoryUrlSuffix, data, loading]);


### PR DESCRIPTION
## Description

Fix a bug where data from GQL was being sorted in place. Apollo doesn't allow data arrays to be mutated.

## Related Issue
PWA-946.

## Acceptance 

### Verification Stakeholders
- @dpatil-magento 
- @sirugh 
- @tjwiebell 

### Specification

### Verification Steps
1. Visit a category page, then a product page.
2. Verify the error is no longer thrown.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [ ] I have added tests to cover my changes, if necessary.
* I have updated the documentation accordingly, if necessary.
