### PR TITLE
Remove "Home Page" from Title

### DIFF
--- a/packages/extensions/venia-sample-language-packs/i18n/fr_FR.json
+++ b/packages/extensions/venia-sample-language-packs/i18n/fr_FR.json
@@ -27,7 +27,6 @@
     "app.errorOffline": "Vous êtes hors ligne. Certaines fonctionnalités peuvent ne pas être disponibles.",
     "app.errorUnexpected": "Pardon! Une erreur inattendue est apparue.",
     "app.infoOnline": "Vous êtes en ligne.",
-    "app.titleHome": "Page d'accueil - {name}",
     "authBar.fallbackText": "Compte",
     "authBar.signInText": "Se connecter",
     "autocomplete.emptyResult": "Aucun resultat n'a été trouvé.",

--- a/packages/venia-concept/template.html
+++ b/packages/venia-concept/template.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#ff6334">
         <link rel="manifest" href="/manifest.json">
 
-        <title>Home Page - <%= STORE_NAME %></title>
+        <title><%= STORE_NAME %></title>
 
         <!--
             Apple Specific Tags

--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -31,7 +31,6 @@
     "app.errorOffline": "You are offline. Some features may be unavailable.",
     "app.errorUnexpected": "Sorry! An unexpected error occurred.",
     "app.infoOnline": "You are online.",
-    "app.titleHome": "Home Page - {name}",
     "authBar.fallbackText": "Account",
     "authBar.signInText": "Sign In",
     "autocomplete.emptyResult": "No results were found.",

--- a/packages/venia-ui/lib/components/App/__tests__/__snapshots__/app.spec.js.snap
+++ b/packages/venia-ui/lib/components/App/__tests__/__snapshots__/app.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`renders with renderErrors 1`] = `
 <HeadProvider>
   <Title>
-    Home Page - Venia
+    Venia
   </Title>
   <Main
     isMasked={true}
@@ -18,7 +18,7 @@ exports[`renders with renderErrors 1`] = `
 exports[`renders with unhandledErrors 1`] = `
 <HeadProvider>
   <Title>
-    Home Page - Venia
+    Venia
   </Title>
   <Main
     isMasked={false}

--- a/packages/venia-ui/lib/components/App/app.js
+++ b/packages/venia-ui/lib/components/App/app.js
@@ -92,12 +92,7 @@ const App = props => {
     if (renderError) {
         return (
             <HeadProvider>
-                <Title>
-                    {formatMessage(
-                        { id: 'app.titleHome', defaultMessage: 'Home Page' },
-                        { name: STORE_NAME }
-                    )}
-                </Title>
+                <Title>{STORE_NAME}</Title>
                 <Main isMasked={true} />
                 <Mask isActive={true} />
                 <ToastContainer />
@@ -107,12 +102,7 @@ const App = props => {
 
     return (
         <HeadProvider>
-            <Title>
-                {formatMessage(
-                    { id: 'app.titleHome', defaultMessage: 'Home Page' },
-                    { name: STORE_NAME }
-                )}
-            </Title>
+            <Title>{STORE_NAME}</Title>
             <Main isMasked={hasOverlay}>
                 <Routes />
             </Main>


### PR DESCRIPTION
## Description

Remove `Home Page` from Title, use `STORE_NAME` and then when the page loads render the appropriate title.  

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1616.

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
@sirugh @brendanfalkowski 
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Navigate to Home Page
2. Refresh Home Page
3. See title `Venia` and then `Venia Home Page`
4. Navigate to Category Page
5. See title `Venia` and then `Category - Venia`

## Screenshots / Screen Captures (if appropriate)
![Screen Capture](http://g.recordit.co/gKhGzGTQX6.gif)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have updated tests to cover my changes.
* I have removed unnecessary translations.
