### PR TITLE
Regression Fix - Content shifted under layered nav on PLP

### DIFF
--- a/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
+++ b/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
@@ -23,105 +23,109 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    />
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
+        className="sidebar"
+      />
+      <div
+        className="categoryContent"
       >
         <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
+          className="heading"
         >
           <div
-            className="root"
+            className="categoryInfo"
+          />
+          <div
+            className="headerButtons"
           >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <div
+              className="root"
             >
-              <span
-                className="content"
+              <button
+                className="root_lowPriority"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
               >
                 <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
+                  className="content"
                 >
                   <span
-                    className="sortText"
+                    className="mobileText"
                   >
                     <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
+                      defaultMessage="Sort"
+                      id="productSort.sortButton"
                     />
-                     
-                    
                   </span>
                   <span
-                    className="root"
+                    className="desktopText"
                   >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      className="sortText"
                     >
-                      <polyline
-                        points="6 9 12 15 18 9"
+                      <mock-FormattedMessage
+                        defaultMessage="Sort by"
+                        id="productSort.sortByButton"
                       />
-                    </svg>
+                       
+                      
+                    </span>
+                    <span
+                      className="root"
+                    >
+                      <svg
+                        className="icon"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polyline
+                          points="6 9 12 15 18 9"
+                        />
+                      </svg>
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
+              </button>
+            </div>
           </div>
+          <SortedByContainer
+            currentSort={
+              Object {
+                "sortAttribute": "",
+                "sortDirection": "",
+                "sortText": "",
+              }
+            }
+          />
         </div>
