### PR TITLE
[chore] Added breaking changes section to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,34 +15,51 @@ Feel free to remove this section before creating this PR. Thank you for your con
 TODO: Describe your changes in detail here.
 
 ## Related Issue
+
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
 <!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
 <!--- Using the above wording causes Github to automatically close the issue on merge. -->
+
 Closes #ISSUE_NUMBER.
 
 ## Acceptance
+
 <!-- The people and processes this pull request needs before it is merged. -->
 <!-- These fields are not required when opening the pull request, but they -->
 <!-- should be populated after code review. -->
+
 ### Verification Stakeholders
+
 <!-- People who must verify that this solves the attached issue. -->
+
 ### Specification
+
 <!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
 <!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->
 
 ### Verification Steps
+
 <!-- Please describe in detail how a reviewer can verify your changes, -->
 <!-- OR how you will demonstrate the changes to the stakeholder(s). -->
+
 1. Go to the FOO page.
 2. Verify the BAR shows up.
 3. Make sure BAZ does a thing.
 
 ## Screenshots / Screen Captures (if appropriate)
 
+## Breaking Changes (if any)
+
+<!-- If there are any breaking changes in this PR, please describe them here-->
+<!-- For example: -->
+<!-- * Removed Foo prop fro component Bar -->
+
 ## Checklist
+
 <!--- Go over all the following points, and make sure you've done anything necessary -->
-* I have added tests to cover my changes, if necessary.
-* I have added translations for new strings, if necessary.
-* I have updated the documentation accordingly, if necessary.
+
+-   I have added tests to cover my changes, if necessary.
+-   I have added translations for new strings, if necessary.
+-   I have updated the documentation accordingly, if necessary.


### PR DESCRIPTION
As a reviewer or the individual responsible for creating release notes I would like to (easily) be able to discern the breaking changes in a pull request.

This PR adds a "breaking changes" section to the PR template. If a PR has breaking changes (at this time only the contributor/reviewer will likely know) this section should be detailed with that information so that other reviewers or the person who is generating release notes can see and verify.