### PR TITLE
[BUGFIX] Replace the mediaBackendUrl when the feature onboard is used

### DIFF
--- a/packages/peregrine/lib/util/makeUrl.js
+++ b/packages/peregrine/lib/util/makeUrl.js
@@ -78,7 +78,6 @@ const makeOptimizedUrl = (path, { type, ...opts } = {}) => {
 
     const { origin } = window.location;
     const isAbsolute = absoluteUrl.test(path);
-    const magentoBackendURL = process.env.MAGENTO_BACKEND_URL;
     let baseURL = new URL(path, mediaBackend);
 
     // If URL is relative and has a supported type, prepend media base onto path
@@ -89,9 +88,9 @@ const makeOptimizedUrl = (path, { type, ...opts } = {}) => {
         }
     }
 
-    if (baseURL.href.startsWith(magentoBackendURL) && !useBackendForImgs) {
+    if (baseURL.href.startsWith(mediaBackend) && !useBackendForImgs) {
         // Replace URL base so optimization middleware can handle request
-        baseURL = new URL(baseURL.href.slice(magentoBackendURL.length), origin);
+        baseURL = new URL(baseURL.href.slice(mediaBackend.length), origin + '/media/');
     }
 
     // Append image optimization parameters


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

if IMAGE_OPTIMIZING_ORIGIN is set to onboard it should replace the mediaBackendUrl with the current window.location
When the media url is different from the admin url it won't be replaced and could result in CORS errors.


### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Setup an environment with multiple stores
2. use a different media url compared to the base url
3. when cors is enabled this will result in CORS erros



### Resolved issues:
1. [x] resolves magento/pwa-studio#3167: [BUGFIX] Replace the mediaBackendUrl when the feature onboard is used