### PR TITLE
[bug] Fixed url redirection

### DIFF
--- a/packages/peregrine/lib/talons/MagentoRoute/useMagentoRoute.js
+++ b/packages/peregrine/lib/talons/MagentoRoute/useMagentoRoute.js
@@ -58,7 +58,7 @@ export const useMagentoRoute = props => {
     // If the entry for this pathname is a redirect, perform the redirect.
     useEffect(() => {
         if (routeData && routeData.isRedirect) {
-            history.replace(routeData.relativeUrl);
+            history.replace('/' + routeData.relativeUrl);
         }
     }, [componentMap, history, pathname, routeData]);
 


### PR DESCRIPTION
## Description
1. It gets stuck at loading when trying to open a subcategory that has been redirected.
2. In the source code, it used history.replace() function but missing the "/" for params.

TODO: Append "/" to the head of params will fix the error.

## Related Issue
Closes #2860 .

##Acceptance

##Verification Stakeholders

##Specification

##Verification Steps

1. Login to admin panel
2. Go to "Marketing / SEO & Search / URL Rewrites"
3. Add an URL rewrite for a subcategory (use 301 or 302 redirect)
4. Go to front-page and clear the browser cache
5. Navigate to the subcategory
6. Make sure the page does not stuck at loading screen.

##Screenshots / Screen Captures (if appropriate)

## Checklist
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.