### PR TITLE
[bug]: Pagebuilder links should use store code

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/configAggregator.spec.js
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/configAggregator.spec.js
@@ -322,3 +322,24 @@ test('banner config aggregator retrieve background video collage-right banner co
         })
     );
 });
+
+test('banner config aggregator updates links with active store code', () => {
+    const old = process.env.USE_STORE_CODE_IN_URL;
+    const oldCode = window.STORE_VIEW_CODE;
+
+    process.env.USE_STORE_CODE_IN_URL = true;
+    window.STORE_VIEW_CODE = 'fr';
+
+    const node = document.createElement('div');
+    node.innerHTML =
+        '<div data-content-type="banner" data-appearance="collage-right" data-show-button="never" data-show-overlay="never" data-element="main" style="margin: 0px;"><div data-element="empty_link"><div class="pagebuilder-banner-wrapper" data-background-images="{}" data-background-type="video" data-video-src="mp4:https://example.com/example.mp4" data-video-loop="true" data-video-play-only-visible="true" data-video-lazy-load="true" data-video-fallback-src="https://example.com/image.jpg" data-element="wrapper" style="background-position: left top; background-size: cover; background-repeat: no-repeat; background-attachment: scroll; border-style: none; border-width: 1px; border-radius: 0px; padding: 40px; min-height: 500px;"><div class="video-overlay" data-video-overlay-color="rgba(216, 56, 56, 0.75)" data-element="video_overlay" style="background-color: rgba(216, 56, 56, 0.75);"></div><div class="pagebuilder-overlay" data-overlay-color="" data-element="overlay" style="background-color: transparent;"><div class="pagebuilder-collage-content"><div data-element="content"><a href="/shop-the-look.html"></a></div></div></div></div></div></div>';
+
+    expect(
+        configAggregator(node.childNodes[0], {
+            appearance: 'collage-right'
+        }).content
+    ).toEqual('<a href="/fr/shop-the-look.html"></a>');
+
+    process.env.USE_STORE_CODE_IN_URL = old;
+    window.STORE_VIEW_CODE = oldCode;
+});

--- a/packages/pagebuilder/lib/ContentTypes/Banner/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/configAggregator.js
@@ -8,6 +8,9 @@ import {
     getIsHidden
 } from '../../utils';
 
