### PR TITLE
[PWA-1878] Proof of Concept - Category Shimmer

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Products/Carousel/__tests__/__snapshots__/carousel.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Products/Carousel/__tests__/__snapshots__/carousel.spec.js.snap
@@ -2,7 +2,10 @@
 
 exports[`renders if \`items\` is an array of objects 1`] = `
 <mock-SlickSlider>
-  <div>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+  >
     <div
       className="undefined undefined"
     >
@@ -53,7 +56,10 @@ https://backend.test/media/catalog/product/test/product/1.png?auto=webp&format=p
     </div>
     <div />
   </div>
-  <div>
+  <div
+    aria-busy="false"
+    aria-live="polite"
+  >
     <div
       className="undefined undefined"
     >

--- a/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
+++ b/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
@@ -37,63 +37,18 @@ Array [
         <div
           className="headerButtons"
         >
-          <div
-            className="root"
-          >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="content"
-              >
-                <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
-                >
-                  <span
-                    className="sortText"
-                  >
-                    <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
-                    />
-                     
-                    
-                  </span>
-                  <span
-                    className="root"
-                  >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polyline
-                        points="6 9 12 15 18 9"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </button>
-          </div>
+          <ProductSort
+            sortProps={
+              Array [
+                Object {
+                  "sortAttribute": "",
+                  "sortDirection": "",
+                  "sortText": "",
+                },
+                [MockFunction],
+              ]
+            }
+          />
         </div>
         <SortedByContainer
           currentSort={
@@ -180,63 +135,18 @@ Array [
               ]
             }
           />
-          <div
-            className="root"
-          >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="content"
-              >
-                <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
-                >
-                  <span
-                    className="sortText"
-                  >
-                    <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
-                    />
-                     
-                    
-                  </span>
-                  <span
-                    className="root"
-                  >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polyline
-                        points="6 9 12 15 18 9"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </button>
-          </div>
+          <ProductSort
+            sortProps={
+              Array [
+                Object {
+                  "sortAttribute": "",
+                  "sortDirection": "",
+                  "sortText": "",
+                },
+                [MockFunction],
+              ]
+            }
+          />
         </div>
         <SortedByContainer
           currentSort={
@@ -357,88 +267,32 @@ Array [
       >
         <div
           className="categoryInfo"
-        />
+        >
+          <Shimmer
+            height={15}
+          />
+        </div>
         <div
           className="headerButtons"
-        />
+        >
+          <ProductSortShimmer />
+        </div>
+        <SortedByContainerShimmer />
       </div>
-      <div
-        className="global"
+      <section
+        className="gallery"
       >
-        <span
-          className="root"
-        >
-          <svg
-            className="icon"
-            fill="none"
-            height={64}
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width={64}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <line
-              x1="12"
-              x2="12"
-              y1="2"
-              y2="6"
-            />
-            <line
-              x1="12"
-              x2="12"
-              y1="18"
-              y2="22"
-            />
-            <line
-              x1="4.93"
-              x2="7.76"
-              y1="4.93"
-              y2="7.76"
-            />
-            <line
-              x1="16.24"
-              x2="19.07"
-              y1="16.24"
-              y2="19.07"
-            />
-            <line
-              x1="2"
-              x2="6"
-              y1="12"
-              y2="12"
-            />
-            <line
-              x1="18"
-              x2="22"
-              y1="12"
-              y2="12"
-            />
-            <line
-              x1="4.93"
-              x2="7.76"
-              y1="19.07"
-              y2="16.24"
-            />
-            <line
-              x1="16.24"
-              x2="19.07"
-              y1="7.76"
-              y2="4.93"
-            />
-          </svg>
-        </span>
-        <span
-          className="message"
-        >
-          <mock-FormattedMessage
-            defaultMessage="Fetching Data..."
-            id="loadingIndicator.message"
-          />
-        </span>
-      </div>
+        <GalleryShimmer
+          items={
+            Object {
+              "id": 1,
+            }
+          }
+        />
+      </section>
+      <div
+        className="pagination"
+      />
     </div>
   </article>,
 ]
@@ -481,63 +335,18 @@ Array [
         <div
           className="headerButtons"
         >
-          <div
-            className="root"
-          >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="content"
-              >
-                <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
-                >
-                  <span
-                    className="sortText"
-                  >
-                    <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
-                    />
-                     
-                    
-                  </span>
-                  <span
-                    className="root"
-                  >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polyline
-                        points="6 9 12 15 18 9"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </button>
-          </div>
+          <ProductSort
+            sortProps={
+              Array [
+                Object {
+                  "sortAttribute": "",
+                  "sortDirection": "",
+                  "sortText": "",
+                },
+                [MockFunction],
+              ]
+            }
+          />
         </div>
         <SortedByContainer
           currentSort={
@@ -655,63 +464,18 @@ Array [
         <div
           className="headerButtons"
         >
-          <div
-            className="root"
-          >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span
-                className="content"
-              >
-                <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
-                >
-                  <span
-                    className="sortText"
-                  >
-                    <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
-                    />
-                     
-                    
-                  </span>
-                  <span
-                    className="root"
-                  >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <polyline
-                        points="6 9 12 15 18 9"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </span>
-            </button>
-          </div>
+          <ProductSort
+            sortProps={
+              Array [
+                Object {
+                  "sortAttribute": "",
+                  "sortDirection": "",
+                  "sortText": "",
+                },
+                [MockFunction],
+              ]
+            }
+          />
         </div>
         <SortedByContainer
           currentSort={

--- a/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
+++ b/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
@@ -269,7 +269,7 @@ Array [
           className="categoryInfo"
         >
           <Shimmer
-            height={15}
+            width={5}
           />
         </div>
         <div

--- a/packages/venia-ui/lib/RootComponents/Category/__tests__/categoryContent.spec.js
+++ b/packages/venia-ui/lib/RootComponents/Category/__tests__/categoryContent.spec.js
@@ -23,12 +23,38 @@ jest.mock('@magento/peregrine/lib/talons/RootComponents/Category', () => ({
 }));
 
 jest.mock('../../../components/Breadcrumbs', () => 'Breadcrumbs');
-jest.mock('../../../components/Gallery', () => 'Gallery');
+jest.mock('../../../components/Gallery', () => ({
+    __esModule: true,
+    default: 'Gallery',
+    GalleryShimmer: 'GalleryShimmer'
+}));
 jest.mock('../../../components/Pagination', () => 'Pagination');
-jest.mock('../../../components/SortedByContainer', () => 'SortedByContainer');
+jest.mock('../../../components/Shimmer', () => 'Shimmer');
+jest.mock('../../../components/ProductSort', () => ({
+    __esModule: true,
+    default: 'ProductSort',
+    ProductSortShimmer: 'ProductSortShimmer'
+}));
+jest.mock('../../../components/SortedByContainer', () => ({
+    __esModule: true,
+    default: 'SortedByContainer',
+    SortedByContainerShimmer: 'SortedByContainerShimmer'
+}));
 jest.mock(
     '../../../components/FilterModalOpenButton',
-    () => 'FilterModalOpenButton'
+    () => ({
+        __esModule: true,
+        default: 'FilterModalOpenButton',
+        FilterModalOpenButtonShimmer: 'FilterModalOpenButtonShimmer'
+    })
+);
+jest.mock(
+    '../../../components/FilterSidebar',
+    () => ({
+        __esModule: true,
+        default: 'FilterSidebar',
+        FilterSidebarShimmer: 'FilterSidebarShimmer'
+    })
 );
 jest.mock('../NoProductsFound', () => 'NoProductsFound');
 

--- a/packages/venia-ui/lib/RootComponents/Category/__tests__/categoryContent.spec.js
+++ b/packages/venia-ui/lib/RootComponents/Category/__tests__/categoryContent.spec.js
@@ -40,22 +40,16 @@ jest.mock('../../../components/SortedByContainer', () => ({
     default: 'SortedByContainer',
     SortedByContainerShimmer: 'SortedByContainerShimmer'
 }));
-jest.mock(
-    '../../../components/FilterModalOpenButton',
-    () => ({
-        __esModule: true,
-        default: 'FilterModalOpenButton',
-        FilterModalOpenButtonShimmer: 'FilterModalOpenButtonShimmer'
-    })
-);
-jest.mock(
-    '../../../components/FilterSidebar',
-    () => ({
-        __esModule: true,
-        default: 'FilterSidebar',
-        FilterSidebarShimmer: 'FilterSidebarShimmer'
-    })
-);
+jest.mock('../../../components/FilterModalOpenButton', () => ({
+    __esModule: true,
+    default: 'FilterModalOpenButton',
+    FilterModalOpenButtonShimmer: 'FilterModalOpenButtonShimmer'
+}));
+jest.mock('../../../components/FilterSidebar', () => ({
+    __esModule: true,
+    default: 'FilterSidebar',
+    FilterSidebarShimmer: 'FilterSidebarShimmer'
+}));
 jest.mock('../NoProductsFound', () => 'NoProductsFound');
 
 const defaultProps = {

--- a/packages/venia-ui/lib/RootComponents/Category/category.css
+++ b/packages/venia-ui/lib/RootComponents/Category/category.css
@@ -38,9 +38,11 @@
 }
 
 .categoryInfo {
+    flex-basis: 100%;
     line-height: var(--venia-global-typography-heading-lineHeight);
     margin: 1rem 0;
     max-width: 75vw;
+    text-align: center;
 }
 
 .headerButtons {
@@ -81,7 +83,7 @@
 
     .categoryInfo {
         margin: 0;
-        flex-basis: 100%;
+        text-align: left;
     }
 
     .sidebar {

--- a/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
+++ b/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
@@ -5,16 +5,17 @@ import { useCategoryContent } from '@magento/peregrine/lib/talons/RootComponents
 
 import { useStyle } from '../../classify';
 import Breadcrumbs from '../../components/Breadcrumbs';
-import Gallery from '../../components/Gallery';
+import FilterModalOpenButton, { FilterModalOpenButtonShimmer } from '../../components/FilterModalOpenButton';
+import { FilterSidebarShimmer } from '../../components/FilterSidebar';
+import Gallery, { GalleryShimmer } from '../../components/Gallery';
 import { StoreTitle } from '../../components/Head';
 import Pagination from '../../components/Pagination';
-import ProductSort from '../../components/ProductSort';
+import ProductSort, { ProductSortShimmer } from '../../components/ProductSort';
 import RichContent from '../../components/RichContent';
+import Shimmer from '../../components/Shimmer';
+import SortedByContainer, { SortedByContainerShimmer } from '../../components/SortedByContainer';
 import defaultClasses from './category.css';
 import NoProductsFound from './NoProductsFound';
-import { fullPageLoadingIndicator } from '../../components/LoadingIndicator';
-import SortedByContainer from '../../components/SortedByContainer';
-import FilterModalOpenButton from '../../components/FilterModalOpenButton';
 
 const FilterModal = React.lazy(() => import('../../components/FilterModal'));
 const FilterSidebar = React.lazy(() =>
@@ -50,12 +51,16 @@ const CategoryContent = props => {
     const classes = useStyle(defaultClasses, props.classes);
 
     const shouldShowFilterButtons = filters && filters.length;
+    const shouldShowFilterShimmer = filters === null;
 
     // If there are no products we can hide the sort button.
     const shouldShowSortButtons = totalPagesFromData;
+    const shouldShowSortShimmer = !totalPagesFromData && isLoading;
 
     const maybeFilterButtons = shouldShowFilterButtons ? (
         <FilterModalOpenButton filters={filters} />
+    ) : shouldShowFilterShimmer ? (
+        <FilterModalOpenButtonShimmer />
     ) : null;
 
     const filtersModal = shouldShowFilterButtons ? (
@@ -64,14 +69,20 @@ const CategoryContent = props => {
 
     const sidebar = shouldShowFilterButtons ? (
         <FilterSidebar filters={filters} />
+    ) : shouldShowFilterShimmer ? (
+        <FilterSidebarShimmer />
     ) : null;
 
     const maybeSortButton = shouldShowSortButtons ? (
         <ProductSort sortProps={sortProps} />
+    ) : shouldShowSortShimmer ? (
+        <ProductSortShimmer />
     ) : null;
 
     const maybeSortContainer = shouldShowSortButtons ? (
         <SortedByContainer currentSort={currentSort} />
+    ) : shouldShowSortShimmer ? (
+        <SortedByContainerShimmer />
     ) : null;
 
     const categoryResultsHeading =
@@ -83,6 +94,8 @@ const CategoryContent = props => {
                 }}
                 defaultMessage={'{count} Results'}
             />
+        ) : isLoading ? (
+            <Shimmer height={15} />
         ) : null;
 
     const categoryDescriptionElement = categoryDescription ? (
@@ -90,24 +103,30 @@ const CategoryContent = props => {
     ) : null;
 
     const content = useMemo(() => {
-        if (totalPagesFromData) {
-            return (
-                <Fragment>
-                    <section className={classes.gallery}>
-                        <Gallery items={items} />
-                    </section>
-                    <div className={classes.pagination}>
-                        <Pagination pageControl={pageControl} />
-                    </div>
-                </Fragment>
-            );
-        } else {
-            if (isLoading) {
-                return fullPageLoadingIndicator;
-            } else {
-                return <NoProductsFound categoryId={categoryId} />;
-            }
+        if (!totalPagesFromData && !isLoading) {
+            return <NoProductsFound categoryId={categoryId} />;
         }
+
+        const gallery = totalPagesFromData ? (
+            <Gallery items={items} />
+        ) : (
+            <GalleryShimmer items={items} />
+        );
+
+        const pagination = totalPagesFromData ? (
+            <Pagination pageControl={pageControl} />
+        ) : null;
+
+        return (
+            <Fragment>
+                <section className={classes.gallery}>
+                    {gallery}
+                </section>
+                <div className={classes.pagination}>
+                    {pagination}
+                </div>
+            </Fragment>
+        );
     }, [
         categoryId,
         classes.gallery,
@@ -132,7 +151,7 @@ const CategoryContent = props => {
                     {categoryDescriptionElement}
                 </div>
                 <div className={classes.sidebar}>
-                    <Suspense fallback={null}>{sidebar}</Suspense>
+                    <Suspense fallback={<FilterSidebarShimmer />}>{sidebar}</Suspense>
                 </div>
                 <div className={classes.categoryContent}>
                     <div className={classes.heading}>

--- a/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
+++ b/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
@@ -5,7 +5,9 @@ import { useCategoryContent } from '@magento/peregrine/lib/talons/RootComponents
 
 import { useStyle } from '../../classify';
 import Breadcrumbs from '../../components/Breadcrumbs';
-import FilterModalOpenButton, { FilterModalOpenButtonShimmer } from '../../components/FilterModalOpenButton';
+import FilterModalOpenButton, {
+    FilterModalOpenButtonShimmer
+} from '../../components/FilterModalOpenButton';
 import { FilterSidebarShimmer } from '../../components/FilterSidebar';
 import Gallery, { GalleryShimmer } from '../../components/Gallery';
 import { StoreTitle } from '../../components/Head';
@@ -13,7 +15,9 @@ import Pagination from '../../components/Pagination';
 import ProductSort, { ProductSortShimmer } from '../../components/ProductSort';
 import RichContent from '../../components/RichContent';
 import Shimmer from '../../components/Shimmer';
-import SortedByContainer, { SortedByContainerShimmer } from '../../components/SortedByContainer';
+import SortedByContainer, {
+    SortedByContainerShimmer
+} from '../../components/SortedByContainer';
 import defaultClasses from './category.css';
 import NoProductsFound from './NoProductsFound';
 
@@ -95,7 +99,7 @@ const CategoryContent = props => {
                 defaultMessage={'{count} Results'}
             />
         ) : isLoading ? (
-            <Shimmer height={15} />
+            <Shimmer width={5} />
         ) : null;
 
     const categoryDescriptionElement = categoryDescription ? (
@@ -119,12 +123,8 @@ const CategoryContent = props => {
 
         return (
             <Fragment>
-                <section className={classes.gallery}>
-                    {gallery}
-                </section>
-                <div className={classes.pagination}>
-                    {pagination}
-                </div>
+                <section className={classes.gallery}>{gallery}</section>
+                <div className={classes.pagination}>{pagination}</div>
             </Fragment>
         );
     }, [
@@ -137,6 +137,8 @@ const CategoryContent = props => {
         totalPagesFromData
     ]);
 
+    const categoryTitle = categoryName ? categoryName : <Shimmer width={5} />;
+
     return (
         <Fragment>
             <Breadcrumbs categoryId={categoryId} />
@@ -145,13 +147,15 @@ const CategoryContent = props => {
                 <div className={classes.categoryHeader}>
                     <h1 className={classes.title}>
                         <div className={classes.categoryTitle}>
-                            {categoryName || '...'}
+                            {categoryTitle}
                         </div>
                     </h1>
                     {categoryDescriptionElement}
                 </div>
                 <div className={classes.sidebar}>
-                    <Suspense fallback={<FilterSidebarShimmer />}>{sidebar}</Suspense>
+                    <Suspense fallback={<FilterSidebarShimmer />}>
+                        {sidebar}
+                    </Suspense>
                 </div>
                 <div className={classes.categoryContent}>
                     <div className={classes.heading}>

--- a/packages/venia-ui/lib/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbs.spec.js.snap
+++ b/packages/venia-ui/lib/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbs.spec.js.snap
@@ -4,12 +4,16 @@ exports[`renders an breadcrumb shimmer if breadcrumbs are loading 1`] = `null`;
 
 exports[`renders an empty div if there was an error fetching breadcrumbs 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 />
 `;
 
 exports[`renders breadcrumbs for a category view 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 >
   <mock-FormattedMessage
