### PR TITLE
[PWA-998] Increase Test Coverage in peregrine/lib/talons/SignIn

### DIFF
--- a/packages/peregrine/lib/talons/SignIn/__tests__/useSignIn.spec.js
+++ b/packages/peregrine/lib/talons/SignIn/__tests__/useSignIn.spec.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/client/testing';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { useCartContext } from '../../../context/cart';
+import { useUserContext } from '../../../context/user';
+import defaultOperations from '../signIn.gql';
+import { useSignIn } from '../useSignIn';
+
+jest.mock('../../../Apollo/clearCartDataFromCache');
+jest.mock('../../../Apollo/clearCustomerDataFromCache');
+jest.mock('../../../hooks/useAwaitQuery');
+jest.mock('../../../store/actions/cart', () => ({
+    retrieveCartId: jest.fn().mockReturnValue('new-cart-id')
+}));
+
+jest.mock('../../../context/cart', () => ({
+    useCartContext: jest.fn().mockReturnValue([
+        { cartId: 'old-cart-id' },
+        {
+            createCart: jest.fn(),
+            removeCart: jest.fn(),
+            getCartDetails: jest.fn()
+        }
+    ])
+}));
+
+jest.mock('../../../context/user', () => ({
+    useUserContext: jest.fn().mockReturnValue([
+        {
+            isGettingDetails: false,
+            getDetailsError: 'getDetails error from redux'
+        },
+        { getUserDetails: jest.fn(), setToken: jest.fn() }
+    ])
+}));
+
+const signInVariables = {
+    email: 'fry@planetexpress.com',
+    password: 'slurm is the best'
+};
+const authToken = 'auth-token-123';
+
+const signInMock = {
+    request: {
+        query: defaultOperations.signInMutation,
+        variables: signInVariables
+    },
+    result: {
+        data: { generateCustomerToken: { token: authToken } }
+    }
+};
+
+const mergeCartsMock = {
+    request: {
+        query: defaultOperations.mergeCartsMutation,
+        variables: {
+            destinationCartId: 'new-cart-id',
+            sourceCartId: 'old-cart-id'
+        }
+    },
+    result: {
+        data: null
+    }
+};
+
+const initialProps = {
+    getCartDetailsQuery: 'getCartDetailsQuery',
+    setDefaultUsername: jest.fn(),
+    showCreateAccount: jest.fn(),
+    showForgotPassword: jest.fn()
+};
+
+const renderHookWithProviders = ({
+    renderHookOptions = { initialProps },
+    mocks = [signInMock, mergeCartsMock]
+} = {}) => {
+    const wrapper = ({ children }) => (
+        <MockedProvider mocks={mocks} addTypename={false}>
+            {children}
+        </MockedProvider>
+    );
+
+    return renderHook(useSignIn, { wrapper, ...renderHookOptions });
+};
+
+test('returns correct shape', () => {
+    const { result } = renderHookWithProviders();
+
+    expect(result.current).toMatchInlineSnapshot(`
+        Object {
+          "errors": Map {
+            "getUserDetailsQuery" => "getDetails error from redux",
+            "signInMutation" => undefined,
+          },
+          "handleCreateAccount": [Function],
+          "handleForgotPassword": [Function],
+          "handleSubmit": [Function],
+          "isBusy": false,
+          "setFormApi": [Function],
+        }
+    `);
+});
+
+test('handleSubmit triggers waterfall of operations and actions', async () => {
+    const [, { getCartDetails }] = useCartContext();
+    const [, { getUserDetails, setToken }] = useUserContext();
+
+    const { result } = renderHookWithProviders();
+
+    await act(() => result.current.handleSubmit(signInVariables));
+
+    expect(result.current.isBusy).toBe(true);
+    expect(setToken).toHaveBeenCalledWith(authToken);
+    expect(getCartDetails).toHaveBeenCalled();
+    expect(getUserDetails).toHaveBeenCalled();
+});
+
+test('handleSubmit exception is logged and resets state', async () => {
+    const errorMessage = 'Oh no! Something went wrong :(';
+    const [, { getUserDetails, setToken }] = useUserContext();
+    setToken.mockRejectedValue(errorMessage);
+    jest.spyOn(console, 'error');
+
+    const { result } = renderHookWithProviders();
+
+    await act(() => result.current.handleSubmit(signInVariables));
+
+    expect(result.current.isBusy).toBe(false);
+    expect(getUserDetails).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(errorMessage);
+});
+
+test('handleForgotPassword triggers callbacks', () => {
+    const mockUsername = 'fry@planetexpress.com';
+    const mockApi = {
+        getValue: jest.fn().mockReturnValue(mockUsername)
+    };
+
+    const { result } = renderHookWithProviders();
+    act(() => result.current.setFormApi(mockApi));
+    act(() => result.current.handleForgotPassword());
+
+    expect(initialProps.setDefaultUsername).toHaveBeenCalledWith(mockUsername);
+    expect(initialProps.showForgotPassword).toHaveBeenCalled();
+});
+
+test('handleCreateAccount triggers callbacks', () => {
+    const mockUsername = 'fry@planetexpress.com';
+    const mockApi = {
+        getValue: jest.fn().mockReturnValue(mockUsername)
+    };
+
+    const { result } = renderHookWithProviders();
+    act(() => result.current.setFormApi(mockApi));
+    act(() => result.current.handleCreateAccount());
+
+    expect(initialProps.setDefaultUsername).toHaveBeenCalledWith(mockUsername);
+    expect(initialProps.showCreateAccount).toHaveBeenCalled();
+});
+
+test('mutation error is returned by talon', async () => {
+    const signInErrorMock = {
+        request: signInMock.request,
+        error: new Error('Uh oh! There was an error signing in :(')
+    };
+
+    const { result } = renderHookWithProviders({ mocks: [signInErrorMock] });
+    await act(() => result.current.handleSubmit(signInVariables));
+
+    expect(result.current.errors.get('signInMutation')).toMatchInlineSnapshot(
+        `[Error: Uh oh! There was an error signing in :(]`
+    );
+});

