### PR TITLE
magento/pwa-devdocs#: Adds a solution to a possible error during SASS loader installation

### DIFF
--- a/pwa-devdocs/src/tutorials/enable-sass-less-support/index.md
+++ b/pwa-devdocs/src/tutorials/enable-sass-less-support/index.md
@@ -16,6 +16,28 @@ Use a package manager, such as `yarn` or `npm`, to install the SASS loader as a 
 yarn add --dev sass-loader node-sass
 ```
 
+{:.bs-callout-warning}
+While installing the SASS loader you may get the error `TypeError: this.getOptions is not a function`.
+To resolve this error, just downgrade to version 10 of SASS loader.
+For this, edit `package.json` and change the version of sass-loader:
+
+```diff
+- "sass-loader": "^12.1.0"
++ "sass-loader": "^10.0.0"
+```
+
+Remove the `node_modules` folder and run:
+
+```sh
+yarn install
+```
+
+Or install sass-loader as a dev dependency with a specific version:
+
+```sh
+yarn add sass-loader@^10.0.0
+```
+
 ### Step 2. Modify the Webpack configuration
 
 Edit `webpack.config.js` and add a new `config` rule entry:


### PR DESCRIPTION
## Description

Tried repeating the steps but faced an error during SASS loader installation.
Adds a solution to a possible error during SASS loader installation to the existing documentation.

## Affected documentation pages

https://magento.github.io/pwa-studio/tutorials/enable-sass-less-support/#add-sass-support

### Resolved issues:
1. [x] resolves magento/pwa-studio#3300: magento/pwa-devdocs#: Adds a solution to a possible error during SASS loader installation