### PR TITLE
#2976 Replace Muli

### DIFF
--- a/packages/venia-concept/src/.storybook/preview-body.html
+++ b/packages/venia-concept/src/.storybook/preview-body.html
@@ -1,103 +1,75 @@
 <!-- The contents of this file are copied from default-font-include.mst which is necessary to ensure the font matches as expected in storybook. -->
 <style type="text/css">
-    /* vietnamese */
-    @font-face {
-        font-family: 'Muli';
+    * cyrillic-ext */ @font-face {
+        font-family: 'Open Sans';
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk40e6fwniDtzNAAw.woff)
-            format('woff');
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWJ0bbck.woff2)
+            format('woff2');
+        unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF,
+            U+A640-A69F, U+FE2E-FE2F;
+    }
+    /* cyrillic */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFUZ0bbck.woff2)
+            format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+    }
+    /* greek-ext */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWZ0bbck.woff2)
+            format('woff2');
+        unicode-range: U+1F00-1FFF;
+    }
+    /* greek */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVp0bbck.woff2)
+            format('woff2');
+        unicode-range: U+0370-03FF;
+    }
+    /* vietnamese */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWp0bbck.woff2)
+            format('woff2');
         unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169,
             U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
     }
     /* latin-ext */
     @font-face {
-        font-family: 'Muli';
+        font-family: 'Open Sans';
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk50e6fwniDtzNAAw.woff)
-            format('woff');
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFW50bbck.woff2)
+            format('woff2');
         unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
             U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
     }
     /* latin */
     @font-face {
-        font-family: 'Muli';
+        font-family: 'Open Sans';
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk30e6fwniDtzM.woff)
-            format('woff');
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-            U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-            U+2212, U+2215, U+FEFF, U+FFFD;
-    }
-    /* vietnamese */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 600;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k40e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169,
-            U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-    }
-    /* latin-ext */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 600;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k50e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-            U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-    }
-    /* latin */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 600;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k30e6fwniDtzM.woff)
-            format('woff');
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-            U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-            U+2212, U+2215, U+FEFF, U+FFFD;
-    }
-    /* vietnamese */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 700;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k40e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169,
-            U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-    }
-    /* latin-ext */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 700;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k50e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-            U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-    }
-    /* latin */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 700;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k30e6fwniDtzM.woff)
-            format('woff');
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVZ0b.woff2)
+            format('woff2');
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
             U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
             U+2212, U+2215, U+FEFF, U+FFFD;

--- a/packages/venia-concept/template.html
+++ b/packages/venia-concept/template.html
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
-<html lang="<%= global.LOCALE %>" data-image-optimizing-origin="<%= process.env.IMAGE_OPTIMIZING_ORIGIN %>" data-media-backend="<%= global.MAGENTO_MEDIA_BACKEND_URL %>">
+<html
+    lang="<%= global.LOCALE %>"
+    data-image-optimizing-origin="<%= process.env.IMAGE_OPTIMIZING_ORIGIN %>"
+    data-media-backend="<%= global.MAGENTO_MEDIA_BACKEND_URL %>"
+>
     <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="theme-color" content="#ff6334">
-        <link rel="manifest" href="/manifest.json">
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="theme-color" content="#ff6334" />
+        <link rel="manifest" href="/manifest.json" />
 
         <!--
             Apple Specific Tags
@@ -19,9 +23,16 @@
             Apple Icons for Homescreen
             Sizes: https://developer.apple.com/design/human-interface-guidelines/ios/icons-and-images/app-icon/
         -->
-        <link rel="apple-touch-icon" href="/venia-static/icons/venia_square_57.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/venia-static/icons/apple-touch-icon.png">
-        <link rel="preconnect" href="<%= process.env.MAGENTO_BACKEND_URL %>">
+        <link
+            rel="apple-touch-icon"
+            href="/venia-static/icons/venia_square_57.png"
+        />
+        <link
+            rel="apple-touch-icon"
+            sizes="180x180"
+            href="/venia-static/icons/apple-touch-icon.png"
+        />
+        <link rel="preconnect" href="<%= process.env.MAGENTO_BACKEND_URL %>" />
         <!--
             This following CSS is a copy of the css returned by Google's font API that
             allows us to "skip" a network round trip.
@@ -35,108 +46,111 @@
             this comment. Remember to replace the preload link above with the src URL!
 
             Example API responses:
