### PR TITLE
[chore]: Cleanup invalid function ref in billing address

### DIFF
--- a/packages/peregrine/lib/talons/CheckoutPage/BillingAddress/useBillingAddress.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/BillingAddress/useBillingAddress.js
@@ -270,12 +270,13 @@ export const useBillingAddress = props => {
                     }
                     setIsBillingAddressSameInCache();
                 } else {
-                    setErrors(formState.errors);
                     throw new Error('Errors in the billing address form');
                 }
             }
         } catch (err) {
-            console.error(err);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(err);
+            }
             onBillingAddressChangedError();
         }
     }, [
@@ -316,7 +317,9 @@ export const useBillingAddress = props => {
                 throw new Error('Billing address mutation failed');
             }
         } catch (err) {
-            console.error(err);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(err);
+            }
             onBillingAddressChangedError();
         }
     }, [

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/useCreditCard.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/useCreditCard.js
@@ -407,7 +407,9 @@ export const useCreditCard = props => {
                 }
             }
         } catch (err) {
-            console.error(err);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(err);
+            }
             setStepNumber(0);
             resetShouldSubmit();
             setShouldRequestPaymentNonce(false);
@@ -456,7 +458,9 @@ export const useCreditCard = props => {
                 throw new Error('Billing address mutation failed');
             }
         } catch (err) {
-            console.error(err);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(err);
+            }
             setStepNumber(0);
             resetShouldSubmit();
             setShouldRequestPaymentNonce(false);
@@ -499,7 +503,9 @@ export const useCreditCard = props => {
                 throw new Error('Credit card nonce save mutation failed.');
             }
         } catch (err) {
-            console.error(err);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(err);
+            }
             setStepNumber(0);
             resetShouldSubmit();
             setShouldRequestPaymentNonce(false);


### PR DESCRIPTION
Oops.

Fixed that.

Also cleaned up some exposed console errors so they only show up outside of prod.

### Resolved issues:
1. [x] resolves magento/pwa-studio#3071: [chore]: Cleanup invalid function ref in billing address