### PR TITLE
[bug] Avoid extra category query

### DIFF
--- a/packages/peregrine/lib/talons/RootComponents/Category/useCategory.js
+++ b/packages/peregrine/lib/talons/RootComponents/Category/useCategory.js
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useLazyQuery, useQuery } from '@apollo/client';
+import { isEqual } from 'lodash';
 
 import mergeOperations from '../../../util/shallowMerge';
 import { useAppContext } from '../../../context/app';
@@ -11,7 +12,7 @@ import {
     getFiltersFromSearch,
     getFilterInput
 } from '../../../talons/FilterModal/helpers';
-import { isEqual } from 'lodash';
+
 import DEFAULT_OPERATIONS from './category.gql';
 
 /**


### PR DESCRIPTION
## Description

The introspection query in the category page is used to construct a map of filters and types so as to properly construct the final `filters` variable when making the category query.

Using `cache-and-network` causes the introspection query to resolve with (likely identical) data. This causes the downstream category query to run twice because the identity of the filters object is not the same.

This PR uses a ref to do a deep equality check on the filters during each render so when the introspection query resolves from the `network` part of `cache-and-network` it does not cause a the category query to refetch unless the filters change.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #3112 and PWA-1666

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to the a category page like `/default/venia-bottoms.html?page=1`
2. View network tab. Ensure that the `GetCategories` query is only invoked once.
3. Try this with a clear cache or with a prepopulated cache. Should never query more than once.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
