### PR TITLE
Gallery item handle link click

### DIFF
--- a/packages/peregrine/lib/talons/Gallery/useGalleryItem.js
+++ b/packages/peregrine/lib/talons/Gallery/useGalleryItem.js
@@ -1,0 +1,6 @@
+const useGalleryItem = props => {
+    const handleLinkClick = undefined;
+    return { ...props, handleLinkClick };
+};
+
+export default useGalleryItem;

--- a/packages/peregrine/lib/talons/Gallery/useGalleryItem.js
+++ b/packages/peregrine/lib/talons/Gallery/useGalleryItem.js
@@ -1,5 +1,5 @@
 const useGalleryItem = props => {
-    const handleLinkClick = undefined;
+    const handleLinkClick = () => {};
     return { ...props, handleLinkClick };
 };
 

--- a/packages/peregrine/lib/talons/Gallery/useGalleryItem.js
+++ b/packages/peregrine/lib/talons/Gallery/useGalleryItem.js
@@ -1,6 +1,4 @@
-const useGalleryItem = props => {
+export const useGalleryItem = props => {
     const handleLinkClick = () => {};
     return { ...props, handleLinkClick };
 };
-
-export default useGalleryItem;

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -4,6 +4,7 @@ import { Link, resourceUrl } from '@magento/venia-drivers';
 import Price from '@magento/venia-ui/lib/components/Price';
 import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
 import { UNCONSTRAINED_SIZE_KEY } from '@magento/peregrine/lib/talons/Image/useImage';
+import useGalleryItem from '@magento/peregrine/lib/talons';
 
 import { mergeClasses } from '../../classify';
 import Image from '../Image';
@@ -37,7 +38,9 @@ const ItemPlaceholder = ({ classes }) => (
 );
 
 const GalleryItem = props => {
-    const { item } = props;
+    const { handleLinkClick, item } = useGalleryItem(props);
+
+    // const { item } = props;
 
     const classes = mergeClasses(defaultClasses, props.classes);
 
@@ -50,7 +53,11 @@ const GalleryItem = props => {
 
     return (
         <div className={classes.root}>
-            <Link to={productLink} className={classes.images}>
+            <Link
+                onClick={handleLinkClick}
+                to={productLink}
+                className={classes.images}
+            >
                 <Image
                     alt={name}
                     classes={{
@@ -62,7 +69,12 @@ const GalleryItem = props => {
                     widths={IMAGE_WIDTHS}
                 />
             </Link>
-            <Link to={productLink} className={classes.name}>
+            <Link
+                onClick={handleLinkClick}
+                onClick={props.onClick}
+                to={productLink}
+                className={classes.name}
+            >
                 <span>{name}</span>
             </Link>
             <div className={classes.price}>

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -4,7 +4,7 @@ import { Link, resourceUrl } from '@magento/venia-drivers';
 import Price from '@magento/venia-ui/lib/components/Price';
 import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
 import { UNCONSTRAINED_SIZE_KEY } from '@magento/peregrine/lib/talons/Image/useImage';
-import useGalleryItem from '@magento/peregrine/lib/talons';
+import useGalleryItem from '@magento/peregrine/lib/talons/Gallery/useGalleryItem';
 
 import { mergeClasses } from '../../classify';
 import Image from '../Image';
@@ -40,8 +40,6 @@ const ItemPlaceholder = ({ classes }) => (
 const GalleryItem = props => {
     const { handleLinkClick, item } = useGalleryItem(props);
 
-    // const { item } = props;
-
     const classes = mergeClasses(defaultClasses, props.classes);
 
     if (!item) {
@@ -71,7 +69,6 @@ const GalleryItem = props => {
             </Link>
             <Link
                 onClick={handleLinkClick}
-                onClick={props.onClick}
                 to={productLink}
                 className={classes.name}
             >

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -4,7 +4,7 @@ import { Link, resourceUrl } from '@magento/venia-drivers';
 import Price from '@magento/venia-ui/lib/components/Price';
 import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
 import { UNCONSTRAINED_SIZE_KEY } from '@magento/peregrine/lib/talons/Image/useImage';
-import useGalleryItem from '@magento/peregrine/lib/talons/Gallery/useGalleryItem';
+import { useGalleryItem } from '@magento/peregrine/lib/talons/Gallery/useGalleryItem';
 
 import { mergeClasses } from '../../classify';
 import Image from '../Image';


### PR DESCRIPTION
## Description


Add link click handler to <Link> inside of GalleryItem. This is necessary for recommendation tracking for product recommendations. 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Related to https://github.com/magento/pwa-studio/issues/3050. We need a long term solution for this problem, but this PR addresses the issue we need solved immediately. 


