### PR TITLE
[feature] Use root category id from gql

### DIFF
--- a/packages/peregrine/lib/store/reducers/catalog.js
+++ b/packages/peregrine/lib/store/reducers/catalog.js
@@ -18,8 +18,7 @@ const initialState = {
     categories: {},
     currentPage: 1,
     pageSize: 6,
-    prevPageTotal: null,
-    rootCategoryId: 2
+    prevPageTotal: null
 };
 
 const reducerMap = {
@@ -69,12 +68,6 @@ const reducerMap = {
                     children_count: childMap.size
                 }
             }
-        };
-    },
-    [actions.setRootCategory]: (state, { payload }) => {
-        return {
-            ...state,
-            rootCategoryId: payload
         };
     },
     [actions.setCurrentPage.receive]: (state, { payload, error }) => {

--- a/packages/peregrine/lib/talons/CategoryList/useCategoryList.js
+++ b/packages/peregrine/lib/talons/CategoryList/useCategoryList.js
@@ -27,7 +27,9 @@ export const useCategoryList = props => {
 
     // Run the query immediately and every time id changes.
     useEffect(() => {
-        runQuery({ variables: { id } });
+        if (id) {
+            runQuery({ variables: { id } });
+        }
     }, [id, runQuery]);
 
     return {

--- a/packages/peregrine/lib/talons/CategoryTree/useCategoryTree.js
+++ b/packages/peregrine/lib/talons/CategoryTree/useCategoryTree.js
@@ -51,7 +51,7 @@ export const useCategoryTree = props => {
     }, [data, updateCategories]);
 
     const rootCategory = data && data.category;
-    console.log(`Root Category, ${rootCategory && rootCategory.id}`);
+
     const { children = [] } = rootCategory || {};
 
     const childCategories = useMemo(() => {

--- a/packages/peregrine/lib/talons/CategoryTree/useCategoryTree.js
+++ b/packages/peregrine/lib/talons/CategoryTree/useCategoryTree.js
@@ -51,6 +51,7 @@ export const useCategoryTree = props => {
     }, [data, updateCategories]);
 
     const rootCategory = data && data.category;
+    console.log(`Root Category, ${rootCategory && rootCategory.id}`);
     const { children = [] } = rootCategory || {};
 
     const childCategories = useMemo(() => {

--- a/packages/peregrine/lib/talons/Cms/cmsPage.gql.js
+++ b/packages/peregrine/lib/talons/Cms/cmsPage.gql.js
@@ -12,6 +12,9 @@ export const GET_CMS_PAGE = gql`
             meta_keywords
             meta_description
         }
+        storeConfig {
+            root_category_id
+        }
     }
 `;
 

--- a/packages/peregrine/lib/talons/Cms/cmsPage.gql.js
+++ b/packages/peregrine/lib/talons/Cms/cmsPage.gql.js
@@ -13,6 +13,7 @@ export const GET_CMS_PAGE = gql`
             meta_description
         }
         storeConfig {
+            id
             root_category_id
         }
     }

--- a/packages/peregrine/lib/talons/Cms/useCmsPage.js
+++ b/packages/peregrine/lib/talons/Cms/useCmsPage.js
@@ -51,6 +51,7 @@ export const useCmsPage = props => {
     const shouldShowLoadingIndicator = !data;
 
     const cmsPage = data ? data.cmsPage : null;
+    const rootCategoryId = data ? data.storeConfig.root_category_id : null;
 
     // TODO: we shouldn't be validating strings to determine if the page has content or not
     const hasContent = useMemo(() => {
@@ -64,8 +65,9 @@ export const useCmsPage = props => {
 
     return {
         cmsPage,
-        hasContent,
         error,
+        hasContent,
+        rootCategoryId,
         shouldShowLoadingIndicator
     };
 };

--- a/packages/peregrine/lib/talons/Navigation/__tests__/useNavigation.spec.js
+++ b/packages/peregrine/lib/talons/Navigation/__tests__/useNavigation.spec.js
@@ -29,8 +29,7 @@ jest.mock('@magento/peregrine/lib/context/catalog', () => {
             categories: {
                 1: { parentId: 0 },
                 2: { parentId: 1 }
-            },
-            rootCategoryId: 1
+            }
         },
         {
             actions: { updateCategories }
@@ -53,6 +52,16 @@ jest.mock('@magento/peregrine/lib/hooks/useAwaitQuery', () => {
         .mockResolvedValue({ data: { customer: {} } });
 
     return { useAwaitQuery };
+});
+
+jest.mock('@apollo/client', () => {
+    const apolloClient = jest.requireActual('@apollo/client');
+    return {
+        ...apolloClient,
+        useQuery: jest
+            .fn()
+            .mockReturnValue({ data: { storeConfig: { root_category_id: 1 } } })
+    };
 });
 
 /*

--- a/packages/peregrine/lib/talons/Navigation/navigation.gql.js
+++ b/packages/peregrine/lib/talons/Navigation/navigation.gql.js
@@ -12,6 +12,16 @@ export const GET_CUSTOMER = gql`
     }
 `;
 
+const GET_ROOT_CATEGORY_ID = gql`
+    query getRootCategoryId {
+        storeConfig {
+            id
+            root_category_id
+        }
+    }
+`;
+
 export default {
-    getCustomerQuery: GET_CUSTOMER
+    getCustomerQuery: GET_CUSTOMER,
+    getRootCategoryId: GET_ROOT_CATEGORY_ID
 };

--- a/packages/peregrine/lib/talons/Navigation/useNavigation.js
+++ b/packages/peregrine/lib/talons/Navigation/useNavigation.js
@@ -50,6 +50,14 @@ export const useNavigation = (props = {}) => {
     const [view, setView] = useState('MENU');
     const [categoryId, setCategoryId] = useState(rootCategoryId);
 
+    useEffect(() => {
+        // On a fresh render with cold cache set the current category as root
+        // once the root category query completes.
+        if (rootCategoryId && !categoryId) {
+            setCategoryId(rootCategoryId)
+        }
+    }, [categoryId, rootCategoryId])
+
     // define local variables
     const category = categories[categoryId];
     const isTopLevel = categoryId === rootCategoryId;

--- a/packages/peregrine/lib/talons/Navigation/useNavigation.js
+++ b/packages/peregrine/lib/talons/Navigation/useNavigation.js
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@apollo/client';
 
 import mergeOperations from '../../util/shallowMerge';
 import { useAppContext } from '../../context/app';
@@ -18,7 +19,7 @@ const ancestors = {
 
 export const useNavigation = (props = {}) => {
     const operations = mergeOperations(DEFAULT_OPERATIONS, props.operations);
-    const { getCustomerQuery } = operations;
+    const { getCustomerQuery, getRootCategoryId } = operations;
     // retrieve app state from context
     const [appState, { closeDrawer }] = useAppContext();
     const [catalogState, { actions: catalogActions }] = useCatalogContext();
@@ -30,10 +31,20 @@ export const useNavigation = (props = {}) => {
         getUserDetails({ fetchUserDetails });
     }, [fetchUserDetails, getUserDetails]);
 
+    const { data: getRootCategoryData } = useQuery(getRootCategoryId, {
+        fetchPolicy: 'cache-and-network'
+    });
+
+    const rootCategoryId = useMemo(() => {
+        if (getRootCategoryData) {
+            return getRootCategoryData.storeConfig.root_category_id;
+        }
+    }, [getRootCategoryData]);
+
     // extract relevant data from app state
     const { drawer } = appState;
     const isOpen = drawer === 'nav';
-    const { categories, rootCategoryId } = catalogState;
+    const { categories } = catalogState;
 
     // get local state
     const [view, setView] = useState('MENU');

--- a/packages/peregrine/lib/talons/Navigation/useNavigation.js
+++ b/packages/peregrine/lib/talons/Navigation/useNavigation.js
@@ -54,9 +54,9 @@ export const useNavigation = (props = {}) => {
         // On a fresh render with cold cache set the current category as root
         // once the root category query completes.
         if (rootCategoryId && !categoryId) {
-            setCategoryId(rootCategoryId)
+            setCategoryId(rootCategoryId);
         }
-    }, [categoryId, rootCategoryId])
+    }, [categoryId, rootCategoryId]);
 
     // define local variables
     const category = categories[categoryId];

--- a/packages/pwa-buildpack/lib/queries/getStoreMediaUrl.graphql
+++ b/packages/pwa-buildpack/lib/queries/getStoreMediaUrl.graphql
@@ -1,6 +1,7 @@
 # Get the media URL from the store configuration.
 query {
     storeConfig {
+        id
         secure_base_media_url
     }
 }

--- a/packages/venia-ui/lib/RootComponents/CMS/__tests__/cms.spec.js
+++ b/packages/venia-ui/lib/RootComponents/CMS/__tests__/cms.spec.js
@@ -73,6 +73,9 @@ test('page is set to loading when checking the network for updates', () => {
                 cmsPage: {
                     url_key: 'cached_page',
                     content: 'Cached Page.'
+                },
+                storeConfig: {
+                    root_category_id: 2
                 }
             },
             error: false,
@@ -103,6 +106,9 @@ test('render CategoryList when default content is present', () => {
                 cmsPage: {
                     url_key: 'homepage',
                     content: 'CMS homepage content goes here.'
+                },
+                storeConfig: {
+                    root_category_id: 2
                 }
             },
             error: false,
@@ -126,6 +132,9 @@ test('render RichContent when default content is not present', () => {
                     content_heading: 'This is a rich content heading',
                     content:
                         '<div class="richContent">This is rich content</div>'
+                },
+                storeConfig: {
+                    root_category_id: 2
                 }
             },
             error: false,
@@ -153,6 +162,9 @@ test('render meta information based on meta data from GraphQL', () => {
                     title: 'Test Title',
                     meta_title: 'Test Meta Title',
                     meta_description: 'Test Meta Description'
+                },
+                storeConfig: {
+                    root_category_id: 2
                 }
             },
             error: false,

--- a/packages/venia-ui/lib/RootComponents/CMS/cms.js
+++ b/packages/venia-ui/lib/RootComponents/CMS/cms.js
@@ -14,7 +14,12 @@ const CMSPage = props => {
     const { id } = props;
 
     const talonProps = useCmsPage({ id });
-    const { cmsPage, hasContent, shouldShowLoadingIndicator } = talonProps;
+    const {
+        cmsPage,
+        hasContent,
+        rootCategoryId,
+        shouldShowLoadingIndicator
+    } = talonProps;
     const { formatMessage } = useIntl();
 
     if (shouldShowLoadingIndicator) {
@@ -50,13 +55,14 @@ const CMSPage = props => {
         );
     }
 
+    // Fallback to a category list if there is no cms content.
     return (
         <CategoryList
             title={formatMessage({
                 id: 'cms.shopByCategory',
                 defaultMessage: 'Shop by category'
             })}
-            id={2}
+            id={rootCategoryId}
         />
     );
 };

--- a/packages/venia-ui/lib/components/CategoryList/categoryList.js
+++ b/packages/venia-ui/lib/components/CategoryList/categoryList.js
@@ -88,7 +88,7 @@ const CategoryList = props => {
 };
 
 CategoryList.propTypes = {
-    id: number,
+    id: number.isRequired,
     title: string,
     classes: shape({
         root: string,

--- a/packages/venia-ui/lib/components/CategoryTree/categoryTree.js
+++ b/packages/venia-ui/lib/components/CategoryTree/categoryTree.js
@@ -45,7 +45,7 @@ const Tree = props => {
 export default Tree;
 
 Tree.propTypes = {
-    categoryId: number.isRequired,
+    categoryId: number,
     classes: shape({
         root: string,
         tree: string

--- a/packages/venia-ui/lib/components/Navigation/__tests__/navigation.spec.js
+++ b/packages/venia-ui/lib/components/Navigation/__tests__/navigation.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { createTestInstance } from '@magento/peregrine';
 
-import { useAppContext } from '@magento/peregrine/lib/context/app';
 import { useNavigation } from '@magento/peregrine/lib/talons/Navigation/useNavigation';
 
 import NavHeader from '../navHeader';

--- a/packages/venia-ui/lib/components/Navigation/__tests__/navigation.spec.js
+++ b/packages/venia-ui/lib/components/Navigation/__tests__/navigation.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { createTestInstance } from '@magento/peregrine';
 
 import { useAppContext } from '@magento/peregrine/lib/context/app';
-import { useUserContext } from '@magento/peregrine/lib/context/user';
 import { useNavigation } from '@magento/peregrine/lib/talons/Navigation/useNavigation';
 
 import NavHeader from '../navHeader';
@@ -21,61 +20,7 @@ jest.mock('../navHeader', () => () => <i />);
 jest.mock('../../Header/storeSwitcher', () => () => 'StoreSwitcher');
 jest.mock('../../Header/currencySwitcher', () => () => 'CurrencySwitcher');
 
-jest.mock('@magento/peregrine/lib/context/app', () => {
-    const closeDrawer = jest.fn();
-    const useAppContext = jest.fn(() => [
-        { drawer: 'nav' },
-        {
-            actions: {},
-            closeDrawer
-        }
-    ]);
-
-    return { useAppContext };
-});
-
-jest.mock('@magento/peregrine/lib/context/catalog', () => {
-    const updateCategories = jest.fn();
-    const useCatalogContext = jest.fn(() => [
-        {
-            categories: {
-                1: { parentId: 0 },
-                2: { parentId: 1 }
-            },
-            rootCategoryId: 1
-        },
-        {
-            actions: { updateCategories }
-        }
-    ]);
-
-    return { useCatalogContext };
-});
-
-jest.mock('@magento/peregrine/lib/context/user', () => {
-    const getUserDetails = jest.fn();
-    const useUserContext = jest.fn(() => [{}, { getUserDetails }]);
-
-    return { useUserContext };
-});
-
-jest.mock('@magento/peregrine/lib/hooks/useAwaitQuery', () => {
-    const useAwaitQuery = jest
-        .fn()
-        .mockResolvedValue({ data: { customer: {} } });
-
-    return { useAwaitQuery };
-});
-
-jest.mock('@magento/peregrine/lib/talons/Navigation/useNavigation', () => {
-    const useNavigationTalon = jest.requireActual(
-        '@magento/peregrine/lib/talons/Navigation/useNavigation'
-    );
-
-    const spy = jest.spyOn(useNavigationTalon, 'useNavigation');
-
-    return Object.assign(useNavigationTalon, { useNavigation: spy });
-});
+jest.mock('@magento/peregrine/lib/talons/Navigation/useNavigation');
 
 /*
  * Tests.
@@ -87,6 +32,10 @@ const talonProps = {
 };
 
 test('renders correctly when open', () => {
+    useNavigation.mockReturnValueOnce({
+        ...talonProps,
+        isOpen: true
+    });
     const instance = createTestInstance(<Navigation />);
 
     expect(instance.toJSON()).toMatchSnapshot();
@@ -94,10 +43,10 @@ test('renders correctly when open', () => {
 });
 
 test('renders correctly when closed', () => {
-    useAppContext.mockImplementationOnce(() => [
-        { drawer: null },
-        { closeDrawer: jest.fn() }
-    ]);
+    useNavigation.mockReturnValueOnce({
+        ...talonProps,
+        isOpen: false
+    });
 
     const instance = createTestInstance(<Navigation />);
 
@@ -118,14 +67,6 @@ test('authModal is rendered when hasModal is true', () => {
 
     // Assert.
     expect(instance.toJSON()).toMatchSnapshot();
-});
-
-test('getUserDetails() is called on mount', () => {
-    const { getUserDetails } = useUserContext()[1];
-
-    createTestInstance(<Navigation />);
-
-    expect(getUserDetails).toHaveBeenCalledTimes(1);
 });
 
 test('view is passed to NavHeader', () => {


### PR DESCRIPTION
## Description

Venia Concept was hardcoded to use root category "2" which is the id of the root category that Magento configures by default but not necessarily the category that a client will have configured. Obtaining the actual root category id for a store from the `storeConfig` query is just one more step in the right direction of a seamless implementation of PWA Studio.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes [PWA_1067](https://jira.corp.magento.com/browse/PWA-1067).

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Configure two 'Stores' with different root categories
2. Using the store switcher, switch between the stores and verify the left nav shows the proper categories.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
