### PR TITLE
[PWA-887] My Account: Order History - Pagination

### DIFF
--- a/packages/peregrine/lib/Apollo/policies/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/peregrine/lib/Apollo/policies/__tests__/__snapshots__/index.spec.js.snap
@@ -56,6 +56,14 @@ Object {
         "merge": [Function],
         "read": [Function],
       },
+      "orders": Object {
+        "items": Object {
+          "merge": true,
+        },
+        "keyArgs": Array [
+          "filter",
+        ],
+      },
     },
     "keyFields": [Function],
   },

--- a/packages/peregrine/lib/Apollo/policies/index.js
+++ b/packages/peregrine/lib/Apollo/policies/index.js
@@ -130,6 +130,12 @@ const typePolicies = {
                     // If there are no cached addresses that's fine - the schema
                     // shows that it is a nullable field.
                 }
+            },
+            orders: {
+                keyArgs: ['filter'],
+                items: {
+                    merge: true
+                }
             }
         }
     },

--- a/packages/peregrine/lib/talons/OrderHistoryPage/__tests__/__snapshots__/useOrderHistoryPage.spec.js.snap
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/__tests__/__snapshots__/useOrderHistoryPage.spec.js.snap
@@ -1,69 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getOrderDetails fetches order details for the given search text 1`] = `
-Array [
-  Object {
-    "variables": Object {
-      "orderNumber": Object {
-        "number": Object {
-          "match": "*****",
-        },
-      },
-    },
-  },
-]
-`;
-
-exports[`handleKeyPress should fetch orders if Enter key is pressed 1`] = `
-Array [
-  Object {
-    "variables": Object {
-      "orderNumber": Object {
-        "number": Object {
-          "match": "*****",
-        },
-      },
-    },
-  },
-]
-`;
-
 exports[`it returns the proper shape while loading without data 1`] = `
 Object {
   "errorMessage": null,
-  "getOrderDetails": [Function],
-  "handleKeyPress": [Function],
-  "isBackgroundLoading": true,
-  "isLoadingWithoutData": false,
+  "handleReset": [Function],
+  "handleSubmit": [Function],
+  "isBackgroundLoading": false,
+  "isLoadingWithoutData": true,
+  "loadMoreOrders": null,
   "orders": Array [],
-  "resetForm": [Function],
-  "searchText": null,
+  "pageInfo": null,
+  "searchText": "",
 }
 `;
 
 exports[`it returns the proper shape with data 1`] = `
 Object {
   "errorMessage": null,
-  "getOrderDetails": [Function],
-  "handleKeyPress": [Function],
+  "handleReset": [Function],
+  "handleSubmit": [Function],
   "isBackgroundLoading": false,
   "isLoadingWithoutData": false,
-  "orders": Array [],
-  "resetForm": [Function],
-  "searchText": null,
-}
-`;
-
-exports[`resetForm should clear search and refetch orders data 1`] = `
-Array [
-  Object {
-    "variables": Object {
-      "orderNumber": Object {
-        "number": Object {
-          "match": "",
-        },
-      },
-    },
+  "loadMoreOrders": [Function],
+  "orders": Array [
+    "order1",
+    "order2",
+  ],
+  "pageInfo": Object {
+    "current": 4,
+    "total": 4,
   },
-]
+  "searchText": "",
+}
 `;

--- a/packages/peregrine/lib/talons/OrderHistoryPage/orderHistoryPage.gql.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/orderHistoryPage.gql.js
@@ -89,6 +89,7 @@ const CustomerOrdersFragment = gql`
             current_page
             total_pages
         }
+        total_count
     }
 `;
 

--- a/packages/peregrine/lib/talons/OrderHistoryPage/orderHistoryPage.gql.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/orderHistoryPage.gql.js
@@ -92,19 +92,14 @@ const CustomerOrdersFragment = gql`
     }
 `;
 
-export const GET_CUSTOMER_ORDER = gql`
+export const GET_CUSTOMER_ORDERS = gql`
     query GetCustomerOrders(
         $filter: CustomerOrdersFilterInput
-        $currentPage: Int!
         $pageSize: Int!
     ) {
         customer {
             id
-            orders(
-                filter: $filter
-                currentPage: $currentPage
-                pageSize: $pageSize
-            ) {
+            orders(filter: $filter, pageSize: $pageSize) {
                 ...CustomerOrdersFragment
             }
         }
@@ -113,5 +108,5 @@ export const GET_CUSTOMER_ORDER = gql`
 `;
 
 export default {
-    getCustomerOrderQuery: GET_CUSTOMER_ORDER
+    getCustomerOrdersQuery: GET_CUSTOMER_ORDERS
 };

--- a/packages/peregrine/lib/talons/OrderHistoryPage/orderHistoryPage.gql.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/orderHistoryPage.gql.js
@@ -85,14 +85,26 @@ const CustomerOrdersFragment = gql`
                 }
             }
         }
+        page_info {
+            current_page
+            total_pages
+        }
     }
 `;
 
 export const GET_CUSTOMER_ORDER = gql`
