### PR TITLE
Handle array of paths as route pattern

### DIFF
--- a/packages/venia-ui/lib/targets/__tests__/makeRoutesTarget.spec.js
+++ b/packages/venia-ui/lib/targets/__tests__/makeRoutesTarget.spec.js
@@ -1,0 +1,66 @@
+const {
+    mockTargetProvider
+} = require('@magento/pwa-buildpack/lib/TestHelpers');
+
+const makeRoutesTarget = require('../makeRoutesTarget');
+const TargetableSet = require('@magento/pwa-buildpack/lib/WebpackTools/targetables/TargetableSet');
+
+const FAKE_ADDED_ROUTE = 'ADDED_ROUTE';
+
+const targets = mockTargetProvider(
+    '@magento/venia-ui',
+    (_, dep) =>
+        ({
+            '@magento/pwa-buildpack': {
+                specialFeatures: {
+                    tap: jest.fn()
+                },
+                transformModules: {
+                    tapPromise: jest.fn()
+                }
+            }
+        }[dep])
+);
+const targetable = TargetableSet.using(targets);
+const mockPrependJSX = jest.fn();
+
+jest.mock(
+    '../../defaultRoutes.json',
+    () => [
+        {
+            name: 'Single path route',
+            pattern: '/simple',
+            exact: true,
+            path: '../AccountInformationPage'
+        },
+        {
+            name: 'Multiple path route',
+            pattern: ['/one', '/two'],
+            exact: true,
+            path: '../AccountInformationPage'
+        }
+    ],
+    { virtual: true }
+);
+
+beforeAll(() => {
+    jest.spyOn(targetable, 'reactComponent').mockImplementation(() => ({
+        addReactLazyImport: () => FAKE_ADDED_ROUTE,
+        prependJSX: mockPrependJSX
+    }));
+});
+
+test('Call prependJSX with the correct path patterns', async () => {
+    makeRoutesTarget(targetable);
+
+    expect(mockPrependJSX).toHaveBeenNthCalledWith(
+        1,
+        'Switch',
+        `<Route exact path={"/simple"}><${FAKE_ADDED_ROUTE}/></Route>`
+    );
+    expect(mockPrependJSX).toHaveBeenNthCalledWith(
+        2,
+        'Switch',
+        `<Route exact path={["/one","/two"]}><${FAKE_ADDED_ROUTE}/></Route>`
+    );
+});

--- a/packages/venia-ui/lib/targets/makeRoutesTarget.js
+++ b/packages/venia-ui/lib/targets/makeRoutesTarget.js
@@ -11,10 +11,14 @@ function makeRoutesTarget(venia) {
 function addRoutes(routeList, routes) {
     for (const route of routes) {
         const AddedRoute = routeList.addReactLazyImport(route.path, route.name);
+
+        const routePath = Array.isArray(route.pattern) ? 
+        `{[${route.pattern.map(path => `"${path}"`).join(", ")}]}` : `"${route.pattern}"`;
+
         routeList.prependJSX(
             'Switch',
             `<Route ${route.exact ? 'exact ' : ''}path="${
-                route.pattern
+                routePath
             }"><${AddedRoute}/></Route>`
         );
     }

--- a/packages/venia-ui/lib/targets/makeRoutesTarget.js
+++ b/packages/venia-ui/lib/targets/makeRoutesTarget.js
@@ -11,15 +11,11 @@ function makeRoutesTarget(venia) {
 function addRoutes(routeList, routes) {
     for (const route of routes) {
         const AddedRoute = routeList.addReactLazyImport(route.path, route.name);
-
-        const routePath = Array.isArray(route.pattern) ? 
-        `{[${route.pattern.map(path => `"${path}"`).join(", ")}]}` : `"${route.pattern}"`;
-
         routeList.prependJSX(
             'Switch',
-            `<Route ${route.exact ? 'exact ' : ''}path="${
-                routePath
-            }"><${AddedRoute}/></Route>`
+            `<Route ${route.exact ? 'exact ' : ''}path={${JSON.stringify(
+                route.pattern
+            )}}><${AddedRoute}/></Route>`
         );
     }
 }


### PR DESCRIPTION
## Description

Extend the functionality of the Routes target of venia-ui. Handle both `string` and `string[]` type of the react-router path prop (see [docs](https://reactrouter.com/web/api/Route/path-string-string)).

## Related Issue
Closes #2892

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Add/modify an entry in "packages/venia-ui/lib/defaultRoutes.json" and define the `pattern` with an array value. For example:
```
    {
        "name": "AccountInformationPage",
        "pattern": ["/account-information", "/acc-info"],
        "exact": true,
        "path": "../AccountInformationPage"
    }
```
2. Run the project with `yarn watch`
3. Navigating to "/account-information" and "/acc-info" gives you the same page

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