@@ -31,6 +35,8 @@ exports[`renders breadcrumbs for a category view 1`] = `
 
 exports[`renders breadcrumbs for a product view 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 >
   <mock-FormattedMessage
@@ -58,6 +64,8 @@ exports[`renders breadcrumbs for a product view 1`] = `
 
 exports[`renders breadcrumbs for intermediate links 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 >
   <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbs.spec.js.snap
+++ b/packages/venia-ui/lib/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbs.spec.js.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders an empty div if breadcrumbs are loading 1`] = `
-<div
-  className="root"
-/>
-`;
+exports[`renders an breadcrumb shimmer if breadcrumbs are loading 1`] = `null`;
 
 exports[`renders an empty div if there was an error fetching breadcrumbs 1`] = `
 <div

--- a/packages/venia-ui/lib/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbs.spec.js.snap
+++ b/packages/venia-ui/lib/components/Breadcrumbs/__tests__/__snapshots__/breadcrumbs.spec.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders an breadcrumb shimmer if breadcrumbs are loading 1`] = `null`;
-
 exports[`renders an empty div if there was an error fetching breadcrumbs 1`] = `
 <div
   aria-busy="false"
@@ -90,3 +88,5 @@ exports[`renders breadcrumbs for intermediate links 1`] = `
   </span>
 </div>
 `;
+
+exports[`renders the breadcrumb shimmer if breadcrumbs are loading 1`] = `null`;