+import { BrowserPersistence } from '@magento/peregrine/lib/util';
+const storage = new BrowserPersistence();
+
 /**
  * Determine the button type based on class
  *
@@ -38,6 +41,18 @@ export default (node, props) => {
     let minHeightPaddingElement = wrapperElement;
     if (props.appearance === 'poster') {
         minHeightPaddingElement = overlayElement;
+    }
+
+    if (process.env.USE_STORE_CODE_IN_URL === 'true') {
+        const storeViewCode =
+            storage.getItem('store_view_code') || STORE_VIEW_CODE;
+
+        // For each link update the href to include the active store code.
+        node.querySelectorAll('a').forEach(oldNode => {
+            const newNode = oldNode.cloneNode(true);
+            newNode.href = `/${storeViewCode}${oldNode.getAttribute('href')}`;
+            oldNode.parentNode.replaceChild(newNode, oldNode);
+        });
     }
 
     return {

--- a/packages/pagebuilder/lib/ContentTypes/Banner/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/configAggregator.js
@@ -5,11 +5,9 @@ import {
     getPadding,
     getTextAlign,
     getCssClasses,
-    getIsHidden
+    getIsHidden,
+    injectStoreCodeHref
 } from '../../utils';
-
-import { BrowserPersistence } from '@magento/peregrine/lib/util';
-const storage = new BrowserPersistence();
 
 /**
  * Determine the button type based on class
@@ -43,17 +41,7 @@ export default (node, props) => {
         minHeightPaddingElement = overlayElement;
     }
 
-    if (process.env.USE_STORE_CODE_IN_URL === 'true') {
-        const storeViewCode =
-            storage.getItem('store_view_code') || STORE_VIEW_CODE;
-
-        // For each link update the href to include the active store code.
-        node.querySelectorAll('a').forEach(oldNode => {
-            const newNode = oldNode.cloneNode(true);
-            newNode.href = `/${storeViewCode}${oldNode.getAttribute('href')}`;
-            oldNode.parentNode.replaceChild(newNode, oldNode);
-        });
-    }
+    node = injectStoreCodeHref(node);
 
     return {
         minHeight: minHeightPaddingElement.style.minHeight || null,

--- a/packages/pagebuilder/lib/ContentTypes/Text/__tests__/configAggregator.spec.js
+++ b/packages/pagebuilder/lib/ContentTypes/Text/__tests__/configAggregator.spec.js
@@ -9,3 +9,21 @@ test('text config aggregator retrieves content', () => {
         }).content
     ).toEqual("<p><strong>Here's some glorious text!</strong></p>");
 });
+
+test('text config aggregator updates links with active store code', () => {
+    const old = process.env.USE_STORE_CODE_IN_URL;
+    const oldCode = window.STORE_VIEW_CODE;
+
+    process.env.USE_STORE_CODE_IN_URL = true;
+    window.STORE_VIEW_CODE = 'fr';
+
+    const node = document.createElement('div');
+    node.innerHTML = `<div data-content-type="text" data-appearance="default" data-element="main" style="border-style: none; border-width: 1px; border-radius: 0px; margin: 0px; padding: 0px;"><a href="/shop-the-look.html"></a></div>`;
+
+    expect(configAggregator(node.childNodes[0]).content).toEqual(
+        '<a href="/fr/shop-the-look.html"></a>'
+    );
+
+    process.env.USE_STORE_CODE_IN_URL = old;
+    window.STORE_VIEW_CODE = oldCode;
+});

--- a/packages/pagebuilder/lib/ContentTypes/Text/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Text/configAggregator.js
@@ -1,20 +1,7 @@
-import { getAdvanced } from '../../utils';
-
-import { BrowserPersistence } from '@magento/peregrine/lib/util';
-const storage = new BrowserPersistence();
+import { getAdvanced, injectStoreCodeHref } from '../../utils';
 
 export default node => {
-    if (process.env.USE_STORE_CODE_IN_URL === 'true') {
-        const storeViewCode =
-            storage.getItem('store_view_code') || STORE_VIEW_CODE;
-
-        // For each link update the href to include the active store code.
-        node.querySelectorAll('a').forEach(oldNode => {
-            const newNode = oldNode.cloneNode(true);
-            newNode.href = `/${storeViewCode}${oldNode.getAttribute('href')}`;
-            oldNode.parentNode.replaceChild(newNode, oldNode);
-        });
-    }
+    node = injectStoreCodeHref(node);
 
     return {
         content: node.innerHTML,

--- a/packages/pagebuilder/lib/ContentTypes/Text/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Text/configAggregator.js
@@ -1,6 +1,21 @@
 import { getAdvanced } from '../../utils';
 
+import { BrowserPersistence } from '@magento/peregrine/lib/util';
+const storage = new BrowserPersistence();
+
 export default node => {
+    if (process.env.USE_STORE_CODE_IN_URL === 'true') {
+        const storeViewCode =
+            storage.getItem('store_view_code') || STORE_VIEW_CODE;
+
+        // For each link update the href to include the active store code.
+        node.querySelectorAll('a').forEach(oldNode => {
+            const newNode = oldNode.cloneNode(true);
+            newNode.href = `/${storeViewCode}${oldNode.getAttribute('href')}`;
+            oldNode.parentNode.replaceChild(newNode, oldNode);
+        });
+    }
+
     return {
         content: node.innerHTML,
         ...getAdvanced(node)

--- a/packages/pagebuilder/lib/utils.js
+++ b/packages/pagebuilder/lib/utils.js
@@ -177,6 +177,13 @@ export function getIsHidden(node) {
     };
 }
 
+/**
+ * Modifies the node and children to include the current store view code in the
+ * link.
+ *
+ * @param node
+ * @returns node
+ */
 export function injectStoreCodeHref(node) {
     if (process.env.USE_STORE_CODE_IN_URL === 'true') {
         const storeViewCode =

--- a/packages/pagebuilder/lib/utils.js
+++ b/packages/pagebuilder/lib/utils.js
@@ -1,3 +1,6 @@
+import { BrowserPersistence } from '@magento/peregrine/lib/util';
+const storage = new BrowserPersistence();
+
 /**
  * Retrieve background images from a master format node
  *
@@ -172,4 +175,19 @@ export function getIsHidden(node) {
     return {
         isHidden: node.style.display === 'none'
     };
+}
+
+export function injectStoreCodeHref(node) {
+    if (process.env.USE_STORE_CODE_IN_URL === 'true') {
+        const storeViewCode =
+            storage.getItem('store_view_code') || STORE_VIEW_CODE;
+
+        // For each link update the href to include the active store code.
+        node.querySelectorAll('a').forEach(oldNode => {
+            const newNode = oldNode.cloneNode(true);
+            newNode.href = `/${storeViewCode}${oldNode.getAttribute('href')}`;
+            oldNode.parentNode.replaceChild(newNode, oldNode);
+        });
+    }
+    return node;
 }

--- a/packages/pagebuilder/lib/utils.js
+++ b/packages/pagebuilder/lib/utils.js
@@ -192,7 +192,13 @@ export function injectStoreCodeHref(node) {
         // For each link update the href to include the active store code.
         node.querySelectorAll('a').forEach(oldNode => {
             const newNode = oldNode.cloneNode(true);
-            newNode.href = `/${storeViewCode}${oldNode.getAttribute('href')}`;
+
+            // Since the href could be relative or absolute, use the property
+            // accessor to ensure we _always_ use the absolute.
+            const updatedUrl = new URL(oldNode.href);
+            updatedUrl.pathname = `${storeViewCode}${updatedUrl.pathname}`;
+            newNode.href = updatedUrl.href;
+
             oldNode.parentNode.replaceChild(newNode, oldNode);
         });
     }


### PR DESCRIPTION
## Description

When `USE_STORE_CODE_IN_URL=true` we update the basename property so links created within venia-ui contain the proper store code.

Pagebuilder needs a similar treatment, as it just injects raw html into the content types.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA-1063](https://jira.corp.magento.com/browse/PWA-1063).

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to PR deploy page. Check links within PageBuilder content ("shop now button", etc).
2. Links should contain store code prefix ie `/default/shop-the-look.html`.

## Screenshots / Screen Captures (if appropriate)

![](https://i.gyazo.com/e1897ed79d0586ee464c0eff551dc4c0.png)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