-            https://fonts.googleapis.com/css?family=Muli:400&display=swap
+            https://fonts.googleapis.com/css?family=Open+Sans:400&display=swap
             https://fonts.googleapis.com/css?family=Source+Serif+Pro:600&display=swap
         -->
         <style type="text/css">
-            /* vietnamese */
+            /* cyrillic-ext */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 400;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk40e6fwniDtzNAAw.woff) format('woff');
-              unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWJ0bbck.woff2)
+                    format('woff2');
+                unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF,
+                    U+A640-A69F, U+FE2E-FE2F;
             }
-            /* latin-ext */
+            /* cyrillic */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 400;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk50e6fwniDtzNAAw.woff) format('woff');
-              unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFUZ0bbck.woff2)
+                    format('woff2');
+                unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
             }
-            /* latin */
+            /* greek-ext */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 400;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk30e6fwniDtzM.woff) format('woff');
-              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWZ0bbck.woff2)
+                    format('woff2');
+                unicode-range: U+1F00-1FFF;
             }
-            /* vietnamese */
+            /* greek */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 600;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k40e6fwniDtzNAAw.woff) format('woff');
-              unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-            }
-            /* latin-ext */
-            @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 600;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k50e6fwniDtzNAAw.woff) format('woff');
-              unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-            }
-            /* latin */
-            @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 600;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k30e6fwniDtzM.woff) format('woff');
-              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVp0bbck.woff2)
+                    format('woff2');
+                unicode-range: U+0370-03FF;
             }
             /* vietnamese */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 700;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k40e6fwniDtzNAAw.woff) format('woff');
-              unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWp0bbck.woff2)
+                    format('woff2');
+                unicode-range: U+0102-0103, U+0110-0111, U+0128-0129,
+                    U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
             }
             /* latin-ext */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 700;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k50e6fwniDtzNAAw.woff) format('woff');
-              unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFW50bbck.woff2)
+                    format('woff2');
+                unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020,
+                    U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
             }
             /* latin */
             @font-face {
-              font-family: 'Muli';
-              font-style: normal;
-              font-weight: 700;
-              font-display: swap;
-              src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k30e6fwniDtzM.woff) format('woff');
-              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                font-family: 'Open Sans';
+                font-style: normal;
+                font-weight: 400;
+                font-display: swap;
+                src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVZ0b.woff2)
+                    format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC,
+                    U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122,
+                    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
             }
             /* latin-ext */
             @font-face {
-              font-family: 'Source Serif Pro';
-              font-style: normal;
-              font-weight: 600;
-              font-display: swap;
-              src: local('Source Serif Pro Semibold'), local('SourceSerifPro-Semibold'), url(https://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasasatSKqxKcsdrOPbQ.woff2) format('woff2');
-              unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+                font-family: 'Source Serif Pro';
+                font-style: normal;
+                font-weight: 600;
+                font-display: swap;
+                src: local('Source Serif Pro Semibold'),
+                    local('SourceSerifPro-Semibold'),
+                    url(https://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasasatSKqxKcsdrOPbQ.woff2)
+                        format('woff2');
+                unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020,
+                    U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
             }
             /* latin */
             @font-face {
-              font-family: 'Source Serif Pro';
-              font-style: normal;
-              font-weight: 600;
-              font-display: swap;
-              src: local('Source Serif Pro Semibold'), local('SourceSerifPro-Semibold'), url(https://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasasatSyqxKcsdrM.woff2) format('woff2');
-              unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+                font-family: 'Source Serif Pro';
+                font-style: normal;
+                font-weight: 600;
+                font-display: swap;
+                src: local('Source Serif Pro Semibold'),
+                    local('SourceSerifPro-Semibold'),
+                    url(https://fonts.gstatic.com/s/sourceserifpro/v7/neIXzD-0qpwxpaWvjeD0X88SAOeasasatSyqxKcsdrM.woff2)
+                        format('woff2');
+                unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC,
+                    U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122,
+                    U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
             }
         </style>
     </head>
@@ -147,10 +161,10 @@
         <noscript>
             <style>
                 .fallback-nojs {
-                  display: flex;
-                  flex-direction: column;
-                  justify-content: center;
-                  align-items: center;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    align-items: center;
                 }
                 .fallback-nojs a {
                     color: currentColor;
@@ -160,11 +174,17 @@
                 }
             </style>
             <div class="fallback-nojs">
-                <img class="fallback-closed" alt="JavaScript is disabled" src="/venia-static/veniaClosed.png">
+                <img
+                    class="fallback-closed"
+                    alt="JavaScript is disabled"
+                    src="/venia-static/veniaClosed.png"
+                />
                 <h1 class="fallback-heading">Oops! JavaScript is disabled</h1>
                 <div>
-                  To browse the Venia store,<br>
-                  <a href="https://www.enable-javascript.com">enable JavaScript in your browser.</a>
+                    To browse the Venia store,<br />
+                    <a href="https://www.enable-javascript.com"
+                        >enable JavaScript in your browser.</a
+                    >
                 </div>
             </div>
         </noscript>

--- a/packages/venia-ui/.storybook/preview-body.html
+++ b/packages/venia-ui/.storybook/preview-body.html
@@ -1,103 +1,75 @@
 <!-- The contents of this file are copied from default-font-include.mst which is necessary to ensure the font matches as expected in storybook. -->
 <style type="text/css">
-    /* vietnamese */
-    @font-face {
-        font-family: 'Muli';
+    * cyrillic-ext */ @font-face {
+        font-family: 'Open Sans';
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk40e6fwniDtzNAAw.woff)
-            format('woff');
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWJ0bbck.woff2)
+            format('woff2');
+        unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF,
+            U+A640-A69F, U+FE2E-FE2F;
+    }
+    /* cyrillic */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFUZ0bbck.woff2)
+            format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+    }
+    /* greek-ext */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWZ0bbck.woff2)
+            format('woff2');
+        unicode-range: U+1F00-1FFF;
+    }
+    /* greek */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVp0bbck.woff2)
+            format('woff2');
+        unicode-range: U+0370-03FF;
+    }
+    /* vietnamese */
+    @font-face {
+        font-family: 'Open Sans';
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFWp0bbck.woff2)
+            format('woff2');
         unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169,
             U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
     }
     /* latin-ext */
     @font-face {
-        font-family: 'Muli';
+        font-family: 'Open Sans';
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk50e6fwniDtzNAAw.woff)
-            format('woff');
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFW50bbck.woff2)
+            format('woff2');
         unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
             U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
     }
     /* latin */
     @font-face {
-        font-family: 'Muli';
+        font-family: 'Open Sans';
         font-style: normal;
         font-weight: 400;
         font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFnOkEk30e6fwniDtzM.woff)
