### PR TITLE
Modified SW to ignore Admin panel routes.

### DIFF
--- a/packages/venia-concept/src/ServiceWorker/__tests__/registerRoutes.spec.js
+++ b/packages/venia-concept/src/ServiceWorker/__tests__/registerRoutes.spec.js
@@ -1,7 +1,11 @@
 import { cacheNames } from 'workbox-core';
 import { registerRoute } from 'workbox-routing';
 import { ExpirationPlugin } from 'workbox-expiration';
-import { CacheFirst, StaleWhileRevalidate } from 'workbox-strategies';
+import {
+    CacheFirst,
+    NetworkOnly,
+    StaleWhileRevalidate
+} from 'workbox-strategies';
 
 import { THIRTY_DAYS, MAX_NUM_OF_IMAGES_TO_CACHE } from '../defaults';
 import registerRoutes from '../registerRoutes';
@@ -27,6 +31,7 @@ jest.mock('workbox-routing', () => {
 jest.mock('workbox-strategies', () => {
     return {
         CacheFirst: jest.fn(),
+        NetworkOnly: jest.fn(),
         StaleWhileRevalidate: jest.fn()
     };
 });
@@ -42,7 +47,29 @@ jest.mock('../Utilities/imageCacheHandler', () => {
 test("A total of 5 routes need to be registered using workbox's registerRoute API", () => {
     registerRoutes();
 
-    expect(registerRoute).toHaveBeenCalledTimes(5);
+    expect(registerRoute).toHaveBeenCalledTimes(6);
+
+    registerRoute.mockClear();
+});
+
+test('There should be a route for admin page with NetworkOnly strategy', () => {
+    registerRoutes();
+
+    /**
+     * This is a crude way to find the route by searching for
+     * content inside the function in the .toString() output, but I am
+     * out of options at this point.
+     *
+     * Obviously there might be a better way to do it just that I
+     * am not aware of it at this point. Feel free to change it.
+     */
+    const [registrationCall] = registerRoute.mock.calls.filter(
+        call =>
+            call[0].toString().includes(".endsWith('/admin')") &&
+            call[0].toString().includes(".includes('/admin/')")
+    );
+
+    expect(registrationCall[1]).toBeInstanceOf(NetworkOnly);
 
     registerRoute.mockClear();
 });

--- a/packages/venia-concept/src/ServiceWorker/registerRoutes.js
+++ b/packages/venia-concept/src/ServiceWorker/registerRoutes.js
@@ -1,7 +1,11 @@
 import { cacheNames } from 'workbox-core';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { registerRoute } from 'workbox-routing';
-import { CacheFirst, StaleWhileRevalidate } from 'workbox-strategies';
+import {
+    CacheFirst,
+    NetworkOnly,
+    StaleWhileRevalidate
+} from 'workbox-strategies';
 import {
     isResizedCatalogImage,
     findSameOrLargerImage,
@@ -18,6 +22,25 @@ import { THIRTY_DAYS, MAX_NUM_OF_IMAGES_TO_CACHE } from './defaults';
  */
 export default function() {
     const catalogCacheHandler = createCatalogCacheHandler();
+
+    /**
+     * Never cache admin URL assets. Always go to the network.
+     *
+     * Will match URLs like:
+     * 1. venia.com/admin
+     * 2. venia.com/admin/admin
+     * 3. venia.com/backend/admin
+     * 4. venia.com/admin/store/settings
+     *
+     * Will not match URLs like:
+     * 1. venia.com/store_admin
+     * 2. venia.com/store/store_admin/settings
+     */
+    registerRoute(
+        ({ url }) =>
+            url.pathname.endsWith('/admin') || url.pathname.includes('/admin/'),
+        new NetworkOnly()
+    );
 
     registerRoute(
         new RegExp('(robots.txt|favicon.ico|manifest.json)'),


### PR DESCRIPTION
## Description

Ignoring `admin` panel routes in the SW. This new rule utilizes the `NetworkOnly` strategy which makes sure that the SW directly relays the call to the network.

https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_only

This code works theoretically because it is looking for the `/admin` path in the URL but I couldn't test because the backend instance I use has a different domain all together. @dpatil-magento make sure you test this on an instance that has the same domain for the app and the admin panel.

## Related Issue
Closes [PWA-462](https://jira.corp.magento.com/browse/PWA-462)

### Verification Stakeholders
@dpatil-magento 
@jimbo 

### Specification
Since we added this check in the SW, it will ignore all the `/admin/` routes. This can be a problem if a store has a route in its app that has `/admin/` in its pathname. Store developers have to be vary of this.

### Verification Steps
1. Go to an admin page and see that it works.
2. Another way to verify is to check the cache storage. You should not find any assets related to the admin panel.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
