### PR TITLE
PWA-1630: Remove product from wish list fails if there are 2 or more products in a wishlist.

### DIFF
--- a/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlistItem.spec.js
+++ b/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlistItem.spec.js
@@ -104,7 +104,7 @@ test('handleRemoveProductFromWishlist callback fires mutation', () => {
     expect(mockMutate).toHaveBeenCalled();
 });
 
-test('handleRemoveProductFromWishlist callback error fires mutation', async () => {
+test('handleRemoveProductFromWishlist callback logs error if the mutation fails', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error');
     const error = new Error('Error.');
     const mockMutate = jest.fn(() => {

--- a/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlistItem.spec.js
+++ b/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlistItem.spec.js
@@ -5,9 +5,13 @@ import { useMutation } from '@apollo/client';
 import createTestInstance from '../../../util/createTestInstance';
 import { useWishlistItem } from '../useWishlistItem';
 
-jest.mock('@apollo/client', () => ({
-    useMutation: jest.fn().mockReturnValue([jest.fn(), { loading: false }])
-}));
+jest.mock('@apollo/client', () => {
+    const ApolloClient = jest.requireActual('@apollo/client');
+    return {
+        ...ApolloClient,
+        useMutation: jest.fn().mockReturnValue([jest.fn(), { loading: false }])
+    };
+});
 
 jest.mock('../../../context/cart', () => {
     const state = { cartId: 'cart123' };
@@ -84,4 +88,40 @@ test('handleAddToCart callback fires mutation', () => {
     });
 
     expect(mockMutate).toHaveBeenCalled();
+});
+
+test('handleRemoveProductFromWishlist callback fires mutation', () => {
+    const mockMutate = jest.fn();
+    useMutation.mockReturnValue([mockMutate, { loading: false }]);
+    createTestInstance(<Component {...baseProps} />);
+
+    const talonProps = log.mock.calls[0][0];
+
+    act(() => {
+        talonProps.handleRemoveProductFromWishlist();
+    });
+
+    expect(mockMutate).toHaveBeenCalled();
+});
+
+test('handleRemoveProductFromWishlist callback error fires mutation', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+    const error = new Error('Error.');
+    const mockMutate = jest.fn(() => {
+        throw error;
+    });
+    useMutation.mockReturnValue([
+        mockMutate,
+        {
+            called: true,
+            error: error,
+            loading: false
+        }
+    ]);
+    createTestInstance(<Component {...baseProps} />);
+    const talonProps = log.mock.calls[0][0];
+    act(() => {
+        talonProps.handleRemoveProductFromWishlist();
+    });
+    expect(consoleErrorSpy).toHaveBeenCalled();
 });

--- a/packages/peregrine/lib/talons/WishlistPage/useWishlistItem.js
+++ b/packages/peregrine/lib/talons/WishlistPage/useWishlistItem.js
@@ -4,8 +4,8 @@ import { useMutation } from '@apollo/client';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
 
 import mergeOperations from '../../util/shallowMerge';
-// TODO: Import the actual default operations once we have them co-located.
-const DEFAULT_OPERATIONS = {};
+
+import DEFAULT_OPERATIONS from './wishlistItem.gql';
 
 // Note: There is only ever zero (0) or one (1) dialogs open for a wishlist item.
 const dialogs = {
@@ -95,6 +95,9 @@ export const useWishlistItem = props => {
             setCurrentDialog(dialogs.NONE);
         } catch (e) {
             setRemoveProductFromWishlistError(e);
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(e);
+            }
         }
     }, [
         removeProductsFromWishlist,

--- a/packages/peregrine/lib/talons/WishlistPage/wishlistItem.gql.js
+++ b/packages/peregrine/lib/talons/WishlistPage/wishlistItem.gql.js
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client';
 
 import { CartTriggerFragment } from '@magento/peregrine/lib/talons/Header/cartTriggerFragments.gql';
 import { MiniCartFragment } from '@magento/peregrine/lib/talons/MiniCart/miniCartFragments.gql';
+import { WishlistFragment } from './wishlistFragment.gql';
 
 export const ADD_WISHLIST_ITEM_TO_CART = gql`
     mutation AddWishlistItemToCart(
@@ -33,7 +34,6 @@ export const REMOVE_PRODUCTS_FROM_WISHLIST = gql`
         ) {
             wishlist {
                 id
-                items_count
                 items_v2 {
                     items {
                         id
@@ -57,17 +57,18 @@ export const REMOVE_PRODUCTS_FROM_WISHLIST = gql`
                         ... on ConfigurableWishlistItem {
                             configurable_options {
                                 id
+                                value_id
                                 option_label
                                 value_label
                             }
                         }
                     }
                 }
-                name
-                sharing_code
+                ...WishlistFragment
             }
         }
     }
+    ${WishlistFragment}
 `;
 
 export default {

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistItem.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistItem.js
@@ -10,7 +10,6 @@ import Image from '../Image';
 import WishlistConfirmRemoveProductDialog from './wishlistConfirmRemoveProductDialog';
 import WishlistMoreActionsDialog from './wishlistMoreActionsDialog';
 import defaultClasses from './wishlistItem.css';
-import wishlistItemOperations from './wishlistItem.gql';
 
 const WishlistItem = props => {
     const { item, wishlistId } = props;
@@ -32,7 +31,6 @@ const WishlistItem = props => {
     const talonProps = useWishlistItem({
         childSku,
         itemId,
-        operations: { ...wishlistItemOperations },
         sku,
         wishlistId
     });


### PR DESCRIPTION
## Description

URL - https://develop.pwa-venia.com

**Steps to reproduce existing bug** 
1. Go to venia as auth user
2. Add 2 products to favorite lists
3. Go to favorite lists and select Remove wishlist for a product.
4. Click Delete

**Expected** - User should be able to remove product from wishlist
**Actual** - User gets error, PFA screen.

### Fix
`value_id` field was missing in `ConfigurableWishlistItem` gql, also EE schema have more fields in `wishlist`, so using different wishlist schemas for CE and EE

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
[[PWA-1630](https://jira.corp.magento.com/browse/PWA-1630)] Remove product from wish list fails if there are 2 or more products in a wishlist.

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Add a simple product to wishlist and verify that you can delete it without seeing this error
2. Add a configurable product with no options selected to wishlist and verify that you can delete it without seeing this error
3. Add a configurable product with options selected to wishlist and verify that you can delete it without seeing this error
4. Add a simple product and configurable product with no options selected to wishlist and verify that you can delete it without seeing this error
5. Add two copies of the same configurable product - one with options selected, one without - to a wishlist and verify that you can delete them without seeing this error
6. Add two copies of the same configurable product - with two different option sets selected - to a wishlist and verify that you can delete it without seeing this error

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
