### PR TITLE
Fix missing projectConfig in create-custom-origin

### DIFF
--- a/packages/pwa-buildpack/lib/cli/create-custom-origin.js
+++ b/packages/pwa-buildpack/lib/cli/create-custom-origin.js
@@ -19,7 +19,7 @@ module.exports.describe =
 module.exports.handler = async function buildpackCli({ directory }) {
     const projectRoot = resolve(directory);
     try {
-        const projectConfig = loadEnvironment(projectRoot, prettyLogger);
+        const projectConfig = await loadEnvironment(projectRoot, prettyLogger);
         if (projectConfig.error) {
             failExpected(projectConfig.error);
         }

--- a/pwa-devdocs/src/pwa-buildpack/configuration-management/index.md
+++ b/pwa-devdocs/src/pwa-buildpack/configuration-management/index.md
@@ -122,7 +122,7 @@ class MyWebpackPlugin {
 **Good**: passing plain objects created by the Configuration object
 
 ```js
-const projectConfig = loadEnvironment(__dirname);
+const projectConfig = await loadEnvironment(__dirname);
 await PWADevServer.configure({
     publicPath: config.output.publicPath,
     graphqlPlayground: true,

--- a/pwa-devdocs/src/pwa-buildpack/reference/buildpack-cli/load-env/index.md
+++ b/pwa-devdocs/src/pwa-buildpack/reference/buildpack-cli/load-env/index.md
@@ -37,7 +37,7 @@ Loads a given directory's `.env` file and provides a [configuration object][].
 ```js
 const { loadEnvironment } = require('@magento/pwa-buildpack');
 
-const configuration = loadEnvironment(process.cwd());
+const configuration = await loadEnvironment(process.cwd());
 ```
 
 #### Parameters
@@ -91,7 +91,7 @@ import { loadEnvironment } from '@magento/pwa-buildpack';
 
 // Give `loadEnvironment` the path to the project root.
 // If the current file is in project root, use the Node builtin `__dirname`.
-const configuration = loadEnvironment('/Users/me/path/to/project');
+const configuration = await loadEnvironment('/Users/me/path/to/project');
 
 // `loadEnvironment` has now read the contents of
 // `/Users/me/path/to/project/.env` and merged it with any environment


### PR DESCRIPTION
## Description

#2853 made loading the environment async. Needs an await for `yarn buildpack create-custom-origin .`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #2898

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
@revanth0212 
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. latest develop
2. run scaffold command
3. remove @magento/venia-sample-backends package
4. run  `yarn buildpack create-custom-origin . `

## Screenshots / Screen Captures (if appropriate)

![image](https://user-images.githubusercontent.com/455508/101302050-7511fa00-389f-11eb-8b0f-aa004491b66d.png)


## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
