### PR TITLE
[chore] do not check coverage on .gql javascript files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -326,7 +326,10 @@ const jestConfig = {
         // Not this file itself
         '!jest.config.js',
         // Exclude deprecated components from coverage report
-        '!**/venia-ui/lib/components/Checkout/**'
+        '!**/venia-ui/lib/components/Checkout/**',
+        // Not GraphQL files, gql.ce.js or gql.ee.js
+        '!**/*.gql.js',
+        '!**/*.gql.**.js'
     ],
     // Don't look for test files in these directories.
     testPathIgnorePatterns: [


### PR DESCRIPTION
## Description

Our gql javascript files are being considered in coverage, which makes our coverage numbers look lower than they are.

For example: https://coveralls.io/builds/40065394

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #ISSUE_NUMBER.

## Acceptance
<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
### Verification Stakeholders
<!-- People who must verify that this solves the attached issue. -->
### Specification
<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

### Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes, -->
<!-- OR how you will demonstrate the changes to the stakeholder(s). -->
1. Ensure coveralls does not report on .gql.js files.

## Screenshots / Screen Captures (if appropriate)

## Checklist
<!--- Go over all the following points, and make sure you've done anything necessary -->
* I have added tests to cover my changes, if necessary.
* I have added translations for new strings, if necessary.
* I have updated the documentation accordingly, if necessary.