--- a/packages/venia-ui/lib/components/Breadcrumbs/__tests__/breadcrumbs.spec.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/__tests__/breadcrumbs.spec.js
@@ -27,7 +27,7 @@ jest.mock('../breadcrumbs.shimmer', () => {
 const defaultProps = {
     categoryId: 'category1'
 };
-test('renders an breadcrumb shimmer if breadcrumbs are loading', () => {
+test('renders the breadcrumb shimmer if breadcrumbs are loading', () => {
     useBreadcrumbs.mockReturnValueOnce({
         isLoading: true,
         normalizedData: []

--- a/packages/venia-ui/lib/components/Breadcrumbs/__tests__/breadcrumbs.spec.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/__tests__/breadcrumbs.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createTestInstance } from '@magento/peregrine';
+import { mockShimmer } from '../breadcrumbs.shimmer';
 import { useBreadcrumbs } from '@magento/peregrine/lib/talons/Breadcrumbs/useBreadcrumbs';
 
 import Breadcrumbs from '../breadcrumbs';
@@ -13,16 +14,27 @@ jest.mock('@magento/peregrine/lib/util/makeUrl', () =>
 jest.mock('../../../classify');
 jest.mock('@magento/peregrine/lib/talons/Breadcrumbs/useBreadcrumbs');
 
+jest.mock('../breadcrumbs.shimmer', () => {
+    const mockedShimmer = jest.fn(() => null);
+
+    return {
+        __esModule: true,
+        default: mockedShimmer,
+        mockShimmer: mockedShimmer
+    }
+});
+
 const defaultProps = {
     categoryId: 'category1'
 };
-test('renders an empty div if breadcrumbs are loading', () => {
+test('renders an breadcrumb shimmer if breadcrumbs are loading', () => {
     useBreadcrumbs.mockReturnValueOnce({
         isLoading: true,
         normalizedData: []
     });
 
     const instance = createTestInstance(<Breadcrumbs {...defaultProps} />);
+    expect(mockShimmer).toHaveBeenCalled();
     expect(instance.toJSON()).toMatchSnapshot();
 });
 

--- a/packages/venia-ui/lib/components/Breadcrumbs/__tests__/breadcrumbs.spec.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/__tests__/breadcrumbs.spec.js
@@ -21,7 +21,7 @@ jest.mock('../breadcrumbs.shimmer', () => {
         __esModule: true,
         default: mockedShimmer,
         mockShimmer: mockedShimmer
-    }
+    };
 });
 
 const defaultProps = {

--- a/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { useBreadcrumbs } from '@magento/peregrine/lib/talons/Breadcrumbs/useBreadcrumbs';
 import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
 import { useStyle } from '../../classify';
+import Shimmer from './breadcrumbs.shimmer';
 import defaultClasses from './breadcrumbs.css';
 
 const DELIMITER = '/';
@@ -44,9 +45,13 @@ const Breadcrumbs = props => {
         });
     }, [classes.divider, classes.link, normalizedData]);
 
-    // Don't display anything but the empty, static height div when loading or
-    // if there was an error.
-    if (isLoading || hasError) {
+
+    if (isLoading) {
+        return <Shimmer />;
+    }
+
+    // Don't display anything but the empty, static height div when there's an error.
+    if (hasError) {
         return <div className={classes.root} />;
     }
 

--- a/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.js
@@ -45,14 +45,19 @@ const Breadcrumbs = props => {
         });
     }, [classes.divider, classes.link, normalizedData]);
 
-
     if (isLoading) {
         return <Shimmer />;
     }
 
     // Don't display anything but the empty, static height div when there's an error.
     if (hasError) {
-        return <div className={classes.root} />;
+        return (
+            <div
+                className={classes.root}
+                aria-live="polite"
+                aria-busy="false"
+            />
+        );
     }
 
     // If we have a "currentProduct" it means we're on a PDP so we want the last
@@ -74,7 +79,7 @@ const Breadcrumbs = props => {
     ) : null;
 
     return (
-        <div className={classes.root}>
+        <div className={classes.root} aria-live="polite" aria-busy="false">
             <Link className={classes.link} to="/">
                 <FormattedMessage id={'global.home'} defaultMessage={'Home'} />
             </Link>

--- a/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.shimmer.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.shimmer.js
@@ -1,19 +1,18 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
-import { mergeClasses } from '../../classify';
+import { useStyle } from '../../classify';
+
 import Shimmer from '../Shimmer';
 import defaultClasses from './breadcrumbs.css';
 
-const BreadcrumbsShimmer = (props) => {
-    const classes = mergeClasses(defaultClasses, props.classes);
+const BreadcrumbsShimmer = props => {
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
-        <Shimmer className={classes.root} width={400} height={15} aria-live="polite" aria-busy="true" />
+        <div className={classes.root} aria-live="polite" aria-busy="true">
+            <Shimmer width={5} />
+        </div>
     );
-};
-
-BreadcrumbsShimmer.defaultProps = {
-    classes: {}
 };
 
 BreadcrumbsShimmer.propTypes = {

--- a/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.shimmer.js
+++ b/packages/venia-ui/lib/components/Breadcrumbs/breadcrumbs.shimmer.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shape, string } from 'prop-types';
+import { mergeClasses } from '../../classify';
+import Shimmer from '../Shimmer';
+import defaultClasses from './breadcrumbs.css';
+
+const BreadcrumbsShimmer = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <Shimmer className={classes.root} width={400} height={15} aria-live="polite" aria-busy="true" />
+    );
+};
+
+BreadcrumbsShimmer.defaultProps = {
+    classes: {}
+};
+
+BreadcrumbsShimmer.propTypes = {
+    classes: shape({
+        root: string
+    })
+};
+
+export default BreadcrumbsShimmer;

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
@@ -53,7 +53,9 @@ describe('#FilterModalOpenButton Shimmer', () => {
 
         expect(mockShimmer).toHaveBeenCalledWith(
             expect.objectContaining({
-                classes:  expect.objectContaining({ root_button: mockClasses[mockClassName] })
+                classes: expect.objectContaining({
+                    root_button: mockClasses[mockClassName]
+                })
             }),
             expect.any(Object)
         );

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
@@ -5,7 +5,7 @@ import ShimmerComponent from '../filterModalOpenButton.shimmer';
 
 const mockClassName = 'filterButtonShimmer';
 const mockClasses = {
-    [mockClassName]: { root_button: 'filterButtonShimmer' }
+    [mockClassName]: 'test-class'
 };
 
 jest.mock('../../Shimmer', () => {
@@ -18,7 +18,9 @@ jest.mock('../../Shimmer', () => {
     };
 });
 
-jest.mock('../../../classify');
+jest.mock('../../../classify', () => ({
+    useStyle: (...classes) => Object.assign({}, ...classes)
+}));
 
 let passedProps = {};
 
@@ -51,7 +53,7 @@ describe('#FilterModalOpenButton Shimmer', () => {
 
         expect(mockShimmer).toHaveBeenCalledWith(
             expect.objectContaining({
-                classes: mockClasses[mockClassName]
+                classes:  expect.objectContaining({ root_button: mockClasses[mockClassName] })
             }),
             expect.any(Object)
         );

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
@@ -3,10 +3,9 @@ import { createTestInstance } from '@magento/peregrine';
 import { mockShimmer } from '../../Shimmer';
 import ShimmerComponent from '../filterModalOpenButton.shimmer';
 
-
-const mockClassName = 'filterButton';
+const mockClassName = 'filterButtonShimmer';
 const mockClasses = {
-    [mockClassName]: 'test-class'
+    [mockClassName]: { root_button: 'filterButtonShimmer' }
 };
 
 jest.mock('../../Shimmer', () => {
@@ -16,12 +15,10 @@ jest.mock('../../Shimmer', () => {
         __esModule: true,
         default: mockedShimmer,
         mockShimmer: mockedShimmer
-    }
+    };
 });
 
-jest.mock('../../../classify', () => ({
-    mergeClasses: (...objects) => Object.assign({}, ...objects)
-}));
+jest.mock('../../../classify');
 
 let passedProps = {};
 
@@ -43,19 +40,18 @@ describe('#FilterModalOpenButton Shimmer', () => {
     });
 
     test('renders Shimmer component', () => {
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
         expect(mockShimmer).toHaveBeenCalled();
     });
 
     test('passes merged class to Shimmer component', () => {
         givenPassedClasses();
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
-
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
         expect(mockShimmer).toHaveBeenCalledWith(
             expect.objectContaining({
-                className: mockClasses[mockClassName]
+                classes: mockClasses[mockClassName]
             }),
             expect.any(Object)
         );

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/__tests__/filterModalOpenButton.shimmer.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+import { mockShimmer } from '../../Shimmer';
+import ShimmerComponent from '../filterModalOpenButton.shimmer';
+
+
+const mockClassName = 'filterButton';
+const mockClasses = {
+    [mockClassName]: 'test-class'
+};
+
+jest.mock('../../Shimmer', () => {
+    const mockedShimmer = jest.fn(() => null);
+
+    return {
+        __esModule: true,
+        default: mockedShimmer,
+        mockShimmer: mockedShimmer
+    }
+});
+
+jest.mock('../../../classify', () => ({
+    mergeClasses: (...objects) => Object.assign({}, ...objects)
+}));
+
+let passedProps = {};
+
+const givenDefaultProps = () => {
+    passedProps = {};
+};
+
+const givenPassedClasses = () => {
+    passedProps = {
+        classes: mockClasses
+    };
+};
+
+describe('#FilterModalOpenButton Shimmer', () => {
+    beforeEach(() => {
+        mockShimmer.mockClear();
+
+        givenDefaultProps();
+    });
+
+    test('renders Shimmer component', () => {
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+        expect(mockShimmer).toHaveBeenCalled();
+    });
+
+    test('passes merged class to Shimmer component', () => {
+        givenPassedClasses();
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+
+        expect(mockShimmer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                className: mockClasses[mockClassName]
+            }),
+            expect.any(Object)
+        );
+    });
+});

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.css
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.css
@@ -1,5 +1,5 @@
 .filterButton {
-    composes: root_lowPriority from '../../components/Button/button.css';
+    composes: root_lowPriority from '../Button/button.css';
     min-width: 6.25rem;
 }
 

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.js
@@ -19,6 +19,8 @@ const FilterModalOpenButton = props => {
             }}
             onClick={handleOpen}
             type="button"
+            aria-live="polite"
+            aria-busy="false"
         >
             <FormattedMessage
                 id={'productList.filter'}
@@ -31,8 +33,8 @@ const FilterModalOpenButton = props => {
 export default FilterModalOpenButton;
 
 FilterModalOpenButton.propTypes = {
-    filters: array,
     classes: shape({
         filterButton: string
-    })
+    }),
+    filters: array
 };

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.shimmer.css
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.shimmer.css
@@ -1,0 +1,4 @@
+.filterButtonShimmer {
+    composes: root_button from '../Shimmer/shimmer.css';
+    composes: filterButton from './filterModalOpenButton.css';
+}

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.shimmer.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.shimmer.js
@@ -1,30 +1,26 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
-import { mergeClasses } from '../../classify';
-import Shimmer from '../Shimmer';
-import defaultClasses from './filterModalOpenButton.css';
+import { useStyle } from '../../classify';
 
-const FilterModalOpenButtonShimmer = (props) => {
-    const classes = mergeClasses(defaultClasses, props.classes);
+import Shimmer from '../Shimmer';
+import defaultClasses from './filterModalOpenButton.shimmer.css';
+
+const FilterModalOpenButtonShimmer = props => {
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
         <Shimmer
-            className={classes.filterButton}
-            width={125}
-            height={45}
+            classes={{ root_button: classes.filterButtonShimmer }}
+            type="button"
             aria-live="polite"
             aria-busy="true"
         />
     );
 };
 
-FilterModalOpenButtonShimmer.defaultProps = {
-    classes: {}
-};
-
 FilterModalOpenButtonShimmer.propTypes = {
     classes: shape({
-        filterButton: string
+        filterButtonShimmer: string
     })
 };
 

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.shimmer.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/filterModalOpenButton.shimmer.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shape, string } from 'prop-types';
+import { mergeClasses } from '../../classify';
+import Shimmer from '../Shimmer';
+import defaultClasses from './filterModalOpenButton.css';
+
+const FilterModalOpenButtonShimmer = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <Shimmer
+            className={classes.filterButton}
+            width={125}
+            height={45}
+            aria-live="polite"
+            aria-busy="true"
+        />
+    );
+};
+
+FilterModalOpenButtonShimmer.defaultProps = {
+    classes: {}
+};
+
+FilterModalOpenButtonShimmer.propTypes = {
+    classes: shape({
+        filterButton: string
+    })
+};
+
+export default FilterModalOpenButtonShimmer;

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/index.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/index.js
@@ -1,2 +1,4 @@
 export { default } from './filterModalOpenButton';
-export { default as FilterModalOpenButtonShimmer } from './filterModalOpenButton.shimmer';
+export {
+    default as FilterModalOpenButtonShimmer
+} from './filterModalOpenButton.shimmer';

--- a/packages/venia-ui/lib/components/FilterModalOpenButton/index.js
+++ b/packages/venia-ui/lib/components/FilterModalOpenButton/index.js
@@ -1,1 +1,2 @@
 export { default } from './filterModalOpenButton';
+export { default as FilterModalOpenButtonShimmer } from './filterModalOpenButton.shimmer';

--- a/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.js
+++ b/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, Fragment } from 'react';
+import React, { useMemo, useCallback, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { array, arrayOf, shape, string, number } from 'prop-types';
 import { useFilterSidebar } from '@magento/peregrine/lib/talons/FilterSidebar';
@@ -90,28 +90,31 @@ const FilterSidebar = props => {
     ) : null;
 
     return (
-        <Fragment>
-            <aside className={classes.root} ref={filterRef}>
-                <div className={classes.body}>
-                    <div className={classes.header}>
-                        <h2 className={classes.headerTitle}>
-                            <FormattedMessage
-                                id={'filterModal.headerTitle'}
-                                defaultMessage={'Filters'}
-                            />
-                        </h2>
-                    </div>
-                    <CurrentFilters
-                        filterApi={filterApi}
-                        filterNames={filterNames}
-                        filterState={filterState}
-                        onRemove={handleApplyFilter}
-                    />
-                    {clearAll}
-                    <ul className={classes.blocks}>{filtersList}</ul>
+        <aside
+            className={classes.root}
+            ref={filterRef}
+            aria-live="polite"
+            aria-busy="false"
+        >
+            <div className={classes.body}>
+                <div className={classes.header}>
+                    <h2 className={classes.headerTitle}>
+                        <FormattedMessage
+                            id={'filterModal.headerTitle'}
+                            defaultMessage={'Filters'}
+                        />
+                    </h2>
                 </div>
-            </aside>
-        </Fragment>
+                <CurrentFilters
+                    filterApi={filterApi}
+                    filterNames={filterNames}
+                    filterState={filterState}
+                    onRemove={handleApplyFilter}
+                />
+                {clearAll}
+                <ul className={classes.blocks}>{filtersList}</ul>
+            </div>
+        </aside>
     );
 };
 

--- a/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.shimmer.js
+++ b/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.shimmer.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shape, string } from 'prop-types';
+import { mergeClasses } from '../../classify';
+import Shimmer from '../Shimmer';
+import defaultClasses from './filterSidebar.css';
+
+const FilterSidebar = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <aside className={classes.root} aria-live="polite" aria-busy="true">
+            <Shimmer width="95%" height="70vh" style={{ marginBottom: 25 }} />
+        </aside>
+    )
+};
+
+FilterSidebar.defaultProps = {
+    classes: {}
+};
+
+FilterSidebar.propTypes = {
+    classes: shape({
+        root: string
+    })
+};
+
+export default FilterSidebar;
+

--- a/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.shimmer.js
+++ b/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.shimmer.js
@@ -1,21 +1,18 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
-import { mergeClasses } from '../../classify';
+import { useStyle } from '../../classify';
+
 import Shimmer from '../Shimmer';
 import defaultClasses from './filterSidebar.css';
 
