### PR TITLE
Checkout page Payment information section UX fix.

### DIFF
--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.css
@@ -1,6 +1,11 @@
 .root {
     display: grid;
     padding: 2rem;
+    padding-bottom: 1rem;
+}
+
+.radio_group {
+    display: grid;
 }
 
 .payment_method {

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.js
@@ -95,6 +95,7 @@ const PaymentMethods = props => {
     return (
         <div className={classes.root}>
             <RadioGroup
+                classes={{root: classes.radio_group}}
                 field="selectedPaymentMethod"
                 initialValue={initialSelectedMethod}
             >

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.js
@@ -95,7 +95,7 @@ const PaymentMethods = props => {
     return (
         <div className={classes.root}>
             <RadioGroup
-                classes={{root: classes.radio_group}}
+                classes={{ root: classes.radio_group }}
                 field="selectedPaymentMethod"
                 initialValue={initialSelectedMethod}
             >


### PR DESCRIPTION
## Description

The payment information section seems to be having a misaligned UI when multiple payment methods are available.

Before:
![image](https://user-images.githubusercontent.com/35203638/126710071-3f5fde18-fac5-4243-b59b-e884c126977e.png)

After:

Desktop:
![image](https://user-images.githubusercontent.com/35203638/126710140-b0c857c1-2ef3-4a8a-9f9d-a1209503904a.png)

Mobile:
![image](https://user-images.githubusercontent.com/35203638/126710353-0e72a763-2443-4076-ae59-b2535fccf570.png)

## Related Issue

Closes PWA-1907

### Verification Stakeholders

@supernova-at 

## Verification Steps

1. Go to the deployed app
2. Add an item to the cart
3. Navigate yourself to the checkout page's payment sectionÏ

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
