### PR TITLE
Safari NumberFormat error fix.

### DIFF
--- a/packages/venia-ui/lib/components/CurrencySymbol/currencySymbol.js
+++ b/packages/venia-ui/lib/components/CurrencySymbol/currencySymbol.js
@@ -25,7 +25,7 @@ const isNarrowSymbolSupported = (() => {
         return true;
     } catch (e) {
         if (e.constructor !== RangeError) {
-            throw e;
+            console.warn(e);
         }
 
         return false;


### PR DESCRIPTION
## Description

Safari browser has a bug related to the INTL NumberFormat polyfill. We are already handling it in the code but unfortunately, we are throwing an error as well. Since an error is thrown the whole app crashes on Safari instead of rendering the app with the handled logic.

This PR simply changes the function to not throw and warn instead to let the backup logic do its magic and render the app.

magento.pwa-venia.com
![image](https://user-images.githubusercontent.com/35203638/126568724-8c442f7c-89dc-4f5b-8c41-dc647e93285f.png)

develop.pwa-venia.com
![image](https://user-images.githubusercontent.com/35203638/126568908-ba9678c7-bc0b-4535-8bcf-9a8cd6b88276.png)

After Fix
![image](https://user-images.githubusercontent.com/35203638/126569242-bd595bd5-a29a-4a0f-87ef-a99e05f9f088.png)

## Related Issue

Closes PWA-1894

## Acceptance

App should render properly on Safari.

### Verification Stakeholders

@eug123 
@tjwiebell 

## Verification Steps

1. Open the deployed app in the safari browser. App should render properly.
2. Go to any category page and prices should render properly.
3. Switch between locales and currencies and nothing should be broken.

#### Is Browser/Device testing needed?

Yes, Browser testing is needed.

## Breaking Changes (if any)

None

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
