### PR TITLE
Add coveralls badge back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/magento/pwa-studio/badge.svg?branch=develop)](https://coveralls.io/github/magento/pwa-studio?branch=develop)
+
 # PWA Studio
 
 Magento PWA Studio is a collection of tools that lets developers build complex Progressive Web Applications on top of Magento 2 stores.


### PR DESCRIPTION
## Description

Adds the Coveralls badge back to the README

## Related Issue

Closes PWA-1012

## Acceptance

Anyone on the team

### Verification Stakeholders

Anyone on the team

### Specification


### Verification Steps

1. View the README.md file
2. Verify Coveralls badge appears at the top with accurate coverage

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
