### PR TITLE
[PWA-1898] Wishlist seems to be cramped in Mobile mode.

### DIFF
--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -424,7 +424,5 @@
     "wishlistPage.wishlistDisabledMessage": "The wishlist is not currently available.",
     "wishlist.itemCountOpen": "Showing {currentCount} of {count} items in this list",
     "wishlist.itemCountClosed": "You have {count} {count, plural, one {item} other {items}} in this list",
-
-
     "wishlist.loadMore": "Load More"
 }

--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -423,6 +423,8 @@
     "wishlistPage.headingText": "{count, plural, one {Favorites List} other {Favorites Lists}}",
     "wishlistPage.wishlistDisabledMessage": "The wishlist is not currently available.",
     "wishlist.itemCountOpen": "Showing {currentCount} of {count} items in this list",
-    "wishlist.itemCountClosed": "You have {count} items in this list",
+    "wishlist.itemCountClosed": "You have {count} {count, plural, one {item} other {items}} in this list",
+
+
     "wishlist.loadMore": "Load More"
 }

--- a/packages/venia-ui/lib/components/WishlistPage/wishlist.css
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlist.css
@@ -7,6 +7,7 @@
 }
 
 .header {
+    align-items: center;
     display: grid;
     grid-auto-flow: column;
     justify-content: space-between;

--- a/packages/venia-ui/lib/components/WishlistPage/wishlist.css
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlist.css
@@ -35,11 +35,6 @@
     grid-auto-flow: column;
 }
 
-.itemsCountContainer {
-    align-items: center;
-    display: grid;
-}
-
 .content_hidden {
     display: none;
 }
@@ -55,9 +50,14 @@
     min-width: 20rem;
 }
 
-@media (max-width: 960px) {
+@media (max-width: 768px) {
     .root {
         padding: 1.5rem;
+    }
+
+    .header {
+        grid-template-rows: 1fr 1fr;
+        row-gap: 0.5rem;
     }
 
     .nameContainer {
@@ -65,6 +65,11 @@
     }
 
     .buttonsContainer {
-        align-items: flex-start;
+        justify-self: end;
+    }
+
+    .itemsCountContainer {
+        grid-column-end: span 2;
+        justify-self: center;
     }
 }

--- a/packages/venia-ui/lib/components/WishlistPage/wishlist.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlist.js
@@ -51,8 +51,11 @@ const Wishlist = props => {
               )
             : formatMessage(
                   {
-                      id: 'wishlist.itemCountClose',
-                      defaultMessage: 'You have {count} items in this list'
+                      id: 'wishlist.itemCountClosed',
+                      defaultMessage: `You have {count} {count, plural,
+                        one {item}
+                        other {items}
+                      } in this list`
                   },
                   { count: itemsCount }
               );


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

While performing regression on PWA 11.0 we have noticed that the wishlist section seems to be cramped in the mobile mode. This is reproducible on both physical devices (iOS and Android) and emulated device screens in chrome dev tools.

Steps:

Login
Add an item to wishlist
Go to wishlist page
Swtich to mobile mode

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

* [[PWA-1898](https://jira.corp.magento.com/browse/PWA-1898)] Wishlist seems to be cramped in Mobile mode.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Screenshots
![Screen Shot 2021-07-21 at 2 40 58 PM](https://user-images.githubusercontent.com/462953/126549895-80865e5a-a2e4-4445-ac83-cd66b3a4b235.png)

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

1. In the mobile viewport (<768px), log in and navigate to Wishlist page with items pre-populated in a list
2. Verify item count element is readable on its own row

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
