### PR TITLE
🪄 Product Item style fixes

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Products/products.css
+++ b/packages/pagebuilder/lib/ContentTypes/Products/products.css
@@ -56,3 +56,7 @@
     composes: root;
     composes: root from '../Slider/slider.css';
 }
+
+.carousel :global .slick-track .slick-slide:not(:first-child) > div {
+    margin-left: 4px;
+}

--- a/packages/pagebuilder/lib/ContentTypes/Products/products.js
+++ b/packages/pagebuilder/lib/ContentTypes/Products/products.js
@@ -71,8 +71,8 @@ const Products = props => {
         paddingBottom,
         paddingLeft,
         cssClasses = [],
-        slidesToShow = 5,
-        slideToShowSmall = 2,
+        slidesToShow = 4,
+        slideToShowSmall = 1,
         slideToShowSmallCenterMode = 1
     } = props;
 

--- a/packages/pagebuilder/lib/ContentTypes/Slider/slider.css
+++ b/packages/pagebuilder/lib/ContentTypes/Slider/slider.css
@@ -59,7 +59,6 @@
 
 .root :global .slick-track .slick-slide > div {
     min-height: inherit;
-    margin: 3px;
 }
 
 .root :global .slick-track:before,

--- a/packages/pagebuilder/lib/ContentTypes/Slider/slider.css
+++ b/packages/pagebuilder/lib/ContentTypes/Slider/slider.css
@@ -59,6 +59,7 @@
 
 .root :global .slick-track .slick-slide > div {
     min-height: inherit;
+    margin: 3px;
 }
 
 .root :global .slick-track:before,

--- a/packages/venia-ui/lib/components/Gallery/gallery.css
+++ b/packages/venia-ui/lib/components/Gallery/gallery.css
@@ -10,7 +10,7 @@
 .items {
     display: grid;
     grid-area: items;
-    grid-gap: 1rem;
+    grid-gap: 2rem 0.5rem;
     grid-template-columns: repeat(1, 1fr);
     margin-bottom: 10px;
 }

--- a/packages/venia-ui/lib/components/Gallery/gallery.css
+++ b/packages/venia-ui/lib/components/Gallery/gallery.css
@@ -11,12 +11,24 @@
     display: grid;
     grid-area: items;
     grid-gap: 1rem;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(1, 1fr);
     margin-bottom: 10px;
 }
 
-@media (max-width: 640px) {
+@media (min-width: 640px) {
     .items {
         grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 960px) {
+    .items {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 1280px) {
+    .items {
+        grid-template-columns: repeat(4, 1fr);
     }
 }

--- a/packages/venia-ui/lib/components/Gallery/item.css
+++ b/packages/venia-ui/lib/components/Gallery/item.css
@@ -11,6 +11,19 @@
 
 .imageContainer {
     grid-area: main;
+    position: relative;
+}
+
+.imageContainer::after {
+    bottom: 0;
+    box-shadow: rgb(0 0 0 / 7%) 0px 0px 10rem inset;
+    content: '';
+    cursor: inherit;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
 }
 
 .image {


### PR DESCRIPTION
### Description

#### Gallery Item Inset Shadow

Products in Venia (and most products) have a white background. Here I added a subtle inset shadow to separate product items from each other.

![image](https://user-images.githubusercontent.com/316104/113910214-2ff2cb80-979e-11eb-9220-feb21b6a60a1.png)
![image](https://user-images.githubusercontent.com/316104/113910385-66304b00-979e-11eb-83f3-697d3b6d3c8d.png)

#### Product Items per Row (Responsive)

![image](https://user-images.githubusercontent.com/316104/113910280-4731b900-979e-11eb-88ba-6d274eeeeccf.png)
![image](https://user-images.githubusercontent.com/316104/113910298-4a2ca980-979e-11eb-9616-7380ef0cc31b.png)
![image](https://user-images.githubusercontent.com/316104/113910306-4d279a00-979e-11eb-9cd6-899cbc0f78ae.png)
![image](https://user-images.githubusercontent.com/316104/113910312-50228a80-979e-11eb-91a8-117107d924ed.png)

### Verification Steps
- Go to any Category Page
- View any PageBuilder content that is rendering the Products (Carousel) Content-Type



### Resolved issues:
1. [x] resolves magento/pwa-studio#3109: 🪄 Product Item style fixes