### PR TITLE
Create a new Target for RichContentTypes (data-content-type=) #2968

### DIFF
--- a/packages/venia-ui/lib/components/RichContent/richContent.js
+++ b/packages/venia-ui/lib/components/RichContent/richContent.js
@@ -19,14 +19,14 @@ import richContentTypes from './richContentTypes';
  *
  * @returns {React.Element} A React component that renders Heading with optional styling properties.
  */
-const RichContent = props => {
+const RichContent = (props) => {
     const classes = useStyle(defaultClasses, props.classes);
     const rendererProps = {
         ...props,
         classes
     };
     for (const ContentType of richContentTypes) {
-        const { component, configAggregator} = ContentType;
+        const { component, configAggregator } = ContentType;
         if (!ContentType.name) {
             ContentType.name = component.name;
         }
@@ -47,7 +47,7 @@ const RichContent = props => {
     if (process.env.NODE_ENV === 'development') {
         console.warn(
             `None of the following rich content renderers returned anything for the provided HTML.`,
-            richContentRenderers.map(r => `<${r.name}>`),
+            richContentRenderers.map((r) => `<${r.name}>`),
             props.html
         );
     }

--- a/packages/venia-ui/lib/components/RichContent/richContent.js
+++ b/packages/venia-ui/lib/components/RichContent/richContent.js
@@ -3,6 +3,8 @@ import { useStyle } from '../../classify';
 import defaultClasses from './richContent.css';
 import { shape, string } from 'prop-types';
 import richContentRenderers from './richContentRenderers';
+import { setContentTypeConfig } from '@magento/pagebuilder/lib/config';
+import richContentTypes from './richContentTypes';
 
 /**
  * RichContent component.
@@ -23,6 +25,18 @@ const RichContent = props => {
         ...props,
         classes
     };
+    for (const ContentType of richContentTypes) {
+        const { component, configAggregator} = ContentType;
+        if (!ContentType.name) {
+            ContentType.name = component.name;
+        }
+        if (ContentType.name && component && configAggregator) {
+            setContentTypeConfig(ContentType.name, {
+                component,
+                configAggregator
+            });
+        }
+    }
     for (const Renderer of richContentRenderers) {
         const { Component, canRender } = Renderer;
         if (canRender(rendererProps.html)) {

--- a/packages/venia-ui/lib/components/RichContent/richContentTypes.js
+++ b/packages/venia-ui/lib/components/RichContent/richContentTypes.js
@@ -1,0 +1,7 @@
+/**
+ * This file is augmented at build time using the @magento/venia-ui build
+ * target "richContentTypes", which allows third-party modules to add
+ * content types rendering strategies to the RichContent component.
+ */
+
+export default [];

--- a/packages/venia-ui/lib/targets/RichContentTypeList.js
+++ b/packages/venia-ui/lib/targets/RichContentTypeList.js
@@ -13,8 +13,7 @@ class RichContentTypeList {
     constructor(venia) {
         const registry = this;
         this._types = venia.esModuleArray({
-            module:
-                '@magento/venia-ui/lib/components/RichContent/richContentTypes.js',
+            module: '@magento/venia-ui/lib/components/RichContent/richContentTypes.js',
             publish(targets) {
                 targets.richContentTypes.call(registry);
             }
@@ -35,8 +34,8 @@ class RichContentTypeList {
             !type.importPath
         ) {
             throw new Error(
-                `richContentTypes target: Argument is not a valid rich content type strategy.`
-                + ` A valid strategy must have a JSX element name as "contentType" and a resolvable path to the renderer module as "importPath".`
+                `richContentTypes target: Argument is not a valid rich content type strategy.` +
+                    ` A valid strategy must have a JSX element name as "contentType" and a resolvable path to the renderer module as "importPath".`
             );
         }
         const componentName = `${type.contentType}ContentType`;

--- a/packages/venia-ui/lib/targets/RichContentTypeList.js
+++ b/packages/venia-ui/lib/targets/RichContentTypeList.js
@@ -1,0 +1,50 @@
+/**
+ * Implementation of our 'richContentTypes' target. This will gather
+ * RichContentType declarations { importPath, contentType } from all
+ * interceptors, and then tap `builtins.transformModules` to inject a module
+ * transform into the build which is configured to generate an array of modules
+ * to be imported and then exported.
+ *
+ * An instance of this class is made available when you use VeniaUI's
+ * `richContentTypes` target.
+ */
+class RichContentTypeList {
+    /** @hideconstructor */
+    constructor(venia) {
+        const registry = this;
+        this._types = venia.esModuleArray({
+            module:
+                '@magento/venia-ui/lib/components/RichContent/richContentTypes.js',
+            publish(targets) {
+                targets.richContentTypes.call(registry);
+            }
+        });
+    }
+    /**
+     * Add a rendering strategy to the RichContent component.
+     *
+     * @param {Object} strategy - Describes the rich content type to include
+     * @param {string} strategy.importPath - Import path to the RichContentRenderer module. Should be package-absolute.
+     * @param {string} strategy.contentType - Name that will be given to the imported renderer in generated code. This is used for debugging purposes.
+     */
+    add(type) {
+        if (
+            typeof type.contentType !== 'string' ||
+            !type.contentType ||
+            typeof type.importPath !== 'string' ||
+            !type.importPath
+        ) {
+            throw new Error(
+                `richContentTypes target: Argument is not a valid rich content type strategy.`
+                + ` A valid strategy must have a JSX element name as "contentType" and a resolvable path to the renderer module as "importPath".`
+            );
+        }
+        const componentName = `${type.contentType}ContentType`;
+
+        this._types.unshift(
+            `import ${componentName} from '${type.importPath}';`
+        );
+    }
+}
+
+module.exports = RichContentTypeList;

--- a/packages/venia-ui/lib/targets/venia-ui-declare.js
+++ b/packages/venia-ui/lib/targets/venia-ui-declare.js
@@ -155,7 +155,26 @@ module.exports = targets => {
 
         categoryListProductAttributes: new targets.types.Sync([
             'categoryListProductAttributes'
-        ])
+        ]),
+
+        /**
+         * Provides access to Venia's RichContent content types
+         *
+         * @member {tapable.SyncHook}
+         *
+         * @see [Intercept function signature]{@link rendererInterceptFunction}
+         * @see [RichContentTypeList]{@link #RichContentTypeList}
+         * @see [RichContent]{@link RichContent}
+         *
+         * @example <caption>Add a content type</caption>
+         * targets.of('@magento/venia-ui').richContentTypes.tap(
+         *   contentTypes => contentTypes.add({
+         *     contentType: 'AdobeXMC',
+         *     importPath: '@adobe/xm-components/xm-content-type'
+         *   })
+         * );
+         */
+        richContentTypes: new targets.types.Sync(['contentTypes'])
     });
 };
 
@@ -337,4 +356,40 @@ module.exports = targets => {
  *      paymentCode: 'cc',
  *      importPath: '@partner/module/path_to_your_component'
  * }
+ */
+
+/**
+ * Rich content types for the RichContent component must implement this
+ * interface. Should be written as an ES Module—a module that exports functions
+ * with these names, rather than an object with these functions as properties.
+ *
+ * @typedef {Object} RichContentType
+ * @interface
+ * @property {React.Component} Component - The React component that does the actual rendering.
+ * @property {function} configAggregator - Function that receives the content to be rendered as
+ * @property {string} data content type name should be the same data-content-type=""
+ *
+ * @example <caption>A component that can render content data-content-type="zlider"</caption>
+ * ```jsx
+ * import React from 'react';
+ * import Component from './zlider';
+ *
+ * const configAggregator = (node, props) => {
+ * const attributeName = 'data-mage-init';
+ * const attribute = node && node.hasAttribute(attributeName) ? node.getAttribute(attributeName) : false;
+ * if (!attribute) {
+ *     return;
+ * }
+ * const config = JSON.parse(attribute);
+ *   return {
+ *       config
+ *   };
+ * }
+ * export default {
+ *   name: 'zlider',
+ *   configAggregator,
+ *   component: Component
+ * }
+ * ```
+ *
  */

--- a/packages/venia-ui/lib/targets/venia-ui-intercept.js
+++ b/packages/venia-ui/lib/targets/venia-ui-intercept.js
@@ -9,6 +9,7 @@ const CheckoutPagePaymentsList = require('./CheckoutPagePaymentsList');
 const SavedPaymentTypes = require('./SavedPaymentTypes');
 const EditablePaymentTypes = require('./EditablePaymentTypes');
 const SummaryPaymentTypes = require('./SummaryPaymentTypes');
+const RichContentTypeList = require('./RichContentTypeList');
 
 module.exports = veniaTargets => {
     const venia = Targetables.using(veniaTargets);
@@ -60,4 +61,6 @@ module.exports = veniaTargets => {
     });
 
     new CategoryListProductAttributes(venia);
+
+    new RichContentTypeList(venia);
 };


### PR DESCRIPTION
## Description

It gets the possibility for an extension to add custom [content type renderers](https://github.com/magento/pwa-studio/blob/develop/packages/pagebuilder/lib/config.js#L29). 

https://github.com/magento/pwa-studio/blob/develop/packages/pagebuilder/lib/config.js#L29

## Related Issue

#2130
#2131
#2968

Closes #2968

## Acceptance
@sirugh
@zetlen

## Verification Steps

intercept.js
```js
    targets
        .of('@magento/venia-ui')
        .richContentTypes.tap(contentTypes => {
            contentTypes.add({
                contentType: 'XSlider',
                importPath: require.resolve(
                    "../lib/components/XSlider/ContentTypes/XSlider/index.js"
                )
            });
        });
```

lib/components/XSlider/ContentTypes/XSlider/index.js

```js
import Component from './xslider';
import configAggregator from './configAggregator';

export default {
    name: 'xslider',
    configAggregator,
    component: Component
}
```