### PR TITLE
Do not assign calcaben on docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_change.md
+++ b/.github/ISSUE_TEMPLATE/doc_change.md
@@ -3,7 +3,7 @@ name: Documentation Request
 about: Help us improve the documentation
 title: "[doc]: A short, simple sentence describing the doc request"
 labels: documentation
-assignees: 'jcalcaben'
+assignees: ''
 ---
 
 <!--


### PR DESCRIPTION
auto-assign breaks some of the sync between jira.