### PR TITLE
Add to wishlist bug fix.

### DIFF
--- a/packages/venia-ui/lib/components/Wishlist/WishlistDialog/wishlistDialog.js
+++ b/packages/venia-ui/lib/components/Wishlist/WishlistDialog/wishlistDialog.js
@@ -118,7 +118,7 @@ const WishlistDialog = props => {
 
 export default WishlistDialog;
 
-WishlistDialog.defaultProps = {
+WishlistDialog.propTypes = {
     classes: shape({}),
     isOpen: bool,
     isLoading: bool,


### PR DESCRIPTION
## Description

There was a bug in the wishlist dialog due to which a user would be stuck with the create dialog, unable to create a new wishlist on the PLP or the PDP page. 

## Related Issue

Closes PWA-1851

## Acceptance

Should be able to add an item to a new or an existing wishlist.

### Verification Stakeholders

@dpatil-magento 

## Test Plan

Go to PLP or the PDP page and try to add an item to a wishlist.

#### Test scenario(s) for direct fix/feature
-   Verify user is able to add an item to a new or an existing wishlist from the PLP page.
-   Verify user is able to add an item to a new or an existing wishlist from the PDP page.

#### Is Browser/Device testing needed?

Yes

## Breaking Changes (if any)

None

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
