### PR TITLE
Set button type on thumbnails

### DIFF
--- a/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
@@ -176,6 +176,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <button
       className="rootSelected"
       onClick={[Function]}
+      type="button"
     >
       <div
         className="root container"
@@ -212,6 +213,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <button
       className="root"
       onClick={[Function]}
+      type="button"
     >
       <div
         className="root container"
@@ -248,6 +250,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <button
       className="root"
       onClick={[Function]}
+      type="button"
     >
       <div
         className="root container"
@@ -284,6 +287,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <button
       className="root"
       onClick={[Function]}
+      type="button"
     >
       <div
         className="root container"

--- a/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
@@ -10,6 +10,7 @@ exports[`renders a transparent main image if no file name is provided 1`] = `
     <button
       className="previousButton"
       onClick={[Function]}
+      type="button"
     >
       <span
         className="root"
@@ -53,6 +54,7 @@ exports[`renders a transparent main image if no file name is provided 1`] = `
     <button
       className="nextButton"
       onClick={[Function]}
+      type="button"
     >
       <span
         className="root"
@@ -92,6 +94,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <button
       className="previousButton"
       onClick={[Function]}
+      type="button"
     >
       <span
         className="root"
@@ -147,6 +150,7 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <button
       className="nextButton"
       onClick={[Function]}
+      type="button"
     >
       <span
         className="root"

--- a/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/thumbnail.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/__tests__/__snapshots__/thumbnail.spec.js.snap
@@ -4,6 +4,7 @@ exports[`renders root class if not the active Thumbnail 1`] = `
 <button
   className="root"
   onClick={[Function]}
+  type="button"
 >
   <div
     className="root container"
@@ -43,6 +44,7 @@ exports[`renders the Thumbnail component correctly 1`] = `
 <button
   className="rootSelected"
   onClick={[Function]}
+  type="button"
 >
   <div
     className="root container"
@@ -82,6 +84,7 @@ exports[`renders transparent placeholder when no file name is provided 1`] = `
 <button
   className="rootSelected"
   onClick={[Function]}
+  type="button"
 >
   <div
     className="root container"

--- a/packages/venia-ui/lib/components/ProductImageCarousel/carousel.js
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/carousel.js
@@ -97,6 +97,7 @@ const ProductImageCarousel = props => {
                 <button
                     className={classes.previousButton}
                     onClick={handlePrevious}
+                    type="button"
                 >
                     <Icon
                         classes={chevronClasses}
@@ -105,7 +106,11 @@ const ProductImageCarousel = props => {
                     />
                 </button>
                 {image}
-                <button className={classes.nextButton} onClick={handleNext}>
+                <button
+                    className={classes.nextButton}
+                    onClick={handleNext}
+                    type="button"
+                >
                     <Icon
                         classes={chevronClasses}
                         src={ChevronRightIcon}

--- a/packages/venia-ui/lib/components/ProductImageCarousel/thumbnail.js
+++ b/packages/venia-ui/lib/components/ProductImageCarousel/thumbnail.js
@@ -67,8 +67,9 @@ const Thumbnail = props => {
 
     return (
         <button
-            onClick={handleClick}
             className={isActive ? classes.rootSelected : classes.root}
+            onClick={handleClick}
+            type="button"
         >
             {thumbnailImage}
         </button>


### PR DESCRIPTION
## Description
Thumbnails in the product image carousel are `button` elements inside a form (add to cart), so their default `type` is `submit`; clicking on them submits the form. This PR sets `type` to `button` so they no longer submit the form.

## Related Issue
PWA-1079

## Acceptance

### Verification Stakeholders
- @dpatil-magento 

### Specification

### Verification Steps
1. Visit a configurable product detail page.
2. Select all required options.
3. Click each of the thumbnails in the image carousel.
4. Verify that no further products are added to the cart.

## Screenshots / Screen Captures (if appropriate)

## Checklist
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
