### PR TITLE
Add compression package as a dependency in create-pwa package.

### DIFF
--- a/packages/create-pwa/package.json
+++ b/packages/create-pwa/package.json
@@ -33,6 +33,7 @@
     "@magento/venia-concept": "10.0.0-alpha.2",
     "chalk": "^2.4.2",
     "change-case": "^3.1.0",
+    "compression": "~1.7.4",
     "execa": "^1.0.0",
     "git-user-info": "^1.0.1",
     "inquirer": "^6.3.1",


### PR DESCRIPTION
## Description

We recently added compression middleware as a peer dependency of `pwa-buildpack` but since `create-pwa` is a consumer of `pwa-buildpack` it has to have compression as a dependency in its `package.json`.

## Related Issue
Closes PWA-1591

## Acceptance
`create-pwa` should work without failure.

### Verification Stakeholders
@jimbo 
@dpatil-magento 

### Verification Steps

This can only be tested once the package is published.

```sh
yarn global remove @magento/create-pwa
yarn global add @magento/create-pwa@alpha
yarn global dir // to get the global directory
cd GLOBAL_DIR/node_modules/@magento/create-pwa
node bin/create-pwa
```

If you wanna test this locally, after step 4 manually change the `package.json` of the `create-pwa` package by adding `compression: ~1.7.4` as a dependency and run a `yarn install` to install the new package.

Then continue with step 5.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
