### PR TITLE
Fixed duplicate filters by using value and label as key.

### DIFF
--- a/packages/peregrine/lib/Price/__tests__/__snapshots__/price.spec.js.snap
+++ b/packages/peregrine/lib/Price/__tests__/__snapshots__/price.spec.js.snap
@@ -48,7 +48,7 @@ Array [
     1
   </span>,
   <span>
-     
+     
   </span>,
   <span>
     000

--- a/packages/peregrine/lib/Price/__tests__/__snapshots__/price.spec.js.snap
+++ b/packages/peregrine/lib/Price/__tests__/__snapshots__/price.spec.js.snap
@@ -48,7 +48,7 @@ Array [
     1
   </span>,
   <span>
-     
+     
   </span>,
   <span>
     000

--- a/packages/venia-ui/lib/components/FilterModal/FilterList/filterDefault.js
+++ b/packages/venia-ui/lib/components/FilterModal/FilterList/filterDefault.js
@@ -7,13 +7,13 @@ import defaultClasses from './filterDefault.css';
 
 const FilterDefault = props => {
     const { classes: propsClasses, isSelected, item, ...restProps } = props;
-    const { label } = item || {};
+    const { label, value_index } = item || {};
     const classes = mergeClasses(defaultClasses, propsClasses);
 
     return (
         <Checkbox
             classes={classes.root}
-            field={label}
+            field={`${label}-${value_index}`}
             fieldState={{
                 value: isSelected
             }}

--- a/packages/venia-ui/lib/components/FilterModal/FilterList/filterDefault.js
+++ b/packages/venia-ui/lib/components/FilterModal/FilterList/filterDefault.js
@@ -35,7 +35,8 @@ FilterDefault.propTypes = {
     group: string,
     isSelected: bool,
     item: shape({
-        label: string
-    }),
+        label: string.isRequired,
+        value_index: string.isRequired
+    }).isRequired,
     label: string
 };


### PR DESCRIPTION
## Description

There was an error in the filters list when there are multiple filters with the same label. Fixed it by using filter value along with the filter label as key.

## Related Issue
Closes [PWA-945](https://jira.corp.magento.com/browse/PWA-945)

### Verification Stakeholders
@dpatil-magento 

### Verification Steps

Backend URL - https://venia-smoketest-x3mnlqi-c5v7sxvquxwl4.eu-4.magentosite.cloud/

1. Go to the deployed app.
2. Search a string "Tops"
3. Now click on any result or try sort/filter. The page should render without any error.

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
- [x] I have added tests to cover my changes, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
