### PR TITLE
Work around order details issue

### DIFF
--- a/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
@@ -111,7 +111,7 @@ const CheckoutPage = props => {
               defaultMessage: 'Checkout'
           });
 
-    if (orderNumber) {
+    if (orderNumber && orderDetailsData) {
         return (
             <OrderConfirmationPage
                 data={orderDetailsData}


### PR DESCRIPTION
## Description

Users have encountered an issue in production where the `useOrderConfirmationPage` talon throws Javascript errors. This happens because we render the confirmation page as soon as we have an order number, but the order number and order details come from separate queries, so the data the confirmation page needs may not have arrived yet.

Just need to wait for that data.

## Related Issue

PWA-1106

## Acceptance

### Verification Stakeholders

- @dpatil-magento 
- @davemacaulay 
- @revanth0212 

### Specification

### Verification Steps
1. Complete checkout.
2. Verify nothing's changed.

## Screenshots / Screen Captures (if appropriate)

## Checklist
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#2885: Work around order details issue