--- a/packages/peregrine/package.json
+++ b/packages/peregrine/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@magento/eslint-config": "~1.5.0",
+    "@testing-library/react-hooks": "~5.0.3",
     "intl": "~1.2.5",
     "intl-locales-supported": "~1.8.12",
     "react": "~17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,6 +2975,18 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/react-hooks@~5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.0.3.tgz#dd0d2048817b013b266d35ca45e3ea48a19fd87e"
+  integrity sha512-UrnnRc5II7LMH14xsYNm/WRch/67cBafmrSQcyFh0v+UUmSf1uzfB7zn5jQXSettGwOSxJwdQUN7PgkT0w22Lg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -3262,10 +3274,24 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
   integrity sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
+  integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
   dependencies:
     "@types/react" "*"
 
@@ -3276,6 +3302,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.1.tgz#eb1f1407dea8da3bc741879c1192aa703ab9975b"
+  integrity sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/reactcss@*":
   version "1.2.3"
@@ -6416,6 +6450,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
+csstype@^3.0.2:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
+  integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
+
 csv-parse@~4.4.6:
   version "4.4.7"
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.4.7.tgz#069de0875b92780ca74a018c9880ab41cb3517a1"
@@ -8197,6 +8236,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@1.1.0:
   version "1.1.0"
@@ -14321,6 +14365,13 @@ react-draggable@^4.0.3:
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.0.tgz#9487443df2f9ba1db90d8ab52351814907ea4af3"
+  integrity sha512-lmPrdi5SLRJR+AeJkqdkGlW/CRkAUvZnETahK58J4xb5wpbfDngasEGu+w0T1iXEhVrYBJZeW+c4V1hILCnMWQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.7:
   version "6.0.8"


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

As part of our initiative to increase test coverage, stability and confidence in our project we've identified this folder as having a lower than acceptable level of test coverage.

Acceptance Criteria:

Increase test coverage to an acceptable level, ideally 100%

## New Library Added
This PR introduces two changes to how we approach unit testing of talons

- Introduction of `@testing-library/react-hooks` - gives us a consistent pattern to align towards when testing talons and custom hooks. Seems proven enough that it's safe to introduce, at least in scope of peregrine. [Their docs](https://react-hooks-testing-library.com/usage/basic-hooks) have lots of good information on usage, but the big patterns are all covered in this PR.
- Usage of Apollo's `MockProvider` that simulates actual operations, instead of us mocking those hooks. The only odd piece here is that operations wait for the next tick of the event loop to flush, but RLRH simplifies this by just awaiting those triggers if you're not concerned with loading state. [Their docs](https://www.apollographql.com/docs/react/development-testing/testing/) also do a great job at explaining usage, but the major patterns are covered in this PR.

## TODO?
I haven't made any of what I've done in this PR a utility just yet. I'm thinking the whole team should iterate on these new patterns a bit before deciding if usage is consistent enough to add utilities. Advice from the maintainers to handle complex context nesting in the app is to add a `test/test-utils` utility that export a `renderHook` method that does this automatically, eg. similar to what `renderHookWithProviders` does here, but every context so we no longer need to mock `useCartContext` or `useUserContext`. This could prove to be difficult with redux still hanging around, but is the ideal solution going forward.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
* [[PWA-998](https://jira.corp.magento.com/browse/PWA-998)] Increase Test Coverage in peregrine/lib/talons/SignIn
## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Look at coveralls report, verify useSignIn is now covered

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
