### PR TITLE
Using --frozen-lockfile while running yarn install.

### DIFF
--- a/docker/run-docker
+++ b/docker/run-docker
@@ -49,7 +49,7 @@ create_certificate () {
   # make docker/certs folder if one does not already exist
   [ -d ./docker/certs ] || mkdir ./docker/certs
   # install devcert dependency
-  cd ./docker && yarn install && cd -
+  cd ./docker && yarn install --frozen-lockfile && cd -
   node ./docker/makeHostAndCert "$DEV_SERVER_HOST" || STATUS=$?
 }
 


### PR DESCRIPTION
## Description

Use `yarn install --frozen-lockfile` to make sure CICD pipelines use the lock file while installing instead of the package.json file.

This will guard us against dependency confusion attacks.

Should also merge: https://github.com/magento-commerce/pwa-studio-cicd/pull/76

## Related Issue

Closes PWA-1657

### Verification Stakeholders

@dpatil-magento 

## Test Plan

Make sure everything is working fine. Deployments should not break.

#### Test scenario(s) for direct fix/feature

None

#### Test scenario(s) for any existing impacted features/areas

None

#### Test scenario(s) for any Magento Backend Supported Configurations

None

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