-const FilterSidebar = (props) => {
-    const classes = mergeClasses(defaultClasses, props.classes);
+const FilterSidebar = props => {
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
         <aside className={classes.root} aria-live="polite" aria-busy="true">
             <Shimmer width="95%" height="70vh" style={{ marginBottom: 25 }} />
         </aside>
-    )
-};
-
-FilterSidebar.defaultProps = {
-    classes: {}
+    );
 };
 
 FilterSidebar.propTypes = {
@@ -25,4 +22,3 @@ FilterSidebar.propTypes = {
 };
 
 export default FilterSidebar;
-

--- a/packages/venia-ui/lib/components/FilterSidebar/index.js
+++ b/packages/venia-ui/lib/components/FilterSidebar/index.js
@@ -1,1 +1,2 @@
 export { default } from './filterSidebar';
+export { default as FilterSidebarShimmer } from './filterSidebar.shimmer';

--- a/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/gallery.spec.js.snap
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/gallery.spec.js.snap
@@ -2,12 +2,16 @@
 
 exports[`renders if \`items\` is an array of objects 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 >
   <div
     className="items"
   >
     <div
+      aria-busy="false"
+      aria-live="polite"
       className="root"
     >
       <div
@@ -65,6 +69,8 @@ exports[`renders if \`items\` is an array of objects 1`] = `
       />
     </div>
     <div
+      aria-busy="false"
+      aria-live="polite"
       className="root"
     >
       <div
@@ -127,6 +133,8 @@ exports[`renders if \`items\` is an array of objects 1`] = `
 
 exports[`renders if \`items\` is an empty array 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 >
   <div

--- a/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/item.spec.js.snap
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/item.spec.js.snap
@@ -2,42 +2,69 @@
 
 exports[`renders a placeholder item while awaiting item 1`] = `
 <div
-  className="root_pending"
+  aria-busy="true"
+  aria-live="polite"
+  className="root"
 >
   <div
-    className="images_pending"
+    className="root_rectangle"
+    style={Object {}}
   >
-    <div
-      className="root container"
+    <span
+      className="content"
     >
-      <img
-        alt="Placeholder for gallery item image"
-        className="image placeholder_layoutOnly"
-        loading="eager"
-        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
-        width={100}
-      />
-      <img
-        alt="Placeholder for gallery item image"
-        className="image loaded"
-        loading="lazy"
-        onError={[MockFunction]}
-        onLoad={[MockFunction]}
-        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
-      />
-    </div>
+      <div
+        className="root container"
+      >
+        <img
+          alt="Placeholder for gallery item image"
+          className="image placeholder_layoutOnly"
+          loading="eager"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
+          width={100}
+        />
+        <img
+          alt="Placeholder for gallery item image"
+          className="image loaded"
+          loading="lazy"
+          onError={[MockFunction]}
+          onLoad={[MockFunction]}
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
+        />
+      </div>
+    </span>
   </div>
   <div
-    className="name_pending"
-  />
+    className="root_rectangle"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <span
+      className="content"
+    />
+  </div>
   <div
-    className="price_pending"
-  />
+    className="root_rectangle"
+    style={
+      Object {
+        "width": "3rem",
+      }
+    }
+  >
+    <span
+      className="content"
+    />
+  </div>
 </div>
 `;
 
 exports[`renders correctly with valid item data 1`] = `
 <div
+  aria-busy="false"
+  aria-live="polite"
   className="root"
 >
   <a

--- a/packages/venia-ui/lib/components/Gallery/__tests__/gallery.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/gallery.shimmer.spec.js
@@ -19,7 +19,9 @@ jest.mock('../item.shimmer', () => {
     };
 });
 
-jest.mock('../../../classify');
+jest.mock('../../../classify', () => ({
+    useStyle: (...classes) => Object.assign({}, ...classes)
+}));
 
 let passedProps = {};
 

--- a/packages/venia-ui/lib/components/Gallery/__tests__/gallery.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/gallery.shimmer.spec.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+import { mockShimmer } from '../item.shimmer';
+import ShimmerComponent from '../gallery.shimmer';
+
+const mockItemClasses = {
+    test: 'test-class'
+};
+
+const mockItems = Array.from({ length: 8 }).fill(null);
+
+jest.mock('../item.shimmer', () => {
+    const mockedShimmer = jest.fn(() => null);
+
+    return {
+        __esModule: true,
+        default: mockedShimmer,
+        mockShimmer: mockedShimmer
+    }
+});
+
+jest.mock('../../../classify', () => ({
+    mergeClasses: (...objects) => Object.assign({}, ...objects)
+}));
+
+let passedProps = {};
+
+const givenDefaultProps = () => {
+    passedProps = {};
+};
+
+const givenMultipleItems = () => {
+    passedProps = {
+        items: mockItems
+    };
+};
+
+const givenClassesAndItems = () => {
+    givenMultipleItems();
+
+    passedProps = {
+        ...passedProps,
+        itemProps: {
+            classes: mockItemClasses
+        }
+    };
+};
+
+describe('#Gallery Shimmer', () => {
+    beforeEach(() => {
+        mockShimmer.mockClear();
+
+        givenDefaultProps();
+    });
+
+    test('renders Item Shimmer component for each item', () => {
+        givenMultipleItems();
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+        expect(mockItems.length).toBeGreaterThan(0);
+        expect(mockShimmer).toHaveBeenCalledTimes(mockItems.length);
+    });
+
+    test('passes merged class to Shimmer component', () => {
+        givenClassesAndItems();
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+
+        expect(mockShimmer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                classes: expect.objectContaining({ ...mockItemClasses })
+            }),
+            expect.any(Object)
+        );
+    });
+});

--- a/packages/venia-ui/lib/components/Gallery/__tests__/gallery.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/gallery.shimmer.spec.js
@@ -16,12 +16,10 @@ jest.mock('../item.shimmer', () => {
         __esModule: true,
         default: mockedShimmer,
         mockShimmer: mockedShimmer
-    }
+    };
 });
 
-jest.mock('../../../classify', () => ({
-    mergeClasses: (...objects) => Object.assign({}, ...objects)
-}));
+jest.mock('../../../classify');
 
 let passedProps = {};
 
