### PR TITLE
Support new GraphQL Header

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -317,7 +317,7 @@ const jestConfig = {
     ],
     // Include files with zero tests in overall coverage analysis by specifying
     // coverage paths manually.
-    collectCoverage: true,
+    collectCoverage: false,
     collectCoverageFrom: [
         // Code directories
         'packages/*/{src,lib,_buildpack}/**/*.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -317,7 +317,7 @@ const jestConfig = {
     ],
     // Include files with zero tests in overall coverage analysis by specifying
     // coverage paths manually.
-    collectCoverage: false,
+    collectCoverage: true,
     collectCoverageFrom: [
         // Code directories
         'packages/*/{src,lib,_buildpack}/**/*.js',

--- a/packages/peregrine/lib/Apollo/__tests__/magentoGqlCacheLink.spec.js
+++ b/packages/peregrine/lib/Apollo/__tests__/magentoGqlCacheLink.spec.js
@@ -1,0 +1,123 @@
+import MagentoGQLCacheLink from '../magentoGqlCacheLink';
+import {
+    mockGetItem,
+    mockSetItem
+} from '@magento/peregrine/lib/util/simplePersistence';
+
+jest.mock('@magento/peregrine/lib/util/simplePersistence');
+
+test('it sets the correct context + headers on outgoing requests', () => {
+    // Arrange.
+    let setContextResult = null;
+    const operation = {
+        setContext: jest.fn().mockImplementation(implementation => {
+            const mockPreviousContext = {
+                not: 'headers',
+                headers: {
+                    something: 'else'
+                }
+            };
+            setContextResult = implementation(mockPreviousContext);
+        }),
+        getContext: jest.fn()
+    };
+    const forward = jest.fn().mockReturnValue([]);
+
+    const instance = new MagentoGQLCacheLink();
+    instance.setCacheId('unit_test');
+
+    // Act.
+    instance.request(operation, forward);
+
+    // Assert.
+    expect(operation.setContext).toHaveBeenCalled();
+
+    // It should retain the previous context.
+    expect(setContextResult.not).toEqual('headers');
+
+    // It should append to the headers.
+    expect(Object.keys(setContextResult.headers)).toHaveLength(2);
+    expect(setContextResult.headers['x-magento-cache-id']).toEqual('unit_test');
+    expect(setContextResult.headers.something).toEqual('else');
+});
+
+test('it tries to seed from local storage', () => {
+    // Arrange.
+    let setContextResult = null;
+    const operation = {
+        setContext: jest.fn().mockImplementation(implementation => {
+            const mockPreviousContext = {
+                not: 'headers',
+                headers: {
+                    something: 'else'
+                }
+            };
+            setContextResult = implementation(mockPreviousContext);
+        }),
+        getContext: jest.fn()
+    };
+    const forward = jest.fn().mockReturnValue([]);
+    mockGetItem.mockReturnValueOnce('unit_test_from_storage');
+
+    const instance = new MagentoGQLCacheLink();
+
+    // Act.
+    instance.request(operation, forward);
+
+    // Assert.
+    expect(setContextResult.headers['x-magento-cache-id']).toEqual(
+        'unit_test_from_storage'
+    );
+});
+
+test('it should save the cache id from responses', () => {
+    // Arrange.
+    const operation = {
+        setContext: jest.fn(),
+        getContext: jest.fn().mockImplementation(() => {
+            const headers = new Map();
+            headers.set('x-magento-cache-id', 'unit_test');
+
+            return {
+                response: {
+                    headers
+                }
+            };
+        })
+    };
+    const forward = jest.fn().mockReturnValue([1]);
+
+    const instance = new MagentoGQLCacheLink();
+
+    // Act.
+    instance.request(operation, forward);
+
+    // Assert.
+    expect(mockSetItem).toHaveBeenCalledTimes(1);
+    expect(mockSetItem).toHaveBeenCalledWith('magento_cache_id', 'unit_test');
+});
+
+test('it does not update its internal value when not present in the response', () => {
+    // Arrange.
+    const operation = {
+        setContext: jest.fn(),
+        getContext: jest.fn().mockImplementation(() => {
+            const headers = new Map();
+
+            return {
+                response: {
+                    headers
+                }
+            };
+        })
+    };
+    const forward = jest.fn().mockReturnValue([1]);
+
+    const instance = new MagentoGQLCacheLink();
+
+    // Act.
+    instance.request(operation, forward);
+
+    // Assert.
+    expect(mockSetItem).toHaveBeenCalledTimes(0);
+});

--- a/packages/peregrine/lib/Apollo/magentoGqlCacheLink.js
+++ b/packages/peregrine/lib/Apollo/magentoGqlCacheLink.js
@@ -1,15 +1,23 @@
 import { ApolloLink } from '@apollo/client';
 import { BrowserPersistence } from '@magento/peregrine/lib/util';
 
+// The name of the header to exchange with the server.
 const CACHE_ID_HEADER = 'x-magento-cache-id';
+// The key in local storage where we save the cache id
 const LOCAL_STORAGE_KEY = 'magento_cache_id';
 const storage = new BrowserPersistence();
 
+/**
+ * The Magento GraphQL Cache Link class is an ApolloLink that is responsible for
+ * Venia sending the proper `x-magento-cache-id` header with each of its GraphQL requests.
+ */
 export default class MagentoGQLCacheLink extends ApolloLink {
     // The links get reinstantiated on refresh.
-    // If we have an existing cache id value from a previous browsing session, use that.
+    // If we have an existing cache id value from a previous browsing session, use it.
     #cacheId = storage.getItem(LOCAL_STORAGE_KEY) || null;
 
+    // Any time the cache id needs to be set, update both our internal variable and
+    // the value in local storage.
     setCacheId(value) {
         this.#cacheId = value;
         storage.setItem(LOCAL_STORAGE_KEY, value);
@@ -30,7 +38,7 @@ export default class MagentoGQLCacheLink extends ApolloLink {
             };
         });
 
-        // Update the cache id with each response.
+        // Update the cache id from each response.
         const updateCacheId = data => {
             const context = operation.getContext();
             const { response } = context;

--- a/packages/peregrine/lib/Apollo/magentoGqlCacheLink.js
+++ b/packages/peregrine/lib/Apollo/magentoGqlCacheLink.js
@@ -1,6 +1,6 @@
 import { ApolloLink } from '@apollo/client';
 
-const CACHE_ID_HEADER = 'X-Magento-Cache-Id';
+const CACHE_ID_HEADER = 'x-magento-cache-id';
 
 export default class MagentoGQLCacheLink extends ApolloLink {
     // Our very first request won't have a cache id.
@@ -15,8 +15,6 @@ export default class MagentoGQLCacheLink extends ApolloLink {
                 [CACHE_ID_HEADER]: this.#cacheId
             };
 
-            console.log('sending out', this.#cacheId);
-
             return {
                 ...previousContext,
                 headers: withCacheHeader
@@ -25,9 +23,14 @@ export default class MagentoGQLCacheLink extends ApolloLink {
 
         // Update the cache id with each response.
         const updateCacheId = data => {
-            this.#cacheId = Math.random();
+            const context = operation.getContext();
+            const { response } = context;
 
-            console.log('received', this.#cacheId);
+            const responseCacheId = response.headers.get(CACHE_ID_HEADER);
+
+            if (responseCacheId) {
+                this.#cacheId = responseCacheId;
+            }
 
             // Purposefully don't modify the result,
             // no other link needs to know about the cache id.

--- a/packages/peregrine/lib/Apollo/magentoGqlCacheLink.js
+++ b/packages/peregrine/lib/Apollo/magentoGqlCacheLink.js
@@ -1,0 +1,39 @@
+import { ApolloLink } from '@apollo/client';
+
+const CACHE_ID_HEADER = 'X-Magento-Cache-Id';
+
+export default class MagentoGQLCacheLink extends ApolloLink {
+    // Our very first request won't have a cache id.
+    #cacheId = null;
+
+    request(operation, forward) {
+        // Attach the cache header to each outgoing request.
+        operation.setContext(previousContext => {
+            const { headers } = previousContext;
+            const withCacheHeader = {
+                ...headers,
+                [CACHE_ID_HEADER]: this.#cacheId
+            };
+
+            console.log('sending out', this.#cacheId);
+
+            return {
+                ...previousContext,
+                headers: withCacheHeader
+            };
+        });
+
+        // Update the cache id with each response.
+        const updateCacheId = data => {
+            this.#cacheId = Math.random();
+
+            console.log('received', this.#cacheId);
+
+            // Purposefully don't modify the result,
+            // no other link needs to know about the cache id.
+            return data;
+        };
+
+        return forward(operation).map(updateCacheId);
+    }
+}

--- a/packages/peregrine/lib/talons/Adapter/useAdapter.js
+++ b/packages/peregrine/lib/talons/Adapter/useAdapter.js
@@ -13,6 +13,7 @@ import MutationQueueLink from '@adobe/apollo-link-mutation-queue';
 import attachClient from '@magento/peregrine/lib/Apollo/attachClientToStore';
 import { CACHE_PERSIST_PREFIX } from '@magento/peregrine/lib/Apollo/constants';
 import typePolicies from '@magento/peregrine/lib/Apollo/policies';
+import MagentoGQLCacheLink from '@magento/peregrine/lib/Apollo/magentoGqlCacheLink';
 import { BrowserPersistence } from '@magento/peregrine/lib/util';
 import shrinkQuery from '@magento/peregrine/lib/util/shrinkQuery';
 
@@ -160,6 +161,8 @@ export const useAdapter = props => {
         []
     );
 
+    const magentoGqlCacheLink = useMemo(() => new MagentoGQLCacheLink(), []);
+
     const apolloLink = useMemo(
         () =>
             ApolloLink.from([
@@ -168,11 +171,20 @@ export const useAdapter = props => {
                 mutationQueueLink,
                 retryLink,
                 authLink,
+                magentoGqlCacheLink,
                 storeLink,
                 errorLink,
                 httpLink
             ]),
-        [authLink, errorLink, httpLink, mutationQueueLink, retryLink, storeLink]
+        [
+            authLink,
+            errorLink,
+            httpLink,
+            magentoGqlCacheLink,
+            mutationQueueLink,
+            retryLink,
+            storeLink
+        ]
     );
 
     const apolloClient = useMemo(() => {


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

This PR adds a new Apollo Link to our Apollo client that reads and attaches the new `X-Magento-Cache-Id` header to every GraphQL request.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes PWA-1868.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

@jimbo @pdohogne-magento 

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Test Plan

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

You will want to point to a backend environment that sends the `x-magento-cache-id` header.

#### Test scenario(s) for direct fix/feature

1. Load the homepage and wait for all requests to complete
2. Look for the `X-Magneto-Cache-Id` header of the last GraphQL request in the Network tab (response headers)
3. Perform an action that causes another GraphQL request (ex: click the shopping bag / cart icon)
4. Inspect the outgoing GraphQL request and verify that it has an `X-Magento-Cache-Id` request header and that the value matches the previous value sent by the server
5. Perform an operation that changes the cache id (ex: log in/out, change store, change currency, change address)
6. Verify that Venia properly updates and sends out its now-refreshed `X-Magento-Cache-Id` value

#### Test scenario(s) for any existing impacted features/areas

n/a

#### Test scenario(s) for any Magento Backend Supported Configurations

n/a

#### Is Browser/Device testing needed?

No

#### Any ad-hoc/edge case scenarios that need to be considered?

Test against environments that don't support the new header, perhaps.

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
