### PR TITLE
[chore] Update comment on cmsPage talon to reflect why we compare against default string

### DIFF
--- a/packages/peregrine/lib/talons/Cms/useCmsPage.js
+++ b/packages/peregrine/lib/talons/Cms/useCmsPage.js
@@ -53,7 +53,9 @@ export const useCmsPage = props => {
     const cmsPage = data ? data.cmsPage : null;
     const rootCategoryId = data ? data.storeConfig.root_category_id : null;
 
-    // TODO: we shouldn't be validating strings to determine if the page has content or not
+    // Only render <RichContent /> if the page isn't empty and doesn't contain
+    // the default CMS Page text. We do this so there is at least a useable home
+    // page by default, the category list component.
     const hasContent = useMemo(() => {
         return (
             cmsPage &&


### PR DESCRIPTION
Adds the context back to why we use this string comparison.

See #3033.