-    query GetCustomerOrders($orderNumber: CustomerOrdersFilterInput) {
+    query GetCustomerOrders(
+        $filter: CustomerOrdersFilterInput
+        $currentPage: Int!
+        $pageSize: Int!
+    ) {
         customer {
             id
-            orders(filter: $orderNumber) {
+            orders(
+                filter: $filter
+                currentPage: $currentPage
+                pageSize: $pageSize
+            ) {
                 ...CustomerOrdersFragment
             }
         }

--- a/packages/peregrine/lib/talons/OrderHistoryPage/useOrderHistoryPage.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/useOrderHistoryPage.js
@@ -49,6 +49,19 @@ export const useOrderHistoryPage = (props = {}) => {
     const isLoadingWithoutData = !orderData && orderLoading;
     const isBackgroundLoading = !!orderData && orderLoading;
 
+    const pageInfo = useMemo(() => {
+        if (orderData) {
+            const { total_count } = orderData.customer.orders;
+
+            return {
+                current: pageSize < total_count ? pageSize : total_count,
+                total: total_count
+            };
+        }
+
+        return null;
+    }, [orderData, pageSize]);
+
     const derivedErrorMessage = useMemo(
         () => deriveErrorMessage([getOrderError]),
         [getOrderError]
@@ -95,6 +108,7 @@ export const useOrderHistoryPage = (props = {}) => {
         isLoadingWithoutData,
         loadMoreOrders,
         orders,
+        pageInfo,
         searchText
     };
 };

--- a/packages/peregrine/lib/talons/OrderHistoryPage/useOrderHistoryPage.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/useOrderHistoryPage.js
@@ -10,11 +10,11 @@ import { deriveErrorMessage } from '../../util/deriveErrorMessage';
 
 import DEFAULT_OPERATIONS from './orderHistoryPage.gql';
 
-const PAGE_SIZE = 2;
+const PAGE_SIZE = 10;
 
 export const useOrderHistoryPage = (props = {}) => {
     const operations = mergeOperations(DEFAULT_OPERATIONS, props.operations);
-    const { getCustomerOrderQuery } = operations;
+    const { getCustomerOrdersQuery } = operations;
 
     const [
         ,
@@ -32,7 +32,7 @@ export const useOrderHistoryPage = (props = {}) => {
         data: orderData,
         error: getOrderError,
         loading: orderLoading
-    } = useQuery(getCustomerOrderQuery, {
+    } = useQuery(getCustomerOrdersQuery, {
         fetchPolicy: 'cache-and-network',
         variables: {
             filter: {
@@ -40,7 +40,6 @@ export const useOrderHistoryPage = (props = {}) => {
                     match: searchText
                 }
             },
-            currentPage: 1,
             pageSize
         }
     });

--- a/packages/peregrine/lib/talons/OrderHistoryPage/useOrderHistoryPage.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/useOrderHistoryPage.js
@@ -63,15 +63,17 @@ export const useOrderHistoryPage = (props = {}) => {
         setSearchText(search);
     }, []);
 
-    const fetchMoreOrders = useCallback(() => {
+    const loadMoreOrders = useMemo(() => {
         if (orderData) {
             const { page_info } = orderData.customer.orders;
             const { current_page, total_pages } = page_info;
 
             if (current_page < total_pages) {
-                setPageSize(current => current + PAGE_SIZE);
+                return () => setPageSize(current => current + PAGE_SIZE);
             }
         }
+
+        return null;
     }, [orderData]);
 
     // If the user is no longer signed in, redirect to the home page.
@@ -88,11 +90,11 @@ export const useOrderHistoryPage = (props = {}) => {
 
     return {
         errorMessage: derivedErrorMessage,
-        fetchMoreOrders,
         handleReset,
         handleSubmit,
         isBackgroundLoading,
         isLoadingWithoutData,
+        loadMoreOrders,
         orders,
         searchText
     };

--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -246,6 +246,7 @@
     "orderHistoryPage.emptyDataMessage": "You don't have any orders yet.",
     "orderHistoryPage.invalidOrderNumber": "Order \"{number}\" was not found.",
     "orderHistoryPage.loadMore": "Load More",
+    "orderHistoryPage.pageInfo": "Showing {current} of {total}",
     "orderHistoryPage.pageTitleText": "Order History",
     "orderHistoryPage.search": "Search by Order Number",
     "orderItems.itemsHeading": "Items",

--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -245,6 +245,7 @@
     "orderDetails.waitingOnTracking": "Waiting for tracking information",
     "orderHistoryPage.emptyDataMessage": "You don't have any orders yet.",
     "orderHistoryPage.invalidOrderNumber": "Order \"{number}\" was not found.",
+    "orderHistoryPage.loadMore": "Load More",
     "orderHistoryPage.pageTitleText": "Order History",
     "orderHistoryPage.search": "Search by Order Number",
     "orderItems.itemsHeading": "Items",

--- a/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/__snapshots__/orderHistoryPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/__snapshots__/orderHistoryPage.spec.js.snap
@@ -12,107 +12,126 @@ exports[`renders correctly with data 1`] = `
       Order History
     </h1>
     <div
-      className="search"
+      className="filterRow"
     >
       <span
-        className="root"
-        style={
-          Object {
-            "--iconsAfter": 0,
-            "--iconsBefore": 1,
-          }
-        }
+        className="pageInfo"
       >
-        <span
-          className="input"
-        >
-          <input
-            className="input"
-            id="search"
-            name="search"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onKeyPress={[MockFunction handleKeyPress]}
-            placeholder="Search by Order Number"
-            value=""
-          />
-        </span>
-        <span
-          className="before"
-        >
-          <span
-            className="root"
-          >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle
-                cx="11"
-                cy="11"
-                r="8"
-              />
-              <line
-                x1="21"
-                x2="16.65"
-                y1="21"
-                y2="16.65"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          className="after"
+        <mock-FormattedMessage
+          defaultMessage="Showing {current} of {total}"
+          id="orderHistoryPage.pageInfo"
+          values={
+            Object {
+              "current": 3,
+              "total": 6,
+            }
+          }
         />
       </span>
-      <p
-        className="root"
-      />
-      <button
-        className="searchButton"
-        disabled={false}
-        onClick={[MockFunction getOrderDetails]}
-        type="button"
+      <form
+        className="search"
+        onKeyDown={[Function]}
+        onReset={[Function]}
+        onSubmit={[Function]}
       >
         <span
-          className="content"
+          className="root"
+          style={
+            Object {
+              "--iconsAfter": 0,
+              "--iconsBefore": 1,
+            }
+          }
         >
           <span
-            className="root"
+            className="input"
           >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <line
-                x1="5"
-                x2="19"
-                y1="12"
-                y2="12"
-              />
-              <polyline
-                points="12 5 19 12 12 19"
-              />
-            </svg>
+            <input
+              className="input"
+              id="search"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Search by Order Number"
+              value=""
+            />
           </span>
+          <span
+            className="before"
+          >
+            <span
+              className="root"
+            >
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="11"
+                  cy="11"
+                  r="8"
+                />
+                <line
+                  x1="21"
+                  x2="16.65"
+                  y1="21"
+                  y2="16.65"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="after"
+          />
         </span>
-      </button>
+        <p
+          className="root"
+        />
+        <button
+          className="searchButton"
+          disabled={false}
+          type="submit"
+        >
+          <span
+            className="content"
+          >
+            <span
+              className="root"
+            >
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="5"
+                  x2="19"
+                  y1="12"
+                  y2="12"
+                />
+                <polyline
+                  points="12 5 19 12 12 19"
+                />
+              </svg>
+            </span>
+          </span>
+        </button>
+      </form>
     </div>
     <ul
       className="orderHistoryTable"
@@ -139,6 +158,21 @@ exports[`renders correctly with data 1`] = `
         }
       />
     </ul>
+    <button
+      className="root_lowPriority"
+      disabled={false}
+      onClick={[MockFunction loadMoreOrders]}
+      type="button"
+    >
+      <span
+        className="content"
+      >
+        <mock-FormattedMessage
+          defaultMessage="Load More"
+          id="orderHistoryPage.loadMore"
+        />
+      </span>
+    </button>
   </div>
 </mock-OrderHistoryContextProvider>
 `;
@@ -155,107 +189,115 @@ exports[`renders correctly without data 1`] = `
       Order History
     </h1>
     <div
-      className="search"
+      className="filterRow"
     >
       <span
-        className="root"
-        style={
-          Object {
-            "--iconsAfter": 0,
-            "--iconsBefore": 1,
-          }
-        }
+        className="pageInfo"
+      />
+      <form
+        className="search"
+        onKeyDown={[Function]}
+        onReset={[Function]}
+        onSubmit={[Function]}
       >
         <span
-          className="input"
+          className="root"
+          style={
+            Object {
+              "--iconsAfter": 0,
+              "--iconsBefore": 1,
+            }
+          }
         >
-          <input
+          <span
             className="input"
-            id="search"
-            name="search"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onKeyPress={[MockFunction handleKeyPress]}
-            placeholder="Search by Order Number"
-            value=""
+          >
+            <input
+              className="input"
+              id="search"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Search by Order Number"
+              value=""
+            />
+          </span>
+          <span
+            className="before"
+          >
+            <span
+              className="root"
+            >
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="11"
+                  cy="11"
+                  r="8"
+                />
+                <line
+                  x1="21"
+                  x2="16.65"
+                  y1="21"
+                  y2="16.65"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="after"
           />
         </span>
-        <span
-          className="before"
-        >
-          <span
-            className="root"
-          >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle
-                cx="11"
-                cy="11"
-                r="8"
-              />
-              <line
-                x1="21"
-                x2="16.65"
-                y1="21"
-                y2="16.65"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          className="after"
+        <p
+          className="root"
         />
-      </span>
-      <p
-        className="root"
-      />
-      <button
-        className="searchButton"
-        disabled={false}
-        onClick={[MockFunction getOrderDetails]}
-        type="button"
-      >
-        <span
-          className="content"
+        <button
+          className="searchButton"
+          disabled={false}
+          type="submit"
         >
           <span
-            className="root"
+            className="content"
           >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              className="root"
             >
-              <line
-                x1="5"
-                x2="19"
-                y1="12"
-                y2="12"
-              />
-              <polyline
-                points="12 5 19 12 12 19"
-              />
-            </svg>
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="5"
+                  x2="19"
+                  y1="12"
+                  y2="12"
+                />
+                <polyline
+                  points="12 5 19 12 12 19"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      </form>
     </div>
     <h3
       className="emptyHistoryMessage"
@@ -290,86 +332,6 @@ Array [
 ]
 `;
 
-exports[`renders full page loading indicator 1`] = `
-<div
-  className="global"
->
-  <span
-    className="root"
-  >
-    <svg
-      className="icon"
-      fill="none"
-      height={64}
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      viewBox="0 0 24 24"
-      width={64}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <line
-        x1="12"
-        x2="12"
-        y1="2"
-        y2="6"
-      />
-      <line
-        x1="12"
-        x2="12"
-        y1="18"
-        y2="22"
-      />
-      <line
-        x1="4.93"
-        x2="7.76"
-        y1="4.93"
-        y2="7.76"
-      />
-      <line
-        x1="16.24"
-        x2="19.07"
-        y1="16.24"
-        y2="19.07"
-      />
-      <line
-        x1="2"
-        x2="6"
-        y1="12"
-        y2="12"
-      />
-      <line
-        x1="18"
-        x2="22"
-        y1="12"
-        y2="12"
-      />
-      <line
-        x1="4.93"
-        x2="7.76"
-        y1="19.07"
-        y2="16.24"
-      />
-      <line
-        x1="16.24"
-        x2="19.07"
-        y1="7.76"
-        y2="4.93"
-      />
-    </svg>
-  </span>
-  <span
-    className="message"
-  >
-    <mock-FormattedMessage
-      defaultMessage="Fetching Data..."
-      id="loadingIndicator.message"
-    />
-  </span>
-</div>
-`;
-
 exports[`renders invalid order id message if order id is wrong 1`] = `
 <mock-OrderHistoryContextProvider>
   <div
@@ -382,70 +344,121 @@ exports[`renders invalid order id message if order id is wrong 1`] = `
       Order History
     </h1>
     <div
-      className="search"
+      className="filterRow"
     >
       <span
-        className="root"
-        style={
-          Object {
-            "--iconsAfter": 1,
-            "--iconsBefore": 1,
-          }
-        }
+        className="pageInfo"
+      />
+      <form
+        className="search"
+        onKeyDown={[Function]}
+        onReset={[Function]}
+        onSubmit={[Function]}
       >
         <span
-          className="input"
-        >
-          <input
-            className="input"
-            id="search"
-            name="search"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onKeyPress={[MockFunction handleKeyPress]}
-            placeholder="Search by Order Number"
-            value=""
-          />
-        </span>
-        <span
-          className="before"
+          className="root"
+          style={
+            Object {
+              "--iconsAfter": 1,
+              "--iconsBefore": 1,
+            }
+          }
         >
           <span
-            className="root"
+            className="input"
           >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
+            <input
+              className="input"
+              id="search"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Search by Order Number"
+              value=""
+            />
+          </span>
+          <span
+            className="before"
+          >
+            <span
+              className="root"
             >
-              <circle
-                cx="11"
-                cy="11"
-                r="8"
-              />
-              <line
-                x1="21"
-                x2="16.65"
-                y1="21"
-                y2="16.65"
-              />
-            </svg>
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="11"
+                  cy="11"
+                  r="8"
+                />
+                <line
+                  x1="21"
+                  x2="16.65"
+                  y1="21"
+                  y2="16.65"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="after"
+          >
+            <button
+              className="root"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="root"
+              >
+                <svg
+                  className="icon"
+                  fill="none"
+                  height={24}
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <line
+                    x1="18"
+                    x2="6"
+                    y1="6"
+                    y2="18"
+                  />
+                  <line
+                    x1="6"
+                    x2="18"
+                    y1="6"
+                    y2="18"
+                  />
+                </svg>
+              </span>
+            </button>
           </span>
         </span>
-        <span
-          className="after"
+        <p
+          className="root"
+        />
+        <button
+          className="searchButton"
+          disabled={false}
+          type="submit"
         >
-          <button
-            className="root"
-            onClick={[MockFunction resetForm]}
-            type="button"
+          <span
+            className="content"
           >
             <span
               className="root"
@@ -463,62 +476,19 @@ exports[`renders invalid order id message if order id is wrong 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <line
-                  x1="18"
-                  x2="6"
-                  y1="6"
-                  y2="18"
+                  x1="5"
+                  x2="19"
+                  y1="12"
+                  y2="12"
                 />
-                <line
-                  x1="6"
-                  x2="18"
-                  y1="6"
-                  y2="18"
+                <polyline
+                  points="12 5 19 12 12 19"
                 />
               </svg>
             </span>
-          </button>
-        </span>
-      </span>
-      <p
-        className="root"
-      />
-      <button
-        className="searchButton"
-        disabled={false}
-        onClick={[MockFunction getOrderDetails]}
-        type="button"
-      >
-        <span
-          className="content"
-        >
-          <span
-            className="root"
-          >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <line
-                x1="5"
-                x2="19"
-                y1="12"
-                y2="12"
-              />
-              <polyline
-                points="12 5 19 12 12 19"
-              />
-            </svg>
           </span>
-        </span>
-      </button>
+        </button>
+      </form>
     </div>
     <h3
       className="emptyHistoryMessage"
@@ -537,6 +507,204 @@ exports[`renders invalid order id message if order id is wrong 1`] = `
 </mock-OrderHistoryContextProvider>
 `;
 
+exports[`renders loading indicator 1`] = `
+<mock-OrderHistoryContextProvider>
+  <div
+    className="root"
+  >
+    Title
+    <h1
+      className="heading"
+    >
+      Order History
+    </h1>
+    <div
+      className="filterRow"
+    >
+      <span
+        className="pageInfo"
+      />
+      <form
+        className="search"
+        onKeyDown={[Function]}
+        onReset={[Function]}
+        onSubmit={[Function]}
+      >
+        <span
+          className="root"
+          style={
+            Object {
+              "--iconsAfter": 0,
+              "--iconsBefore": 1,
+            }
+          }
+        >
+          <span
+            className="input"
+          >
+            <input
+              className="input"
+              id="search"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Search by Order Number"
+              value=""
+            />
+          </span>
+          <span
+            className="before"
+          >
+            <span
+              className="root"
+            >
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="11"
+                  cy="11"
+                  r="8"
+                />
+                <line
+                  x1="21"
+                  x2="16.65"
+                  y1="21"
+                  y2="16.65"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="after"
+          />
+        </span>
+        <p
+          className="root"
+        />
+        <button
+          className="searchButton"
+          disabled={true}
+          type="submit"
+        >
+          <span
+            className="content"
+          >
+            <span
+              className="root"
+            >
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="5"
+                  x2="19"
+                  y1="12"
+                  y2="12"
+                />
+                <polyline
+                  points="12 5 19 12 12 19"
+                />
+              </svg>
+            </span>
+          </span>
+        </button>
+      </form>
+    </div>
+    <div
+      className="root"
+    >
+      <span
+        className="root"
+      >
+        <svg
+          className="icon"
+          fill="none"
+          height={64}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={64}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <line
+            x1="12"
+            x2="12"
+            y1="2"
+            y2="6"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="18"
+            y2="22"
+          />
+          <line
+            x1="4.93"
+            x2="7.76"
+            y1="4.93"
+            y2="7.76"
+          />
+          <line
+            x1="16.24"
+            x2="19.07"
+            y1="16.24"
+            y2="19.07"
+          />
+          <line
+            x1="2"
+            x2="6"
+            y1="12"
+            y2="12"
+          />
+          <line
+            x1="18"
+            x2="22"
+            y1="12"
+            y2="12"
+          />
+          <line
+            x1="4.93"
+            x2="7.76"
+            y1="19.07"
+            y2="16.24"
+          />
+          <line
+            x1="16.24"
+            x2="19.07"
+            y1="7.76"
+            y2="4.93"
+          />
+        </svg>
+      </span>
+      <span
+        className="message"
+      />
+    </div>
+  </div>
+</mock-OrderHistoryContextProvider>
+`;
+
 exports[`renders no orders message is orders is empty 1`] = `
 <mock-OrderHistoryContextProvider>
   <div
@@ -549,107 +717,115 @@ exports[`renders no orders message is orders is empty 1`] = `
       Order History
     </h1>
     <div
-      className="search"
+      className="filterRow"
     >
       <span
-        className="root"
-        style={
-          Object {
-            "--iconsAfter": 0,
-            "--iconsBefore": 1,
-          }
-        }
+        className="pageInfo"
+      />
+      <form
+        className="search"
+        onKeyDown={[Function]}
+        onReset={[Function]}
+        onSubmit={[Function]}
       >
         <span
-          className="input"
+          className="root"
+          style={
+            Object {
+              "--iconsAfter": 0,
+              "--iconsBefore": 1,
+            }
+          }
         >
-          <input
+          <span
             className="input"
-            id="search"
-            name="search"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onKeyPress={[MockFunction handleKeyPress]}
-            placeholder="Search by Order Number"
-            value=""
+          >
+            <input
+              className="input"
+              id="search"
+              name="search"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Search by Order Number"
+              value=""
+            />
+          </span>
+          <span
+            className="before"
+          >
+            <span
+              className="root"
+            >
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="11"
+                  cy="11"
+                  r="8"
+                />
+                <line
+                  x1="21"
+                  x2="16.65"
+                  y1="21"
+                  y2="16.65"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="after"
           />
         </span>
-        <span
-          className="before"
-        >
-          <span
-            className="root"
-          >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle
-                cx="11"
-                cy="11"
-                r="8"
-              />
-              <line
-                x1="21"
-                x2="16.65"
-                y1="21"
-                y2="16.65"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          className="after"
+        <p
+          className="root"
         />
-      </span>
-      <p
-        className="root"
-      />
-      <button
-        className="searchButton"
-        disabled={false}
-        onClick={[MockFunction getOrderDetails]}
-        type="button"
-      >
-        <span
-          className="content"
+        <button
+          className="searchButton"
+          disabled={false}
+          type="submit"
         >
           <span
-            className="root"
+            className="content"
           >
-            <svg
-              className="icon"
-              fill="none"
-              height={24}
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              className="root"
             >
-              <line
-                x1="5"
-                x2="19"
-                y1="12"
-                y2="12"
-              />
-              <polyline
-                points="12 5 19 12 12 19"
-              />
-            </svg>
+              <svg
+                className="icon"
+                fill="none"
+                height={24}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="5"
+                  x2="19"
+                  y1="12"
+                  y2="12"
+                />
+                <polyline
+                  points="12 5 19 12 12 19"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      </form>
     </div>
     <h3
       className="emptyHistoryMessage"

--- a/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/__snapshots__/resetButton.spec.js.snap
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/__snapshots__/resetButton.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders reset trigger 1`] = `
+<button
+  onClick={[Function]}
+  type="button"
+>
+  <span>
+    <svg
+      fill="none"
+      height={24}
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <line
+        x1="18"
+        x2="6"
+        y1="6"
+        y2="18"
+      />
+      <line
+        x1="6"
+        x2="18"
+        y1="6"
+        y2="18"
+      />
+    </svg>
+  </span>
+</button>
+`;

--- a/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/orderHistoryPage.spec.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/orderHistoryPage.spec.js
@@ -13,12 +13,13 @@ jest.mock(
             .mockName('useOrderHistoryPage')
             .mockReturnValue({
                 errorMessage: null,
-                getOrderDetails: jest.fn().mockName('getOrderDetails'),
-                handleKeyPress: jest.fn().mockName('handleKeyPress'),
+                handleReset: jest.fn().mockName('handleReset'),
+                handleSubmit: jest.fn().mockName('handleSubmit'),
                 isBackgroundLoading: false,
                 isLoadingWithoutData: false,
+                loadMoreOrders: null,
                 orders: [],
-                resetForm: jest.fn().mockName('resetForm'),
+                pageInfo: null,
                 searchText: ''
             })
     })
@@ -54,16 +55,17 @@ jest.mock('../orderRow', () => 'OrderRow');
 
 const talonProps = {
     errorMessage: null,
-    getOrderDetails: jest.fn().mockName('getOrderDetails'),
-    handleKeyPress: jest.fn().mockName('handleKeyPress'),
+    handleReset: jest.fn().mockName('handleReset'),
+    handleSubmit: jest.fn().mockName('handleSubmit'),
     isBackgroundLoading: false,
     isLoadingWithoutData: false,
+    loadMoreOrders: null,
     orders: [],
-    resetForm: jest.fn().mockName('resetForm'),
+    pageInfo: null,
     searchText: ''
 };
 
-test('renders full page loading indicator', () => {
+test('renders loading indicator', () => {
     useOrderHistoryPage.mockReturnValueOnce({
         ...talonProps,
         isLoadingWithoutData: true,
@@ -91,7 +93,9 @@ test('renders correctly with data', () => {
     useOrderHistoryPage.mockReturnValueOnce({
         ...talonProps,
         isLoadingWithoutData: false,
-        orders: [{ id: 1 }, { id: 2 }, { id: 3 }]
+        loadMoreOrders: jest.fn().mockName('loadMoreOrders'),
+        orders: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        pageInfo: { current: 3, total: 6 }
     });
 
     const tree = createTestInstance(<OrderHistoryPage />);

--- a/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/resetButton.spec.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/resetButton.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useFormApi } from 'informed';
+import { createTestInstance } from '@magento/peregrine';
+
+import Trigger from '../../Trigger';
+import ResetButton from '../resetButton';
+
+jest.mock('informed', () => ({
+    useFormApi: jest.fn()
+}));
+
+const props = { onReset: jest.fn() };
+
+test('renders reset trigger', () => {
+    const tree = createTestInstance(<ResetButton {...props} />);
+
+    expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('calls reset handlers on click', () => {
+    const mockReset = jest.fn();
+    useFormApi.mockReturnValue({ reset: mockReset });
+
+    const { root } = createTestInstance(<ResetButton {...props} />);
+    const triggerNode = root.findByType(Trigger);
+    const { action } = triggerNode.props;
+
+    action();
+
+    expect(mockReset).toHaveBeenCalled();
+    expect(props.onReset).toHaveBeenCalled();
+});

--- a/packages/venia-ui/lib/components/OrderHistoryPage/index.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/index.js
@@ -1,9 +1,1 @@
-import React from 'react';
-import { Form } from 'informed';
-import OrderHistoryPage from './orderHistoryPage';
-
-export default props => (
-    <Form>
-        <OrderHistoryPage {...props} />
-    </Form>
-);
+export { default } from './orderHistoryPage';

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.css
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.css
@@ -20,13 +20,21 @@
     row-gap: 1rem;
 }
 
+.filterRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.pageInfo {
+    font-size: 0.875rem;
+}
+
 .search {
     display: grid;
     grid-auto-flow: column;
     gap: 1rem;
     width: 22rem;
-    justify-self: end;
-    justify-content: end;
 }
 
 .searchButton {
@@ -50,6 +58,12 @@
     .root {
         padding-left: 1.5rem;
         padding-right: 1.5rem;
+    }
+
+    .filterRow {
+        align-items: flex-start;
+        flex-direction: column;
+        row-gap: 1rem;
     }
 
     .search {

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.css
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.css
@@ -41,6 +41,11 @@
     color: white;
 }
 
+.loadMoreButton {
+    composes: root_lowPriority from '../Button/button.css';
+    justify-self: center;
+}
+
 @media (max-width: 960px) {
     .root {
         padding-left: 1.5rem;

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.css
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.css
@@ -21,19 +21,19 @@
 }
 
 .filterRow {
-    display: flex;
     align-items: center;
+    display: flex;
     justify-content: space-between;
 }
 
 .pageInfo {
-    font-size: 0.875rem;
+    font-size: var(--venia-typography-body-S-fontSize);
 }
 
 .search {
     display: grid;
-    grid-auto-flow: column;
     gap: 1rem;
+    grid-auto-flow: column;
     width: 22rem;
 }
 

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
@@ -43,6 +43,7 @@ const OrderHistoryPage = props => {
         isBackgroundLoading,
         isLoadingWithoutData,
         orders,
+        pageInfo,
         searchText
     } = talonProps;
     const [, { addToast }] = useToasts();
@@ -117,6 +118,14 @@ const OrderHistoryPage = props => {
         />
     );
 
+    const pageInfoLabel = pageInfo ? (
+        <FormattedMessage
+            defaultMessage={'Showing {current} of {total}'}
+            id={'orderHistoryPage.pageInfo'}
+            values={pageInfo}
+        />
+    ) : null;
+
     const loadMoreButton = loadMoreOrders ? (
         <Button
             classes={{ root_lowPriority: classes.loadMoreButton }}
@@ -148,23 +157,28 @@ const OrderHistoryPage = props => {
             <div className={classes.root}>
                 <Title>{title}</Title>
                 <h1 className={classes.heading}>{PAGE_TITLE}</h1>
-                <Form className={classes.search} onSubmit={handleSubmit}>
-                    <TextInput
-                        after={resetButtonElement}
-                        before={searchIcon}
-                        field="search"
-                        id={classes.search}
-                        placeholder={SEARCH_PLACE_HOLDER}
-                    />
-                    <Button
-                        className={classes.searchButton}
-                        disabled={isBackgroundLoading || isLoadingWithoutData}
-                        priority={'high'}
-                        type="submit"
-                    >
-                        {submitIcon}
-                    </Button>
-                </Form>
+                <div className={classes.filterRow}>
+                    <span className={classes.pageInfo}>{pageInfoLabel}</span>
+                    <Form className={classes.search} onSubmit={handleSubmit}>
+                        <TextInput
+                            after={resetButtonElement}
+                            before={searchIcon}
+                            field="search"
+                            id={classes.search}
+                            placeholder={SEARCH_PLACE_HOLDER}
+                        />
+                        <Button
+                            className={classes.searchButton}
+                            disabled={
+                                isBackgroundLoading || isLoadingWithoutData
+                            }
+                            priority={'high'}
+                            type="submit"
+                        >
+                            {submitIcon}
+                        </Button>
+                    </Form>
+                </div>
                 {pageContents}
                 {loadMoreButton}
             </div>

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
@@ -2,11 +2,11 @@ import React, { useMemo, useEffect } from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import {
     Search as SearchIcon,
-    X as ClearIcon,
     AlertCircle as AlertCircleIcon,
     ArrowRight as SubmitIcon
 } from 'react-feather';
 import { shape, string } from 'prop-types';
+import { Form } from 'informed';
 
 import { useToasts } from '@magento/peregrine/lib/Toasts';
 import OrderHistoryContextProvider from '@magento/peregrine/lib/talons/OrderHistoryPage/orderHistoryContext';
@@ -15,13 +15,13 @@ import { useOrderHistoryPage } from '@magento/peregrine/lib/talons/OrderHistoryP
 import Icon from '../Icon';
 import Button from '../Button';
 import TextInput from '../TextInput';
-import Trigger from '../Trigger';
 import { Title } from '../Head';
 import { fullPageLoadingIndicator } from '../LoadingIndicator';
 import OrderRow from './orderRow';
 import { mergeClasses } from '../../classify';
 
 import defaultClasses from './orderHistoryPage.css';
+import ResetButton from './resetButton';
 
 const errorIcon = (
     <Icon
@@ -31,19 +31,17 @@ const errorIcon = (
         }}
     />
 );
-const clearIcon = <Icon src={ClearIcon} size={24} />;
 const searchIcon = <Icon src={SearchIcon} size={24} />;
 
 const OrderHistoryPage = props => {
     const talonProps = useOrderHistoryPage();
     const {
         errorMessage,
-        getOrderDetails,
-        handleKeyPress,
+        handleReset,
+        handleSubmit,
         isBackgroundLoading,
         isLoadingWithoutData,
         orders,
-        resetForm,
         searchText
     } = talonProps;
     const [, { addToast }] = useToasts();
@@ -101,9 +99,7 @@ const OrderHistoryPage = props => {
     // STORE_NAME is injected by Webpack at build time.
     const title = `${PAGE_TITLE} - ${STORE_NAME}`;
 
-    const resetButton = searchText ? (
-        <Trigger action={resetForm}>{clearIcon}</Trigger>
-    ) : null;
+    const resetElement = <ResetButton onReset={handleReset} />;
 
     const submitIcon = (
         <Icon
@@ -136,24 +132,27 @@ const OrderHistoryPage = props => {
             <div className={classes.root}>
                 <Title>{title}</Title>
                 <h1 className={classes.heading}>{PAGE_TITLE}</h1>
-                <div className={classes.search}>
+                <Form
+                    className={classes.search}
+                    onSubmit={handleSubmit}
+                    allowEmptyStrings={true}
+                >
                     <TextInput
-                        after={resetButton}
+                        after={resetElement}
                         before={searchIcon}
                         field="search"
                         id={classes.search}
                         placeholder={SEARCH_PLACE_HOLDER}
-                        onKeyPress={handleKeyPress}
                     />
                     <Button
                         disabled={isBackgroundLoading || isLoadingWithoutData}
                         priority={'high'}
-                        onClick={getOrderDetails}
                         className={classes.searchButton}
+                        type="submit"
                     >
                         {submitIcon}
                     </Button>
-                </div>
+                </Form>
                 {pageContents}
             </div>
         </OrderHistoryContextProvider>

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
@@ -37,6 +37,7 @@ const OrderHistoryPage = props => {
     const talonProps = useOrderHistoryPage();
     const {
         errorMessage,
+        fetchMoreOrders,
         handleReset,
         handleSubmit,
         isBackgroundLoading,
@@ -154,6 +155,9 @@ const OrderHistoryPage = props => {
                     </Button>
                 </Form>
                 {pageContents}
+                <button type="button" onClick={fetchMoreOrders}>
+                    Fetch More
+                </button>
             </div>
         </OrderHistoryContextProvider>
     );

--- a/packages/venia-ui/lib/components/OrderHistoryPage/resetButton.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/resetButton.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useFieldState, useFormApi } from 'informed';
+import { X as ClearIcon } from 'react-feather';
+
+import Icon from '../Icon';
+import Trigger from '../Trigger';
+
+const clearIcon = <Icon src={ClearIcon} size={24} />;
+
+const ResetButton = props => {
+    const { onReset } = props;
+    const searchText = useFieldState('search');
+    const formApi = useFormApi();
+
+    const handleReset = () => {
+        formApi.reset();
+        onReset();
+    };
+
+    return searchText ? (
+        <Trigger action={handleReset}>{clearIcon}</Trigger>
+    ) : null;
+};
+
+export default ResetButton;

--- a/packages/venia-ui/lib/components/OrderHistoryPage/resetButton.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/resetButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useFormApi } from 'informed';
+import { func } from 'prop-types';
 import { X as ClearIcon } from 'react-feather';
 
 import Icon from '../Icon';
@@ -13,10 +14,17 @@ const ResetButton = props => {
 
     const handleReset = () => {
         formApi.reset();
-        onReset();
+
+        if (onReset) {
+            onReset();
+        }
     };
 
     return <Trigger action={handleReset}>{clearIcon}</Trigger>;
 };
 
 export default ResetButton;
+
+ResetButton.propTypes = {
+    onReset: func
+};

--- a/packages/venia-ui/lib/components/OrderHistoryPage/resetButton.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/resetButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useFieldState, useFormApi } from 'informed';
+import { useFormApi } from 'informed';
 import { X as ClearIcon } from 'react-feather';
 
 import Icon from '../Icon';
@@ -9,7 +9,6 @@ const clearIcon = <Icon src={ClearIcon} size={24} />;
 
 const ResetButton = props => {
     const { onReset } = props;
-    const searchText = useFieldState('search');
     const formApi = useFormApi();
 
     const handleReset = () => {
@@ -17,9 +16,7 @@ const ResetButton = props => {
         onReset();
     };
 
-    return searchText ? (
-        <Trigger action={handleReset}>{clearIcon}</Trigger>
-    ) : null;
+    return <Trigger action={handleReset}>{clearIcon}</Trigger>;
 };
 
 export default ResetButton;


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

As a customer with lots of Orders (20+), I would like pagination (struggling to come up with a story here, sorry!). This will allow me to view my most recent Orders without waiting for a large network request to come back with all of my orders.

Technical Notes:
pageSize defaults to 20 and can be adjusted
Response fields include total_count and page info (current page, page size, total pages)
I don't see any ability to sort the orders response, appears to be by order number/date

After some thinking on this, I propose a simple UI for the Shoppers where if there are >10 orders in their Order History the page will display the first 10 orders (most recent to oldest) and a "Load More" button will appear below the list of orders. The Shopper can then tap this to load the next 10 orders. This will be the the behavior until all orders have been loaded.  

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-887](https://jira.corp.magento.com/browse/PWA-887)] My Account: Order History - Pagination

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
Test Plan : (In below considered 10 as pagination point)

**Verify Pagination**
1. Does not display if there are 0 orders
2. Does not display if there are 10 orders
3. Does display if there are 11 orders.

**Verify if user hit Load More**
1. When there are than 11 orders then next 1 order should display and Load More button should no more exist.
2. When there are 20 orders next 10 order should display and Load More button should no more exist.
3. When there are 21 orders next 10 order should display and Load More button should exists.

1. Verify Load more button functionality for page with 50 or more orders.
2. Verify above scenarios for Desktop Chrome, FF, Safari and Android/iOS devices.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