@@ -55,7 +53,7 @@ describe('#Gallery Shimmer', () => {
 
     test('renders Item Shimmer component for each item', () => {
         givenMultipleItems();
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
         expect(mockItems.length).toBeGreaterThan(0);
         expect(mockShimmer).toHaveBeenCalledTimes(mockItems.length);
@@ -63,8 +61,7 @@ describe('#Gallery Shimmer', () => {
 
     test('passes merged class to Shimmer component', () => {
         givenClassesAndItems();
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
-
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
         expect(mockShimmer).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/venia-ui/lib/components/Gallery/gallery.js
+++ b/packages/venia-ui/lib/components/Gallery/gallery.js
@@ -3,6 +3,7 @@ import { string, shape, array } from 'prop-types';
 
 import { useStyle } from '../../classify';
 import GalleryItem from './item';
+import GalleryItemShimmer from './item.shimmer';
 import defaultClasses from './gallery.css';
 import { useGallery } from '@magento/peregrine/lib/talons/Gallery/useGallery';
 
@@ -22,7 +23,7 @@ const Gallery = props => {
         () =>
             items.map((item, index) => {
                 if (item === null) {
-                    return <GalleryItem key={index} />;
+                    return <GalleryItemShimmer key={index} />;
                 }
                 return (
                     <GalleryItem
@@ -36,7 +37,7 @@ const Gallery = props => {
     );
 
     return (
-        <div className={classes.root}>
+        <div className={classes.root} aria-live="polite" aria-busy="false">
             <div className={classes.items}>{galleryItems}</div>
         </div>
     );

--- a/packages/venia-ui/lib/components/Gallery/gallery.shimmer.js
+++ b/packages/venia-ui/lib/components/Gallery/gallery.shimmer.js
@@ -1,26 +1,26 @@
 import React from 'react';
 import { shape, string, array, object } from 'prop-types';
-import { mergeClasses } from '../../classify';
-import ItemShimmer from './item.shimmer';
+import { useStyle } from '../../classify';
+
+import GalleryItemShimmer from './item.shimmer';
 import defaultClasses from './gallery.css';
 
-const GalleryShimmer = (props) => {
-    const { items, itemProps } = props
-    const classes = mergeClasses(defaultClasses, props.classes);
+const GalleryShimmer = props => {
+    const { items, itemProps } = props;
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
         <div className={classes.root} aria-live="polite" aria-busy="true">
             <div className={classes.items}>
-                {items.map((item, index) => {
-                    return <ItemShimmer key={`item_${index}`} {...itemProps} />;
-                })}
+                {items.map((item, index) => (
+                    <GalleryItemShimmer key={index} {...itemProps} />
+                ))}
             </div>
         </div>
     );
 };
 
 GalleryShimmer.defaultProps = {
-    classes: {},
     items: [],
     itemProps: {}
 };

--- a/packages/venia-ui/lib/components/Gallery/gallery.shimmer.js
+++ b/packages/venia-ui/lib/components/Gallery/gallery.shimmer.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shape, string, array, object } from 'prop-types';
+import { mergeClasses } from '../../classify';
+import ItemShimmer from './item.shimmer';
+import defaultClasses from './gallery.css';
+
+const GalleryShimmer = (props) => {
+    const { items, itemProps } = props
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <div className={classes.root} aria-live="polite" aria-busy="true">
+            <div className={classes.items}>
+                {items.map((item, index) => {
+                    return <ItemShimmer key={`item_${index}`} {...itemProps} />;
+                })}
+            </div>
+        </div>
+    );
+};
+
+GalleryShimmer.defaultProps = {
+    classes: {},
+    items: [],
+    itemProps: {}
+};
+
+GalleryShimmer.propTypes = {
+    classes: shape({
+        root: string,
+        items: string
+    }),
+    items: array,
+    itemProps: shape({
+        classes: object
+    })
+};
+
+export default GalleryShimmer;

--- a/packages/venia-ui/lib/components/Gallery/index.js
+++ b/packages/venia-ui/lib/components/Gallery/index.js
@@ -1,3 +1,3 @@
 export { default } from './gallery';
 export { default as GalleryShimmer } from './gallery.shimmer';
-export { default as ItemShimmer } from './item.shimmer';
+export { default as GalleryItemShimmer } from './item.shimmer';

--- a/packages/venia-ui/lib/components/Gallery/index.js
+++ b/packages/venia-ui/lib/components/Gallery/index.js
@@ -1,1 +1,3 @@
 export { default } from './gallery';
+export { default as GalleryShimmer } from './gallery.shimmer';
+export { default as ItemShimmer } from './item.shimmer';

--- a/packages/venia-ui/lib/components/Gallery/item.css
+++ b/packages/venia-ui/lib/components/Gallery/item.css
@@ -17,11 +17,7 @@
     display: block;
     height: 100%;
     object-fit: contain;
-    opacity: 1;
-    transition-duration: 512ms;
-    transition-property: opacity, visibility;
-    transition-timing-function: ease-out;
-    visibility: visible;
+    transition: opacity 512ms ease-out;
     width: 100%;
 }
 
@@ -48,30 +44,4 @@
 .price {
     font-size: var(--venia-typography-detail-XL-fontSize);
     min-height: 1rem;
-}
-
-/* state: pending */
-
-.root_pending {
-    composes: root;
-}
-
-.image_pending {
-    composes: image;
-    background-color: rgb(var(--venia-global-color-gray));
-}
-
-.images_pending {
-    composes: images;
-}
-
-.name_pending {
-    composes: name;
-    background-color: rgb(var(--venia-global-color-gray));
-}
-
-.price_pending {
-    composes: price;
-    background-color: rgb(var(--venia-global-color-gray));
-    width: 3rem;
 }

--- a/packages/venia-ui/lib/components/Gallery/item.css
+++ b/packages/venia-ui/lib/components/Gallery/item.css
@@ -21,6 +21,16 @@
     width: 100%;
 }
 
+.imageLoaded {
+    composes: loaded from '../Image/image.css';
+    opacity: 1;
+}
+
+.imageNotLoaded {
+    composes: notLoaded from '../Image/image.css';
+    opacity: 0;
+}
+
 .imagePlaceholder {
     composes: image;
     background-color: rgb(var(--venia-global-color-gray));

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -52,6 +52,8 @@ const GalleryItem = props => {
                     alt={name}
                     classes={{
                         image: classes.image,
+                        loaded: classes.imageLoaded,
+                        notLoaded: classes.imageNotLoaded,
                         root: classes.imageContainer
                     }}
                     height={IMAGE_HEIGHT}
@@ -80,16 +82,13 @@ const GalleryItem = props => {
 GalleryItem.propTypes = {
     classes: shape({
         image: string,
+        imageLoaded: string,
+        imageNotLoaded: string,
         imageContainer: string,
-        image_pending: string,
         images: string,
-        images_pending: string,
         name: string,
-        name_pending: string,
         price: string,
-        price_pending: string,
-        root: string,
-        root_pending: string
+        root: string
     }),
     item: shape({
         id: number.isRequired,

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -4,11 +4,11 @@ import { Link } from 'react-router-dom';
 import Price from '@magento/venia-ui/lib/components/Price';
 import { UNCONSTRAINED_SIZE_KEY } from '@magento/peregrine/lib/talons/Image/useImage';
 import { useGalleryItem } from '@magento/peregrine/lib/talons/Gallery/useGalleryItem';
-import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
 import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
 
 import { useStyle } from '../../classify';
 import Image from '../Image';
+import GalleryItemShimmer from "./item.shimmer";
 import defaultClasses from './item.css';
 import WishlistGalleryButton from '../Wishlist/AddToListButton';
 
@@ -22,23 +22,6 @@ const IMAGE_WIDTHS = new Map()
     .set(640, IMAGE_WIDTH)
     .set(UNCONSTRAINED_SIZE_KEY, 840);
 
-const ItemPlaceholder = ({ classes }) => (
-    <div className={classes.root_pending}>
-        <div className={classes.images_pending}>
-            <Image
-                alt="Placeholder for gallery item image"
-                classes={{
-                    image: classes.image_pending,
-                    root: classes.imageContainer
-                }}
-                src={transparentPlaceholder}
-            />
-        </div>
-        <div className={classes.name_pending} />
-        <div className={classes.price_pending} />
-    </div>
-);
-
 const GalleryItem = props => {
     const { handleLinkClick, item, wishlistButtonProps } = useGalleryItem(
         props
@@ -47,7 +30,7 @@ const GalleryItem = props => {
     const classes = useStyle(defaultClasses, props.classes);
 
     if (!item) {
-        return <ItemPlaceholder classes={classes} />;
+        return <GalleryItemShimmer classes={classes} />;
     }
 
     const { name, price, small_image, url_key, url_suffix } = item;
@@ -59,7 +42,7 @@ const GalleryItem = props => {
     ) : null;
 
     return (
-        <div className={classes.root}>
+        <div className={classes.root} aria-live="polite" aria-busy="false">
             <Link
                 onClick={handleLinkClick}
                 to={productLink}
@@ -98,7 +81,6 @@ GalleryItem.propTypes = {
     classes: shape({
         image: string,
         imageContainer: string,
-        imagePlaceholder: string,
         image_pending: string,
         images: string,
         images_pending: string,

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -8,7 +8,7 @@ import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
 
 import { useStyle } from '../../classify';
 import Image from '../Image';
-import GalleryItemShimmer from "./item.shimmer";
+import GalleryItemShimmer from './item.shimmer';
 import defaultClasses from './item.css';
 import WishlistGalleryButton from '../Wishlist/AddToListButton';
 

--- a/packages/venia-ui/lib/components/Gallery/item.shimmer.js
+++ b/packages/venia-ui/lib/components/Gallery/item.shimmer.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shape, string } from 'prop-types';
+import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
+import { mergeClasses } from '../../classify';
+import Shimmer from '../Shimmer';
+import Image from '../Image';
+import defaultClasses from './item.css';
+
+const ItemShimmer = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <div className={classes.root_pending}>
+            <div className={classes.images_pending}>
+                <Image
+                    alt="Placeholder for gallery item image"
+                    classes={{
+                        image: classes.image_pending,
+                        root: classes.imageContainer
+                    }}
+                    src={transparentPlaceholder}
+                />
+            </div>
+            <div className={classes.name_pending} />
+            <div className={classes.price_pending} />
+            <Shimmer height={24} width={24} />
+        </div>
+    );
+};
+
+ItemShimmer.defaultProps = {
+    classes: {}
+};
+
+ItemShimmer.propTypes = {
+    classes: shape({
+        root_pending: string,
+        images_pending: string,
+        image_pending: string,
+        imageContainer: string,
+        name_pending: string,
+        price_pending: string
+    })
+};
+
+export default ItemShimmer;

--- a/packages/venia-ui/lib/components/Gallery/item.shimmer.js
+++ b/packages/venia-ui/lib/components/Gallery/item.shimmer.js
@@ -1,46 +1,37 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
 import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
-import { mergeClasses } from '../../classify';
+import { useStyle } from '../../classify';
+
 import Shimmer from '../Shimmer';
 import Image from '../Image';
 import defaultClasses from './item.css';
 
-const ItemShimmer = (props) => {
-    const classes = mergeClasses(defaultClasses, props.classes);
+const GalleryItemShimmer = props => {
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
-        <div className={classes.root_pending}>
-            <div className={classes.images_pending}>
+        <div className={classes.root} aria-live="polite" aria-busy="true">
+            <Shimmer>
                 <Image
                     alt="Placeholder for gallery item image"
                     classes={{
-                        image: classes.image_pending,
+                        image: classes.image,
                         root: classes.imageContainer
                     }}
                     src={transparentPlaceholder}
                 />
-            </div>
-            <div className={classes.name_pending} />
-            <div className={classes.price_pending} />
-            <Shimmer height={24} width={24} />
+            </Shimmer>
+            <Shimmer width="100%" />
+            <Shimmer width={3} />
         </div>
     );
 };
 
-ItemShimmer.defaultProps = {
-    classes: {}
-};
-
-ItemShimmer.propTypes = {
+GalleryItemShimmer.propTypes = {
     classes: shape({
-        root_pending: string,
-        images_pending: string,
-        image_pending: string,
-        imageContainer: string,
-        name_pending: string,
-        price_pending: string
+        root: string
     })
 };
 
-export default ItemShimmer;
+export default GalleryItemShimmer;

--- a/packages/venia-ui/lib/components/Header/header.css
+++ b/packages/venia-ui/lib/components/Header/header.css
@@ -56,7 +56,6 @@
         display: block;
         width: 100%;
         background-color: rgb(var(--venia-global-color-gray-100));
-        height: 2.25rem;
     }
 
     .toolbar {

--- a/packages/venia-ui/lib/components/Header/header.css
+++ b/packages/venia-ui/lib/components/Header/header.css
@@ -56,6 +56,7 @@
         display: block;
         width: 100%;
         background-color: rgb(var(--venia-global-color-gray-100));
+        height: 2.25rem;
     }
 
     .toolbar {

--- a/packages/venia-ui/lib/components/Image/image.css
+++ b/packages/venia-ui/lib/components/Image/image.css
@@ -20,12 +20,12 @@
     position: absolute;
     top: 0;
     left: 0;
-    opacity: 1;
+    visibility: visible;
 }
 
 .notLoaded {
     composes: loaded;
-    opacity: 0;
+    visibility: hidden;
 }
 
 .placeholder {

--- a/packages/venia-ui/lib/components/Image/image.css
+++ b/packages/venia-ui/lib/components/Image/image.css
@@ -11,7 +11,7 @@
 
 .image {
     /*
-     * For customization, we provide an empty image class. 
+     * For customization, we provide an empty image class.
      * These styles will be applied directly to the image itself.
      */
 }
@@ -20,12 +20,12 @@
     position: absolute;
     top: 0;
     left: 0;
-    visibility: visible;
+    opacity: 1;
 }
 
 .notLoaded {
     composes: loaded;
-    visibility: hidden;
+    opacity: 0;
 }
 
 .placeholder {

--- a/packages/venia-ui/lib/components/MagentoRoute/__tests__/magentoRoute.spec.js
+++ b/packages/venia-ui/lib/components/MagentoRoute/__tests__/magentoRoute.spec.js
@@ -7,7 +7,9 @@ import MagentoRoute from '../magentoRoute';
 jest.mock('@magento/peregrine/lib/talons/MagentoRoute');
 jest.mock('@magento/venia-ui/lib/components/ErrorView', () => 'ErrorView');
 jest.mock('@magento/venia-ui/lib/components/LoadingIndicator', () => ({
-    fullPageLoadingIndicator: 'LoadingIndicator'
+    __esModule: true,
+    default: () => 'LoadingIndicator',
+    fullPageLoadingIndicator: 'FullLoadingIndicator'
 }));
 
 test('renders loading indicator while loading', () => {
@@ -27,7 +29,7 @@ test('renders loading indicator while redirecting', () => {
 
     const tree = createTestInstance(<MagentoRoute />);
 
-    expect(tree.toJSON()).toMatchInlineSnapshot(`"LoadingIndicator"`);
+    expect(tree.toJSON()).toMatchInlineSnapshot(`"FullLoadingIndicator"`);
 });
 
 test('renders component', () => {

--- a/packages/venia-ui/lib/components/MagentoRoute/__tests__/magentoRoute.spec.js
+++ b/packages/venia-ui/lib/components/MagentoRoute/__tests__/magentoRoute.spec.js
@@ -7,9 +7,7 @@ import MagentoRoute from '../magentoRoute';
 jest.mock('@magento/peregrine/lib/talons/MagentoRoute');
 jest.mock('@magento/venia-ui/lib/components/ErrorView', () => 'ErrorView');
 jest.mock('@magento/venia-ui/lib/components/LoadingIndicator', () => ({
-    __esModule: true,
-    default: () => 'LoadingIndicator',
-    fullPageLoadingIndicator: 'FullLoadingIndicator'
+    fullPageLoadingIndicator: 'LoadingIndicator'
 }));
 
 test('renders loading indicator while loading', () => {
@@ -29,7 +27,7 @@ test('renders loading indicator while redirecting', () => {
 
     const tree = createTestInstance(<MagentoRoute />);
 
-    expect(tree.toJSON()).toMatchInlineSnapshot(`"FullLoadingIndicator"`);
+    expect(tree.toJSON()).toMatchInlineSnapshot(`"LoadingIndicator"`);
 });
 
 test('renders component', () => {

--- a/packages/venia-ui/lib/components/MagentoRoute/magentoRoute.js
+++ b/packages/venia-ui/lib/components/MagentoRoute/magentoRoute.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { useMagentoRoute } from '@magento/peregrine/lib/talons/MagentoRoute';
 
 import ErrorView from '@magento/venia-ui/lib/components/ErrorView';
-import { fullPageLoadingIndicator } from '@magento/venia-ui/lib/components/LoadingIndicator';
+import LoadingIndicator, { fullPageLoadingIndicator } from '@magento/venia-ui/lib/components/LoadingIndicator';
 
 const MESSAGES = new Map()
     .set(
@@ -23,7 +23,16 @@ const MagentoRoute = () => {
         isRedirect
     } = talonProps;
 
-    if (isLoading || isRedirect) {
+    if (isLoading) {
+        return (
+            <LoadingIndicator>
+                <FormattedMessage
+                    id={'loadingIndicator.message'}
+                    defaultMessage={'Fetching Data...'}
+                />
+            </LoadingIndicator>
+        );
+    } else if (isRedirect) {
         return fullPageLoadingIndicator;
     } else if (RootComponent) {
         return <RootComponent id={id} />;

--- a/packages/venia-ui/lib/components/MagentoRoute/magentoRoute.js
+++ b/packages/venia-ui/lib/components/MagentoRoute/magentoRoute.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useMagentoRoute } from '@magento/peregrine/lib/talons/MagentoRoute';
 
 import ErrorView from '@magento/venia-ui/lib/components/ErrorView';
-import LoadingIndicator, { fullPageLoadingIndicator } from '@magento/venia-ui/lib/components/LoadingIndicator';
+import { fullPageLoadingIndicator } from '@magento/venia-ui/lib/components/LoadingIndicator';
 
 const MESSAGES = new Map()
     .set(
@@ -23,16 +23,7 @@ const MagentoRoute = () => {
         isRedirect
     } = talonProps;
 
-    if (isLoading) {
-        return (
-            <LoadingIndicator>
-                <FormattedMessage
-                    id={'loadingIndicator.message'}
-                    defaultMessage={'Fetching Data...'}
-                />
-            </LoadingIndicator>
-        );
-    } else if (isRedirect) {
+    if (isLoading || isRedirect) {
         return fullPageLoadingIndicator;
     } else if (RootComponent) {
         return <RootComponent id={id} />;

--- a/packages/venia-ui/lib/components/ProductSort/__tests__/__snapshots__/productSort.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductSort/__tests__/__snapshots__/productSort.spec.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<div>
+<div
+  aria-busy="false"
+  aria-live="polite"
+>
   <button
     disabled={false}
     onClick={[Function]}

--- a/packages/venia-ui/lib/components/ProductSort/__tests__/productSort.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/ProductSort/__tests__/productSort.shimmer.spec.js
@@ -4,7 +4,7 @@ import { mockShimmer } from '../../Shimmer';
 import ShimmerComponent from '../productSort.shimmer';
 
 
-const mockClassName = 'sortButton';
+const mockClassName = 'sortButtonShimmer';
 const mockClasses = {
     [mockClassName]: 'test-class'
 };
@@ -20,7 +20,7 @@ jest.mock('../../Shimmer', () => {
 });
 
 jest.mock('../../../classify', () => ({
-    mergeClasses: (...objects) => Object.assign({}, ...objects)
+    useStyle: (...classes) => Object.assign({}, ...classes)
 }));
 
 let passedProps = {};
@@ -43,19 +43,19 @@ describe('#productSort Shimmer', () => {
     });
 
     test('renders Shimmer component', () => {
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
         expect(mockShimmer).toHaveBeenCalled();
     });
 
     test('passes merged class to Shimmer component', () => {
         givenPassedClasses();
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
 
         expect(mockShimmer).toHaveBeenCalledWith(
             expect.objectContaining({
-                className: mockClasses[mockClassName]
+                classes: expect.objectContaining({ root_button: mockClasses[mockClassName] })
             }),
             expect.any(Object)
         );

--- a/packages/venia-ui/lib/components/ProductSort/__tests__/productSort.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/ProductSort/__tests__/productSort.shimmer.spec.js
@@ -3,7 +3,6 @@ import { createTestInstance } from '@magento/peregrine';
 import { mockShimmer } from '../../Shimmer';
 import ShimmerComponent from '../productSort.shimmer';
 
-
 const mockClassName = 'sortButtonShimmer';
 const mockClasses = {
     [mockClassName]: 'test-class'
@@ -16,7 +15,7 @@ jest.mock('../../Shimmer', () => {
         __esModule: true,
         default: mockedShimmer,
         mockShimmer: mockedShimmer
-    }
+    };
 });
 
 jest.mock('../../../classify', () => ({
@@ -52,10 +51,11 @@ describe('#productSort Shimmer', () => {
         givenPassedClasses();
         createTestInstance(<ShimmerComponent {...passedProps} />);
 
-
         expect(mockShimmer).toHaveBeenCalledWith(
             expect.objectContaining({
-                classes: expect.objectContaining({ root_button: mockClasses[mockClassName] })
+                classes: expect.objectContaining({
+                    root_button: mockClasses[mockClassName]
+                })
             }),
             expect.any(Object)
         );

--- a/packages/venia-ui/lib/components/ProductSort/__tests__/productSort.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/ProductSort/__tests__/productSort.shimmer.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+import { mockShimmer } from '../../Shimmer';
+import ShimmerComponent from '../productSort.shimmer';
+
+
+const mockClassName = 'sortButton';
+const mockClasses = {
+    [mockClassName]: 'test-class'
+};
+
+jest.mock('../../Shimmer', () => {
+    const mockedShimmer = jest.fn(() => null);
+
+    return {
+        __esModule: true,
+        default: mockedShimmer,
+        mockShimmer: mockedShimmer
+    }
+});
+
+jest.mock('../../../classify', () => ({
+    mergeClasses: (...objects) => Object.assign({}, ...objects)
+}));
+
+let passedProps = {};
+
+const givenDefaultProps = () => {
+    passedProps = {};
+};
+
+const givenPassedClasses = () => {
+    passedProps = {
+        classes: mockClasses
+    };
+};
+
+describe('#productSort Shimmer', () => {
+    beforeEach(() => {
+        mockShimmer.mockClear();
+
+        givenDefaultProps();
+    });
+
+    test('renders Shimmer component', () => {
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+        expect(mockShimmer).toHaveBeenCalled();
+    });
+
+    test('passes merged class to Shimmer component', () => {
+        givenPassedClasses();
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+
+        expect(mockShimmer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                className: mockClasses[mockClassName]
+            }),
+            expect.any(Object)
+        );
+    });
+});

--- a/packages/venia-ui/lib/components/ProductSort/index.js
+++ b/packages/venia-ui/lib/components/ProductSort/index.js
@@ -1,1 +1,2 @@
 export { default } from './productSort';
+export { default as ProductSortShimmer } from './productSort.shimmer';

--- a/packages/venia-ui/lib/components/ProductSort/productSort.js
+++ b/packages/venia-ui/lib/components/ProductSort/productSort.js
@@ -75,7 +75,12 @@ const ProductSort = props => {
     };
 
     return (
-        <div ref={elementRef} className={classes.root}>
+        <div
+            ref={elementRef}
+            className={classes.root}
+            aria-live="polite"
+            aria-busy="false"
+        >
             <Button
                 priority={'low'}
                 classes={{

--- a/packages/venia-ui/lib/components/ProductSort/productSort.shimmer.css
+++ b/packages/venia-ui/lib/components/ProductSort/productSort.shimmer.css
@@ -1,0 +1,14 @@
+.root {
+    composes: root from './productSort.css';
+}
+
+.sortButtonShimmer {
+    composes: root_button from '../Shimmer/shimmer.css';
+    composes: sortButton from './productSort.css';
+}
+
+@media (min-width: 1024px) {
+    .sortButtonShimmer {
+        min-width: 12rem;
+    }
+}

--- a/packages/venia-ui/lib/components/ProductSort/productSort.shimmer.js
+++ b/packages/venia-ui/lib/components/ProductSort/productSort.shimmer.js
@@ -1,27 +1,27 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
-import { mergeClasses } from '../../classify';
-import Shimmer from '../Shimmer';
-import defaultClasses from './productSort.css';
+import { useStyle } from '../../classify';
 
-const ProductSortShimmer = (props) => {
-    const classes = mergeClasses(defaultClasses, props.classes);
+import Shimmer from '../Shimmer';
+import defaultClasses from './productSort.shimmer.css';
+
+const ProductSortShimmer = props => {
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
         <div className={classes.root} aria-live="polite" aria-busy="true">
-            <Shimmer className={classes.sortButton} width={125} height={45} />
+            <Shimmer
+                classes={{ root_button: classes.sortButtonShimmer }}
+                type="button"
+            />
         </div>
     );
-};
-
-ProductSortShimmer.defaultProps = {
-    classes: {}
 };
 
 ProductSortShimmer.propTypes = {
     classes: shape({
         root: string,
-        sortButton: string
+        sortButtonShimmer: string
     })
 };
 

--- a/packages/venia-ui/lib/components/ProductSort/productSort.shimmer.js
+++ b/packages/venia-ui/lib/components/ProductSort/productSort.shimmer.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shape, string } from 'prop-types';
+import { mergeClasses } from '../../classify';
+import Shimmer from '../Shimmer';
+import defaultClasses from './productSort.css';
+
+const ProductSortShimmer = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <div className={classes.root} aria-live="polite" aria-busy="true">
+            <Shimmer className={classes.sortButton} width={125} height={45} />
+        </div>
+    );
+};
+
+ProductSortShimmer.defaultProps = {
+    classes: {}
+};
+
+ProductSortShimmer.propTypes = {
+    classes: shape({
+        root: string,
+        sortButton: string
+    })
+};
+
+export default ProductSortShimmer;

--- a/packages/venia-ui/lib/components/Shimmer/__stories__/shimmer.js
+++ b/packages/venia-ui/lib/components/Shimmer/__stories__/shimmer.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Shimmer from '../shimmer';
+import Image from '../../Image';
+import { transparentPlaceholder } from '@magento/peregrine/lib/util/images';
+
+const stories = storiesOf('Components/Shimmer', module);
+
+stories.add('Default', () => <Shimmer width="100%" />);
+
+stories.add('Multiple Shimmer with different widths', () => {
+    return (
+        <div style={{ display: 'grid', gridGap: '0.5rem' }}>
+            <Shimmer width="100%" />
+            <Shimmer width="50%" />
+            <Shimmer width="25%" />
+        </div>
+    );
+});
+
+stories.add('A Shimmer of an Image Component', () => {
+    return (
+        <Shimmer>
+            <Image
+                alt="Image Shimmer"
+                src={transparentPlaceholder}
+                width={200}
+            />
+        </Shimmer>
+    );
+});
+
+stories.add('A Shimmer with fixed dimensions and border radius', () => {
+    return <Shimmer borderRadius={3} height={3} width={3} />;
+});
+
+stories.add('A Shimmer of type button', () => <Shimmer type="button" />);
+
+stories.add('A Shimmer of type textInput', () => <Shimmer type="textInput" />);
+
+stories.add('A Shimmer of type textArea', () => <Shimmer type="textArea" />);
+
+stories.add('A Shimmer of type radio', () => (
+    <Shimmer animationSize="small" type="radio" />
+));
+
+stories.add('A Shimmer of type checkbox', () => (
+    <Shimmer animationSize="small" type="checkbox" />
+));
+
+const loremContentText =
+    'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusantium alias consectetur delectus enim est, excepturi fuga, in ipsam molestiae necessitatibus non nostrum quam rerum sequi voluptatem. Nemo neque perferendis quaerat.';
+const buttonContentText = 'Flexible Shimmer Button with content';
+
+stories.add('Multiple Shimmer with different types and content', () => {
+    return (
+        <div style={{ display: 'grid', gridGap: '0.5rem' }}>
+            <Shimmer>
+                <p>{loremContentText}</p>
+            </Shimmer>
+            <Shimmer width="25%" />
+            <Shimmer width="50%" />
+            <div style={{ display: 'flex' }}>
+                <Shimmer style={{ marginRight: '0.5rem' }} type="button">
+                    {buttonContentText}
+                </Shimmer>
+                <Shimmer type="button" />
+            </div>
+        </div>
+    );
+});

--- a/packages/venia-ui/lib/components/Shimmer/__tests__/__snapshots__/shimmer.spec.js.snap
+++ b/packages/venia-ui/lib/components/Shimmer/__tests__/__snapshots__/shimmer.spec.js.snap
@@ -5,8 +5,6 @@ exports[`#Shimmer renders default size 1`] = `
   className="root_rectangle"
   style={
     Object {
-      "borderRadius": undefined,
-      "height": undefined,
       "width": "100%",
     }
   }

--- a/packages/venia-ui/lib/components/Shimmer/__tests__/__snapshots__/shimmer.spec.js.snap
+++ b/packages/venia-ui/lib/components/Shimmer/__tests__/__snapshots__/shimmer.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#Shimmer renders default size 1`] = `
+<div
+  className="root_rectangle"
+  style={
+    Object {
+      "borderRadius": undefined,
+      "height": undefined,
+      "width": "100%",
+    }
+  }
+>
+  <span
+    className="content"
+  />
+</div>
+`;

--- a/packages/venia-ui/lib/components/Shimmer/__tests__/shimmer.spec.js
+++ b/packages/venia-ui/lib/components/Shimmer/__tests__/shimmer.spec.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+
+import Shimmer from '../shimmer';
+
+jest.mock('../../../classify');
+jest.mock('../../Button', () => () => <i />);
+
+let inputProps = {};
+
+const givenDefaultValues = () => {
+    inputProps = {
+        width: '100%'
+    };
+};
+
+const givenWidth = () => {
+    inputProps = {
+        width: 200
+    };
+};
+
+const givenHeight = () => {
+    inputProps = {
+        height: '200px'
+    };
+};
+
+const givenButtonType = () => {
+    inputProps = {
+        type: 'button'
+    };
+};
+
+const Component = () => {
+    return <Shimmer {...inputProps} />;
+};
+
+describe('#Shimmer', () => {
+    beforeEach(() => {
+        givenDefaultValues();
+    });
+
+    it('renders default size', () => {
+        const instance = createTestInstance(<Component />);
+
+        expect(instance.toJSON()).toMatchSnapshot();
+    });
+
+    it('renders rectangle of given width', () => {
+        givenWidth();
+        const { root } = createTestInstance(<Component />);
+
+        const styles = root.children[0].children[0].props.style;
+        expect(styles).toHaveProperty('width', '200rem');
+    });
+
+    it('renders rectangle of given height', () => {
+        givenHeight();
+        const { root } = createTestInstance(<Component />);
+
+        const styles = root.children[0].children[0].props.style;
+        expect(styles).toHaveProperty('height', '200px');
+    });
+
+    it('renders Shimmer of given button type', () => {
+        givenButtonType();
+        const { root } = createTestInstance(<Component />);
+
+        expect(root.children[0].children[0].props.className).toContain(
+            '_button'
+        );
+    });
+});

--- a/packages/venia-ui/lib/components/Shimmer/index.js
+++ b/packages/venia-ui/lib/components/Shimmer/index.js
@@ -1,0 +1,1 @@
+export { default } from './shimmer';

--- a/packages/venia-ui/lib/components/Shimmer/shimmer.css
+++ b/packages/venia-ui/lib/components/Shimmer/shimmer.css
@@ -1,0 +1,71 @@
+.root {
+    display: inline-block;
+    background: rgb(var(--venia-global-color-gray))
+        linear-gradient(
+            to right,
+            rgb(var(--venia-global-color-gray)) 0%,
+            rgb(var(--venia-global-color-gray-50)) 40%,
+            rgb(var(--venia-global-color-gray)) 80%,
+            rgb(var(--venia-global-color-gray)) 100%
+        )
+        no-repeat;
+    background-size: var(--venia-global-maxWidth) 100%;
+    pointer-events: none;
+    -webkit-animation-name: shimmerAnimation;
+    -webkit-animation-duration: 1s;
+    -webkit-animation-timing-function: linear;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-fill-mode: forwards;
+}
+
+.root_rectangle {
+    composes: root;
+    min-height: var(--venia-typography-body-M-fontSize);
+}
+
+.root_button {
+    composes: root from '../Button/button.css';
+    composes: root;
+    border: none;
+}
+
+.root_checkbox {
+    composes: input from '../Checkbox/checkbox.css';
+    composes: root;
+    border: none;
+}
+
+.root_radio {
+    composes: input from '../RadioGroup/radio.css';
+    composes: root;
+    border: none;
+}
+
+.root_textArea {
+    composes: input from '../TextArea/textArea.css';
+    composes: root;
+    min-height: 6.75rem;
+    border: none;
+}
+
+.root_textInput {
+    composes: input from '../TextInput/textInput.css';
+    composes: root;
+    border: none;
+}
+
+.content {
+    overflow: hidden;
+    visibility: hidden;
+    opacity: 0;
+}
+
+@-webkit-keyframes shimmerAnimation {
+    0% {
+        background-position: calc(var(--venia-global-maxWidth) * -1) 0;
+    }
+
+    100% {
+        background-position: var(--venia-global-maxWidth) 0;
+    }
+}

--- a/packages/venia-ui/lib/components/Shimmer/shimmer.js
+++ b/packages/venia-ui/lib/components/Shimmer/shimmer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { node, number, oneOf, oneOfType, shape, string } from 'prop-types';
 
 import { useStyle } from '../../classify';
@@ -16,24 +16,20 @@ const Shimmer = props => {
     } = props;
     const classes = useStyle(defaultClasses, props.classes);
 
-    const style = {
-        ...customStyles,
-        borderRadius: borderRadius
-            ? typeof borderRadius === 'number'
-                ? `${borderRadius}rem`
-                : borderRadius
-            : undefined,
-        height: height
-            ? typeof height === 'number'
-                ? `${height}rem`
-                : height
-            : undefined,
-        width: width
-            ? typeof width === 'number'
-                ? `${width}rem`
-                : width
-            : undefined
-    };
+    const style = useMemo(() => {
+        const combinedStyles = {
+            ...customStyles
+        };
+
+        Object.entries({ borderRadius, height, width })
+            .forEach(([type, value]) => {
+                if (typeof value !== 'undefined') {
+                    combinedStyles[type] = typeof value === 'number' ? `${value}rem` : value
+                }
+            });
+
+        return combinedStyles;
+    }, [customStyles, borderRadius, height, width]);
 
     const rootClass = `root_${type}`;
 

--- a/packages/venia-ui/lib/components/Shimmer/shimmer.js
+++ b/packages/venia-ui/lib/components/Shimmer/shimmer.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const getDimensionStyle = (dimension) => {
+    return typeof dimension === 'string' ? dimension : `${dimension}px`;
+};
+
+export default (props) => {
+    const { width, height, className, style, ...restProps } = props;
+    const styles = {
+        ...style,
+        width: width ? getDimensionStyle(width) : '100%',
+        height: height ? getDimensionStyle(height) : 'auto',
+        backgroundColor: 'rgb(244,245,245)'
+    };
+
+    return (
+        <div
+            {...restProps}
+            className={className}
+            style={styles}
+        />
+    );
+};

--- a/packages/venia-ui/lib/components/Shimmer/shimmer.js
+++ b/packages/venia-ui/lib/components/Shimmer/shimmer.js
@@ -1,23 +1,88 @@
 import React from 'react';
+import { node, number, oneOf, oneOfType, shape, string } from 'prop-types';
 
-const getDimensionStyle = (dimension) => {
-    return typeof dimension === 'string' ? dimension : `${dimension}px`;
-};
+import { useStyle } from '../../classify';
+import defaultClasses from './shimmer.css';
 
-export default (props) => {
-    const { width, height, className, style, ...restProps } = props;
-    const styles = {
-        ...style,
-        width: width ? getDimensionStyle(width) : '100%',
-        height: height ? getDimensionStyle(height) : 'auto',
-        backgroundColor: 'rgb(244,245,245)'
+const Shimmer = props => {
+    const {
+        borderRadius,
+        height,
+        width,
+        style: customStyles,
+        type,
+        children,
+        ...restProps
+    } = props;
+    const classes = useStyle(defaultClasses, props.classes);
+
+    const style = {
+        ...customStyles,
+        borderRadius: borderRadius
+            ? typeof borderRadius === 'number'
+                ? `${borderRadius}rem`
+                : borderRadius
+            : undefined,
+        height: height
+            ? typeof height === 'number'
+                ? `${height}rem`
+                : height
+            : undefined,
+        width: width
+            ? typeof width === 'number'
+                ? `${width}rem`
+                : width
+            : undefined
     };
 
+    const rootClass = `root_${type}`;
+
     return (
-        <div
-            {...restProps}
-            className={className}
-            style={styles}
-        />
+        <div className={classes[rootClass]} style={style} {...restProps}>
+            <span className={classes.content}>{children}</span>
+        </div>
     );
 };
+
+/**
+ * Props for {@link Shimmer}
+ *
+ * @typedef props
+ *
+ * @property {Object} classes is an object containing the class names for the
+ * Shimmer component.
+ * @property {string} classes.root is the class for the container
+ * @property {string} classes.content is the class for the content
+ * @property {number | string} borderRadius is the border radius of the Shimmer
+ * @property {number | string} height is the height of the Shimmer
+ * @property {number | string} width is the width of the Shimmer
+ * @property {Object} style is an object of inline styles
+ * @property {string} type is the type of the Shimmer
+ * @property {node} children are the children of the Shimmer
+ */
+Shimmer.propTypes = {
+    classes: shape({
+        root: string,
+        content: string
+    }),
+    borderRadius: oneOfType([number, string]),
+    height: oneOfType([number, string]),
+    width: oneOfType([number, string]),
+    style: shape({}),
+    type: oneOf([
+        'rectangle',
+        'button',
+        'checkbox',
+        'radio',
+        'textArea',
+        'textInput'
+    ]),
+    children: node
+};
+
+Shimmer.defaultProps = {
+    style: {},
+    type: 'rectangle'
+};
+
+export default Shimmer;

--- a/packages/venia-ui/lib/components/Shimmer/shimmer.js
+++ b/packages/venia-ui/lib/components/Shimmer/shimmer.js
@@ -21,12 +21,14 @@ const Shimmer = props => {
             ...customStyles
         };
 
-        Object.entries({ borderRadius, height, width })
-            .forEach(([type, value]) => {
+        Object.entries({ borderRadius, height, width }).forEach(
+            ([type, value]) => {
                 if (typeof value !== 'undefined') {
-                    combinedStyles[type] = typeof value === 'number' ? `${value}rem` : value
+                    combinedStyles[type] =
+                        typeof value === 'number' ? `${value}rem` : value;
                 }
-            });
+            }
+        );
 
         return combinedStyles;
     }, [customStyles, borderRadius, height, width]);

--- a/packages/venia-ui/lib/components/SortedByContainer/__tests__/sortedByContainer.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/__tests__/sortedByContainer.shimmer.spec.js
@@ -19,9 +19,7 @@ jest.mock('../../Shimmer', () => {
     }
 });
 
-jest.mock('../../../classify', () => ({
-    mergeClasses: (...objects) => Object.assign({}, ...objects)
-}));
+jest.mock('../../../classify');
 
 let passedProps = {};
 
@@ -43,21 +41,8 @@ describe('#sortedByContainer Shimmer', () => {
     });
 
     test('renders Shimmer component', () => {
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+        createTestInstance(<ShimmerComponent {...passedProps} />);
 
         expect(mockShimmer).toHaveBeenCalled();
-    });
-
-    test('passes merged class to Shimmer component', () => {
-        givenPassedClasses();
-        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
-
-
-        expect(mockShimmer).toHaveBeenCalledWith(
-            expect.objectContaining({
-                className: mockClasses[mockClassName]
-            }),
-            expect.any(Object)
-        );
     });
 });

--- a/packages/venia-ui/lib/components/SortedByContainer/__tests__/sortedByContainer.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/__tests__/sortedByContainer.shimmer.spec.js
@@ -3,12 +3,6 @@ import { createTestInstance } from '@magento/peregrine';
 import { mockShimmer } from '../../Shimmer';
 import ShimmerComponent from '../sortedByContainer.shimmer';
 
-
-const mockClassName = 'root';
-const mockClasses = {
-    [mockClassName]: 'test-class'
-};
-
 jest.mock('../../Shimmer', () => {
     const mockedShimmer = jest.fn(() => null);
 
@@ -16,7 +10,7 @@ jest.mock('../../Shimmer', () => {
         __esModule: true,
         default: mockedShimmer,
         mockShimmer: mockedShimmer
-    }
+    };
 });
 
 jest.mock('../../../classify');
@@ -25,12 +19,6 @@ let passedProps = {};
 
 const givenDefaultProps = () => {
     passedProps = {};
-};
-
-const givenPassedClasses = () => {
-    passedProps = {
-        classes: mockClasses
-    };
 };
 
 describe('#sortedByContainer Shimmer', () => {

--- a/packages/venia-ui/lib/components/SortedByContainer/__tests__/sortedByContainer.shimmer.spec.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/__tests__/sortedByContainer.shimmer.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { createTestInstance } from '@magento/peregrine';
+import { mockShimmer } from '../../Shimmer';
+import ShimmerComponent from '../sortedByContainer.shimmer';
+
+
+const mockClassName = 'root';
+const mockClasses = {
+    [mockClassName]: 'test-class'
+};
+
+jest.mock('../../Shimmer', () => {
+    const mockedShimmer = jest.fn(() => null);
+
+    return {
+        __esModule: true,
+        default: mockedShimmer,
+        mockShimmer: mockedShimmer
+    }
+});
+
+jest.mock('../../../classify', () => ({
+    mergeClasses: (...objects) => Object.assign({}, ...objects)
+}));
+
+let passedProps = {};
+
+const givenDefaultProps = () => {
+    passedProps = {};
+};
+
+const givenPassedClasses = () => {
+    passedProps = {
+        classes: mockClasses
+    };
+};
+
+describe('#sortedByContainer Shimmer', () => {
+    beforeEach(() => {
+        mockShimmer.mockClear();
+
+        givenDefaultProps();
+    });
+
+    test('renders Shimmer component', () => {
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+        expect(mockShimmer).toHaveBeenCalled();
+    });
+
+    test('passes merged class to Shimmer component', () => {
+        givenPassedClasses();
+        const instance = createTestInstance(<ShimmerComponent {...passedProps} />);
+
+
+        expect(mockShimmer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                className: mockClasses[mockClassName]
+            }),
+            expect.any(Object)
+        );
+    });
+});

--- a/packages/venia-ui/lib/components/SortedByContainer/index.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/index.js
@@ -1,1 +1,2 @@
 export { default } from './sortedByContainer';
+export { default as SortedByContainerShimmer } from './sortedByContainer.shimmer';

--- a/packages/venia-ui/lib/components/SortedByContainer/index.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/index.js
@@ -1,2 +1,4 @@
 export { default } from './sortedByContainer';
-export { default as SortedByContainerShimmer } from './sortedByContainer.shimmer';
+export {
+    default as SortedByContainerShimmer
+} from './sortedByContainer.shimmer';

--- a/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.js
@@ -10,7 +10,7 @@ const SortedByContainer = props => {
     const classes = useStyle(defaultClasses, props.classes);
 
     return (
-        <div className={classes.root}>
+        <div className={classes.root} aria-live="polite" aria-busy="true">
             <FormattedMessage
                 id={'searchPage.sortContainer'}
                 defaultMessage={'Items sorted by '}

--- a/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.shimmer.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.shimmer.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shape, string } from 'prop-types';
+import {mergeClasses} from '../../classify';
+import Shimmer from '../Shimmer';
+import defaultClasses from './sortedByContainer.css'
+
+const SortedByContainerShimmer = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+
+    return (
+        <Shimmer className={classes.root} height={15} />
+    )
+};
+
+SortedByContainerShimmer.defaultProps = {
+    classes: {}
+};
+
+SortedByContainerShimmer.propTypes = {
+    classes: shape({
+        root: string
+    })
+};
+
+export default SortedByContainerShimmer;

--- a/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.shimmer.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.shimmer.js
@@ -1,19 +1,18 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
-import {mergeClasses} from '../../classify';
-import Shimmer from '../Shimmer';
-import defaultClasses from './sortedByContainer.css'
+import { useStyle } from '../../classify';
 
-const SortedByContainerShimmer = (props) => {
-    const classes = mergeClasses(defaultClasses, props.classes);
+import Shimmer from '../Shimmer';
+import defaultClasses from './sortedByContainer.css';
+
+const SortedByContainerShimmer = props => {
+    const classes = useStyle(defaultClasses, props.classes);
 
     return (
-        <Shimmer className={classes.root} height={15} />
-    )
-};
-
-SortedByContainerShimmer.defaultProps = {
-    classes: {}
+        <div className={classes.root} aria-live="polite" aria-busy="true">
+            <Shimmer width={10} />
+        </div>
+    );
 };
 
 SortedByContainerShimmer.propTypes = {

--- a/pwa-devdocs/_drafts/venia-pwa-concept/component/shimmer/index.md
+++ b/pwa-devdocs/_drafts/venia-pwa-concept/component/shimmer/index.md
@@ -1,0 +1,144 @@
+# Shimmer
+The Shimmer component provides an easy way to indicate to users that data is loading in a certain area of the website
+without blocking the entire page with a full-screen loader (or worse, an empty space.) This improves the perceived speed of the site,
+while maintaining or reducing the CLS (Content Layout Shift) on page load
+
+## General Use
+### Props
+* **classes** - `Object` Styles to apply to the `root` or the `content` of the Shimmer
+* **borderRadius** - `string|number` Border radius of component
+* **height** - `string|number` Height to apply to component. **Number is used as `rem`**. String value is used directly.
+* **width** - `string|number` Width to apply to component. **Number is used as `rem`**. String value is used directly.
+* **style** - `Object` CSS styles to apply to component
+* **type** - `'rectangle'|'button'|'checkbox'|'radio'|'textArea'|'textInput'` Base style-category to apply to component
+* **children** - `node` Children to output within the Shimmer. Useful for Image placeholders
+
+### Accessibility
+To maintain accessibility for screen readers, we can pass `aria-live="polite" aria-busy="true"` to the Shimmer component (or an
+element that wraps the Shimmer(s) in a more complex instance).
+
+It's important to then add `aria-live="polite" aria-busy="false"` to the _normal_ component that replaces the shimmer
+
+### Example
+```jsx
+// ....
+import Shimmer from '../path/to/base/Shimmer';
+// ....
+export default () => {
+  // ....
+  return (
+    <Shimmer />
+  );
+};
+```
+
+## Shimmer for Components
+When loading data, previously we would return null (or a full-screen loader) instead of the actual component. We can now return a
+_**shimmer**_ version of the component, which will take up the same space without relying on data.
+
+Direct use of the Shimmer component within _normal_ components should be avoided when possible. If the shimmer is replacing a component
+that is imported, a `.shimmer.js` file should be created for that imported component in its folder and exported in its `index.js`.
+
+### Example
+There are 4 critical files
+* **Main.js** - the main component that has the loading status and would usually return null for the component while loading
+* **SubComponent/index.js** - Previously would only export the main component. Must now export named variable for shimmer component
+* **SubComponent/subComponent** - Same SubComponent as usual
+* **SubComponent/subComponent.shimmer.js** - `.shimmer.js` extension is used for easily identifying that it's a shimmer and
+  the component it's attached to. It can contain complex arrangement of base Shimmer elements, or include other subcomponents Shimmers.
+
+**Main.js**
+```jsx
+import React from 'react';
+import SubComponent, { SubComponentShimmer } from '../path/to/SubComponent';
+// ....
+export default () => {
+    const { data, isLoading } = fetchData();
+    
+    if (isLoading) {
+        return (
+          <SubComponentShimmer />  
+        );
+    }
+    
+    if (!data) {
+        return 'No data';
+    }
+    
+    return (
+        <SubComponent someValue={data} />
+    );
+};
+// ....
+```
+---
+**../path/to/SubComponent/index.js**
+```jsx
+export { default } from './subComponent.js';
+// Export named shimmer component
+export { default as SubComponentShimmer } from './subComponent.shimmer.js';
+```
+---
+**../path/to/SubComponent/subComponent.js**
+```jsx
+import React from 'react';
+import { shape, string } from 'prop-types';
+import { mergeClasses } from '../../path/to/classify';
+import defaultClasses from './subComponent.css';
+
+const SubComponent = (props) => {
+    const classes = mergeClasses(defaultClasses, props.classes);
+    const { someValue } = props;
+    
+    return (
+        <div className={classes.root}>
+          <div className={classes.item}>{someValue}</div>
+        </div>
+    );
+};
+
+SubComponent.defaultProps = {
+    classes: {}
+};
+
+SubComponent.propTypes = {
+    classes: shape({
+      root: string,
+      item: string
+    })
+}
+
+export default SubComponent;
+```
+---
+**../path/to/SubComponent/subComponent.shimmer.js**
+```jsx
+import React from 'react';
+import { mergeClasses } from '../../path/to/classify';
+import Shimmer from '../path/to/base/Shimmer';
+import defaultClasses from './subComponent.css'; // Load same classes as real SubComponent
+
+const SubComponentShimmer = (props) => {
+    // Important to still merge-in prop classes for extensibility/targetability
+    const classes = mergeClasses(defaultClasses, props.classes);
+    
+    return (
+      <div className={classes.root}>
+        <Shimmer className={classes.item} />
+      </div>  
+    );
+};
+
+SubComponentShimmer.defaultProps = {
+  classes: {}
+};
+
+SubComponentShimmer.propTypes = {
+  classes: shape({
+    root: string,
+    item: string
+  })
+}
+
+export default SubComponentShimmer;
+```


### PR DESCRIPTION
## Description
_Proof of Concept_
Adding Shimmer components while data is loading instead of a full page loader. The goal is to show a skeleton of the page, where the shimmer components take up about the same place the normal components with data would. This will improve the LCS score, and the user's perception of site speed. This Proof of Concept was done on the category page. It includes:
- Base component for all Shimmers
- Draft documentation for the Shimmer component and its use
- Category sub-component Shimmer components (which include one or more base Shimmer components)

### Short comings of this PoC
The full-screen loader is still necessary while determining the type of the page. This means that there are two loading phases which isn't ideal. SSR will correct this for the initial load. However additional strategies will need to be worked on for page-changes after the initial load.

## Related Issue
https://jira.corp.magento.com/browse/PWA-1878
https://jira.corp.magento.com/browse/PWA-1879

Relates to issue: https://github.com/magento/pwa-studio/issues/3148

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

@tkacheva @davemacaulay @jimbo @schensley 

### Specification

Draft documentation for use available in pwa-devdocs/_drafts/venia-pwa-concept/component/shimmer/index.md

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

1. Visit category page
2. Once the page-type is determined, the full-screen-loader should disappear
3. The Shimmer components should then render in place of the filters, sort/filter buttons, product tiles, breadcrumbs
4. Validate that the LCS score from Lighthouse has maintained or improved

#### Test scenario(s) for any existing impacted features/areas

1. Validate that applying filters renders the product Item shimmer component while loading

#### Is Browser/Device testing needed?

Yes, validate that mobile shimmers appear correctly

## Breaking Changes (if any)

- Added exports to index.js files for shimmers
- Changed content of categoryContent root component so targetables may change.

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

- [x] I have added tests to cover my changes, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
