### PR TITLE
chore: add translation checkbox line for pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ TODO: Describe your changes in detail here.
 <!--- Using the above wording causes Github to automatically close the issue on merge. -->
 Closes #ISSUE_NUMBER.
 
-## Acceptance 
+## Acceptance
 <!-- The people and processes this pull request needs before it is merged. -->
 <!-- These fields are not required when opening the pull request, but they -->
 <!-- should be populated after code review. -->
@@ -44,4 +44,5 @@ Closes #ISSUE_NUMBER.
 ## Checklist
 <!--- Go over all the following points, and make sure you've done anything necessary -->
 - [ ] I have added tests to cover my changes, if necessary.
+- [ ] I have added translations for new strings, if necessary.
 * I have updated the documentation accordingly, if necessary.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,6 +43,6 @@ Closes #ISSUE_NUMBER.
 
 ## Checklist
 <!--- Go over all the following points, and make sure you've done anything necessary -->
-- [ ] I have added tests to cover my changes, if necessary.
-- [ ] I have added translations for new strings, if necessary.
+* I have added tests to cover my changes, if necessary.
+* I have added translations for new strings, if necessary.
 * I have updated the documentation accordingly, if necessary.


### PR DESCRIPTION
Going forward we want to ensure no raw/non-translated strings are used in the app on accident. #2789 will start failing CI if there are raw strings found, but @anthoula had a good idea which was to add a line to the PR template as an additional check.