-        <SortedByContainer
-          currentSort={
-            Object {
-              "sortAttribute": "",
-              "sortDirection": "",
-              "sortText": "",
+        <section
+          className="gallery"
+        >
+          <Gallery
+            items={
+              Object {
+                "id": 1,
+              }
             }
-          }
-        />
-      </div>
-      <section
-        className="gallery"
-      >
-        <Gallery
-          items={
-            Object {
-              "id": 1,
-            }
-          }
-        />
-      </section>
-      <div
-        className="pagination"
-      >
-        <Pagination
-          pageControl={Object {}}
-        />
+          />
+        </section>
+        <div
+          className="pagination"
+        >
+          <Pagination
+            pageControl={Object {}}
+          />
+        </div>
       </div>
     </div>
   </article>,
@@ -151,128 +155,132 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    >
-      <require('../../components/FilterSidebar')
-        filters={
-          Array [
-            Object {},
-          ]
-        }
-      />
-    </div>
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
+        className="sidebar"
+      >
+        <require('../../components/FilterSidebar')
+          filters={
+            Array [
+              Object {},
+            ]
+          }
+        />
+      </div>
+      <div
+        className="categoryContent"
       >
         <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
+          className="heading"
         >
-          <FilterModalOpenButton
-            filters={
-              Array [
-                Object {},
-              ]
-            }
+          <div
+            className="categoryInfo"
           />
           <div
-            className="root"
+            className="headerButtons"
           >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <FilterModalOpenButton
+              filters={
+                Array [
+                  Object {},
+                ]
+              }
+            />
+            <div
+              className="root"
             >
-              <span
-                className="content"
+              <button
+                className="root_lowPriority"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
               >
                 <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
+                  className="content"
                 >
                   <span
-                    className="sortText"
+                    className="mobileText"
                   >
                     <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
+                      defaultMessage="Sort"
+                      id="productSort.sortButton"
                     />
-                     
-                    
                   </span>
                   <span
-                    className="root"
+                    className="desktopText"
                   >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      className="sortText"
                     >
-                      <polyline
-                        points="6 9 12 15 18 9"
+                      <mock-FormattedMessage
+                        defaultMessage="Sort by"
+                        id="productSort.sortByButton"
                       />
-                    </svg>
+                       
+                      
+                    </span>
+                    <span
+                      className="root"
+                    >
+                      <svg
+                        className="icon"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polyline
+                          points="6 9 12 15 18 9"
+                        />
+                      </svg>
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
+              </button>
+            </div>
           </div>
+          <SortedByContainer
+            currentSort={
+              Object {
+                "sortAttribute": "",
+                "sortDirection": "",
+                "sortText": "",
+              }
+            }
+          />
         </div>
-        <SortedByContainer
-          currentSort={
-            Object {
-              "sortAttribute": "",
-              "sortDirection": "",
-              "sortText": "",
+        <section
+          className="gallery"
+        >
+          <Gallery
+            items={
+              Object {
+                "id": 1,
+              }
             }
+          />
+        </section>
+        <div
+          className="pagination"
+        >
+          <Pagination
+            pageControl={Object {}}
+          />
+        </div>
+        <require('../../components/FilterModal')
+          filters={
+            Array [
+              Object {},
+            ]
           }
         />
       </div>
-      <section
-        className="gallery"
-      >
-        <Gallery
-          items={
-            Object {
-              "id": 1,
-            }
-          }
-        />
-      </section>
-      <div
-        className="pagination"
-      >
-        <Pagination
-          pageControl={Object {}}
-        />
-      </div>
-      <require('../../components/FilterModal')
-        filters={
-          Array [
-            Object {},
-          ]
-        }
-      />
     </div>
   </article>,
 ]
@@ -301,24 +309,28 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    />
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
+        className="sidebar"
+      />
+      <div
+        className="categoryContent"
       >
         <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
+          className="heading"
+        >
+          <div
+            className="categoryInfo"
+          />
+          <div
+            className="headerButtons"
+          />
+        </div>
+        <NoProductsFound
+          categoryId={42}
         />
       </div>
-      <NoProductsFound
-        categoryId={42}
-      />
     </div>
   </article>,
 ]
@@ -347,97 +359,101 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    />
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
-      >
-        <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
-        />
-      </div>
+        className="sidebar"
+      />
       <div
-        className="global"
+        className="categoryContent"
       >
-        <span
-          className="root"
+        <div
+          className="heading"
         >
-          <svg
-            className="icon"
-            fill="none"
-            height={64}
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width={64}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <line
-              x1="12"
-              x2="12"
-              y1="2"
-              y2="6"
-            />
-            <line
-              x1="12"
-              x2="12"
-              y1="18"
-              y2="22"
-            />
-            <line
-              x1="4.93"
-              x2="7.76"
-              y1="4.93"
-              y2="7.76"
-            />
-            <line
-              x1="16.24"
-              x2="19.07"
-              y1="16.24"
-              y2="19.07"
-            />
-            <line
-              x1="2"
-              x2="6"
-              y1="12"
-              y2="12"
-            />
-            <line
-              x1="18"
-              x2="22"
-              y1="12"
-              y2="12"
-            />
-            <line
-              x1="4.93"
-              x2="7.76"
-              y1="19.07"
-              y2="16.24"
-            />
-            <line
-              x1="16.24"
-              x2="19.07"
-              y1="7.76"
-              y2="4.93"
-            />
-          </svg>
-        </span>
-        <span
-          className="message"
-        >
-          <mock-FormattedMessage
-            defaultMessage="Fetching Data..."
-            id="loadingIndicator.message"
+          <div
+            className="categoryInfo"
           />
-        </span>
+          <div
+            className="headerButtons"
+          />
+        </div>
+        <div
+          className="global"
+        >
+          <span
+            className="root"
+          >
+            <svg
+              className="icon"
+              fill="none"
+              height={64}
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              width={64}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <line
+                x1="12"
+                x2="12"
+                y1="2"
+                y2="6"
+              />
+              <line
+                x1="12"
+                x2="12"
+                y1="18"
+                y2="22"
+              />
+              <line
+                x1="4.93"
+                x2="7.76"
+                y1="4.93"
+                y2="7.76"
+              />
+              <line
+                x1="16.24"
+                x2="19.07"
+                y1="16.24"
+                y2="19.07"
+              />
+              <line
+                x1="2"
+                x2="6"
+                y1="12"
+                y2="12"
+              />
+              <line
+                x1="18"
+                x2="22"
+                y1="12"
+                y2="12"
+              />
+              <line
+                x1="4.93"
+                x2="7.76"
+                y1="19.07"
+                y2="16.24"
+              />
+              <line
+                x1="16.24"
+                x2="19.07"
+                y1="7.76"
+                y2="4.93"
+              />
+            </svg>
+          </span>
+          <span
+            className="message"
+          >
+            <mock-FormattedMessage
+              defaultMessage="Fetching Data..."
+              id="loadingIndicator.message"
+            />
+          </span>
+        </div>
       </div>
     </div>
   </article>,
@@ -467,105 +483,109 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    />
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
+        className="sidebar"
+      />
+      <div
+        className="categoryContent"
       >
         <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
+          className="heading"
         >
           <div
-            className="root"
+            className="categoryInfo"
+          />
+          <div
+            className="headerButtons"
           >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <div
+              className="root"
             >
-              <span
-                className="content"
+              <button
+                className="root_lowPriority"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
               >
                 <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
+                  className="content"
                 >
                   <span
-                    className="sortText"
+                    className="mobileText"
                   >
                     <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
+                      defaultMessage="Sort"
+                      id="productSort.sortButton"
                     />
-                     
-                    
                   </span>
                   <span
-                    className="root"
+                    className="desktopText"
                   >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      className="sortText"
                     >
-                      <polyline
-                        points="6 9 12 15 18 9"
+                      <mock-FormattedMessage
+                        defaultMessage="Sort by"
+                        id="productSort.sortByButton"
                       />
-                    </svg>
+                       
+                      
+                    </span>
+                    <span
+                      className="root"
+                    >
+                      <svg
+                        className="icon"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polyline
+                          points="6 9 12 15 18 9"
+                        />
+                      </svg>
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
+              </button>
+            </div>
           </div>
+          <SortedByContainer
+            currentSort={
+              Object {
+                "sortAttribute": "",
+                "sortDirection": "",
+                "sortText": "",
+              }
+            }
+          />
         </div>
-        <SortedByContainer
-          currentSort={
-            Object {
-              "sortAttribute": "",
-              "sortDirection": "",
-              "sortText": "",
+        <section
+          className="gallery"
+        >
+          <Gallery
+            items={
+              Object {
+                "id": 1,
+              }
             }
-          }
-        />
-      </div>
-      <section
-        className="gallery"
-      >
-        <Gallery
-          items={
-            Object {
-              "id": 1,
-            }
-          }
-        />
-      </section>
-      <div
-        className="pagination"
-      >
-        <Pagination
-          pageControl={Object {}}
-        />
+          />
+        </section>
+        <div
+          className="pagination"
+        >
+          <Pagination
+            pageControl={Object {}}
+          />
+        </div>
       </div>
     </div>
   </article>,
@@ -595,24 +615,28 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    />
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
+        className="sidebar"
+      />
+      <div
+        className="categoryContent"
       >
         <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
+          className="heading"
+        >
+          <div
+            className="categoryInfo"
+          />
+          <div
+            className="headerButtons"
+          />
+        </div>
+        <NoProductsFound
+          categoryId={42}
         />
       </div>
-      <NoProductsFound
-        categoryId={42}
-      />
     </div>
   </article>,
 ]
@@ -641,105 +665,109 @@ Array [
       </h1>
     </div>
     <div
-      className="sidebar"
-    />
-    <div
-      className="categoryContent"
+      className="contentWrapper"
     >
       <div
-        className="heading"
+        className="sidebar"
+      />
+      <div
+        className="categoryContent"
       >
         <div
-          className="categoryInfo"
-        />
-        <div
-          className="headerButtons"
+          className="heading"
         >
           <div
-            className="root"
+            className="categoryInfo"
+          />
+          <div
+            className="headerButtons"
           >
-            <button
-              className="root_lowPriority"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <div
+              className="root"
             >
-              <span
-                className="content"
+              <button
+                className="root_lowPriority"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
               >
                 <span
-                  className="mobileText"
-                >
-                  <mock-FormattedMessage
-                    defaultMessage="Sort"
-                    id="productSort.sortButton"
-                  />
-                </span>
-                <span
-                  className="desktopText"
+                  className="content"
                 >
                   <span
-                    className="sortText"
+                    className="mobileText"
                   >
                     <mock-FormattedMessage
-                      defaultMessage="Sort by"
-                      id="productSort.sortByButton"
+                      defaultMessage="Sort"
+                      id="productSort.sortButton"
                     />
-                     
-                    
                   </span>
                   <span
-                    className="root"
+                    className="desktopText"
                   >
-                    <svg
-                      className="icon"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <span
+                      className="sortText"
                     >
-                      <polyline
-                        points="6 9 12 15 18 9"
+                      <mock-FormattedMessage
+                        defaultMessage="Sort by"
+                        id="productSort.sortByButton"
                       />
-                    </svg>
+                       
+                      
+                    </span>
+                    <span
+                      className="root"
+                    >
+                      <svg
+                        className="icon"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polyline
+                          points="6 9 12 15 18 9"
+                        />
+                      </svg>
+                    </span>
                   </span>
                 </span>
-              </span>
-            </button>
+              </button>
+            </div>
           </div>
+          <SortedByContainer
+            currentSort={
+              Object {
+                "sortAttribute": "",
+                "sortDirection": "",
+                "sortText": "",
+              }
+            }
+          />
         </div>
-        <SortedByContainer
-          currentSort={
-            Object {
-              "sortAttribute": "",
-              "sortDirection": "",
-              "sortText": "",
+        <section
+          className="gallery"
+        >
+          <Gallery
+            items={
+              Object {
+                "id": 1,
+              }
             }
-          }
-        />
-      </div>
-      <section
-        className="gallery"
-      >
-        <Gallery
-          items={
-            Object {
-              "id": 1,
-            }
-          }
-        />
-      </section>
-      <div
-        className="pagination"
-      >
-        <Pagination
-          pageControl={Object {}}
-        />
+          />
+        </section>
+        <div
+          className="pagination"
+        >
+          <Pagination
+            pageControl={Object {}}
+          />
+        </div>
       </div>
     </div>
   </article>,

--- a/packages/venia-ui/lib/RootComponents/Category/category.css
+++ b/packages/venia-ui/lib/RootComponents/Category/category.css
@@ -50,14 +50,18 @@
     padding-bottom: 1.5rem;
 }
 
+.contentWrapper {
+    width: 100%;
+}
+
 .sidebar {
     display: none;
 }
 
 @media (min-width: 1024px) {
-    .root {
+    .contentWrapper {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
     }
 
     .categoryHeader {

--- a/packages/venia-ui/lib/RootComponents/Category/category.css
+++ b/packages/venia-ui/lib/RootComponents/Category/category.css
@@ -61,7 +61,6 @@
 @media (min-width: 1024px) {
     .contentWrapper {
         display: flex;
-        flex-wrap: nowrap;
     }
 
     .categoryHeader {

--- a/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
+++ b/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
@@ -131,22 +131,24 @@ const CategoryContent = props => {
                     </h1>
                     {categoryDescriptionElement}
                 </div>
-                <div className={classes.sidebar}>
-                    <Suspense fallback={null}>{sidebar}</Suspense>
-                </div>
-                <div className={classes.categoryContent}>
-                    <div className={classes.heading}>
-                        <div className={classes.categoryInfo}>
-                            {categoryResultsHeading}
-                        </div>
-                        <div className={classes.headerButtons}>
-                            {maybeFilterButtons}
-                            {maybeSortButton}
-                        </div>
-                        {maybeSortContainer}
+                <div className={classes.contentWrapper}>
+                    <div className={classes.sidebar}>
+                        <Suspense fallback={null}>{sidebar}</Suspense>
                     </div>
-                    {content}
-                    <Suspense fallback={null}>{filtersModal}</Suspense>
+                    <div className={classes.categoryContent}>
+                        <div className={classes.heading}>
+                            <div className={classes.categoryInfo}>
+                                {categoryResultsHeading}
+                            </div>
+                            <div className={classes.headerButtons}>
+                                {maybeFilterButtons}
+                                {maybeSortButton}
+                            </div>
+                            {maybeSortContainer}
+                        </div>
+                        {content}
+                        <Suspense fallback={null}>{filtersModal}</Suspense>
+                    </div>
                 </div>
             </article>
         </Fragment>


### PR DESCRIPTION
## Description

Fixing regression introduced by [Layered Navigation](https://github.com/magento/pwa-studio/pull/3137) where content shifts below the layered nav if an item's title exceeds the space available.

## Related Issue

Fixes issue https://jira.corp.magento.com/browse/PWA-1897

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

@revanth0212 

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

- Validate that "Shop the look" category displays correctly when browser width is between 1024px - 1100px
- Validate that layout displays correctly outside of this range as well

#### Is Browser/Device testing needed?

Yes, device testing is needed as layered nav + gallery UI components may be impacted on mobile and desktop

## Breaking Changes (if any)

Layout/targetable references of category content changed.

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

- [x] I have added tests to cover my changes, if necessary.