### PR TITLE
Regression Fix - Account chip welcome message in non-default store view

### DIFF
--- a/packages/venia-ui/lib/components/AccountChip/accountChip.js
+++ b/packages/venia-ui/lib/components/AccountChip/accountChip.js
@@ -41,7 +41,7 @@ const AccountChip = props => {
     } else {
         if (!isLoadingUserName) {
             chipText = formatMessage(
-                { id: 'accountChip.chipText', defaultMessage: 'Hi' },
+                { id: 'accountChip.chipText', defaultMessage: 'Hi, {name}' },
                 { name: currentUser.firstname }
             );
         } else if (shouldIndicateLoading) {


### PR DESCRIPTION
## Description

When in the french store view, without the french language pack, the account chip's welcome message when logged in was simply "Hi". This PR applies the proper message templating to the default message

## Related Issue

https://jira.corp.magento.com/browse/PWA-1239

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

@revanth0212 

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

- Ensure language pack for French is not installed
- Sign in to your customer account
- Navigate to French store view
- Validate that message contains customer's first name (ex "Hi, Justin")

#### Is Browser/Device testing needed?

No

#### Any ad-hoc/edge case scenarios that need to be considered?

No

## Breaking Changes (if any)

None

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

N/A
