### PR TITLE
Add meta tag for prerender.io

### DIFF
--- a/packages/venia-ui/lib/components/MagentoRoute/magentoRoute.js
+++ b/packages/venia-ui/lib/components/MagentoRoute/magentoRoute.js
@@ -5,6 +5,7 @@ import {
     NOT_FOUND,
     useMagentoRoute
 } from '@magento/peregrine/lib/talons/MagentoRoute';
+import { Meta } from '@magento/venia-ui/lib/components/Head';
 
 import { fullPageLoadingIndicator } from '../LoadingIndicator';
 
@@ -16,6 +17,11 @@ const MagentoRoute = () => {
     const talonProps = useMagentoRoute();
     const { component: RootComponent, id, isLoading, routeError } = talonProps;
 
+    const metaElements =
+        routeError === NOT_FOUND ? (
+            <Meta name="prerender-status-code" content="404" />
+        ) : null;
+
     if (isLoading) {
         return fullPageLoadingIndicator;
     } else if (RootComponent) {
@@ -23,6 +29,7 @@ const MagentoRoute = () => {
     } else if (routeError === NOT_FOUND) {
         return (
             <ErrorView>
+                {metaElements}
                 <h1>{MESSAGES.get(routeError)}</h1>
             </ErrorView>
         );


### PR DESCRIPTION
# DO NOT MERGE

## Description
Demonstrate how to add a `<meta>` tag that lets Prerender.io know to treat the current route as a 404, even though it received a 200.

## Related Issue
PWA-1149

## Acceptance

### Verification Stakeholders
- @dpatil-magento 

### Specification

### Verification Steps
1. Visit a nonexisting route, such as `/foo`.
2. Verify that `<meta name="prerender-status-code" content="404">` is in the document head.

## Screenshots / Screen Captures (if appropriate)

## Checklist
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
