### PR TITLE
Adding dependency to PWA Studio version

### DIFF
--- a/pwa-devdocs/src/product-recs/index.md
+++ b/pwa-devdocs/src/product-recs/index.md
@@ -26,7 +26,7 @@ Product Recommendations support on PWA requires installing the `venia-product-re
    ```
 
    {:.bs-callout-info}
-   The `venia-product-recommendations` package requires [PWA Studio 10.0.0](https://github.com/magento/pwa-studio/releases/) or later.
+   The `venia-product-recommendations` package requires [PWA Studio 10.0.0](https://github.com/magento/pwa-studio/releases/tag/v10.0.0) or later.
 
    This package contains storefront functionality to collect required behavioral data and render the recommendations.
    Some recommendation types use behavioral data from your shoppers to train machine learning models that build personalized recommendations.

--- a/pwa-devdocs/src/product-recs/index.md
+++ b/pwa-devdocs/src/product-recs/index.md
@@ -24,6 +24,10 @@ Product Recommendations support on PWA requires installing the `venia-product-re
    ```sh
    npm install @magento/venia-product-recommendations
    ```
+
+   {:.bs-callout-info}
+   The `venia-product-recommendations` package requires [PWA Studio 10.0.0](https://github.com/magento/pwa-studio/releases/) or later.
+
    This package contains storefront functionality to collect required behavioral data and render the recommendations.
    Some recommendation types use behavioral data from your shoppers to train machine learning models that build personalized recommendations.
    Other recommendation types use catalog data only and do not use any behavioral data.


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

This PR adds a note that specifies the PWA Studio version that's required for the Product Recommendations integration.

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Go to https://magento.github.io/pwa-studio/product-recs/#install-the-product-recommendations-module
2. Verify there's a note that specifies the required PWA Studio version.