-            format('woff');
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-            U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-            U+2212, U+2215, U+FEFF, U+FFFD;
-    }
-    /* vietnamese */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 600;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k40e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169,
-            U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-    }
-    /* latin-ext */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 600;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k50e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-            U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-    }
-    /* latin */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 600;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkQl0k30e6fwniDtzM.woff)
-            format('woff');
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-            U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
-            U+2212, U+2215, U+FEFF, U+FFFD;
-    }
-    /* vietnamese */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 700;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k40e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169,
-            U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-    }
-    /* latin-ext */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 700;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k50e6fwniDtzNAAw.woff)
-            format('woff');
-        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
-            U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-    }
-    /* latin */
-    @font-face {
-        font-family: 'Muli';
-        font-style: normal;
-        font-weight: 700;
-        font-display: swap;
-        src: url(https://fonts.gstatic.com/s/muli/v20/7Aulp_0qiz-aVz7u3PJLcUMYOFkpl0k30e6fwniDtzM.woff)
-            format('woff');
+        src: url(https://fonts.gstatic.com/s/opensans/v20/mem8YaGs126MiZpBA-UFVZ0b.woff2)
+            format('woff2');
         unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
             U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193,
             U+2212, U+2215, U+FEFF, U+FFFD;

--- a/packages/venia-ui/lib/tokens.css
+++ b/packages/venia-ui/lib/tokens.css
@@ -52,7 +52,7 @@
     --venia-global-color-warning-light: var(--venia-global-color-gray-100);
 
     /* font family */
-    --venia-global-fontFamily-sansSerif: 'Muli', sans-serif;
+    --venia-global-fontFamily-sansSerif: 'Open Sans', sans-serif;
     --venia-global-fontFamily-serif: 'Source Serif Pro', serif;
 
     /* font size */


### PR DESCRIPTION
## Description

2976

## Related Issue

Closes #2976

## Acceptance

- Use Open Sans font.
- Update default-font-include.mst (this file may be deprecated/unused) and venia-concept/template.html using output of https://fonts.googleapis.com/css?family=Open+Sans:400&display=swap. Be sure not to remove the Source Serif lines.
- Update all other references from Muli to Open Sans

### Verification Stakeholders

### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
# Front is replaced in any views

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
