### PR TITLE
calling `startsWith` on undefined

### DIFF
--- a/packages/peregrine/lib/util/makeUrl.js
+++ b/packages/peregrine/lib/util/makeUrl.js
@@ -31,7 +31,7 @@ const absoluteUrl = /^(data|http|https)?:/i;
 const joinUrls = (base, url) =>
     (base.endsWith('/') ? base.slice(0, -1) : base) +
     '/' +
-    (url.startsWith('/') ? url.slice(1) : url);
+    (url&&url.startsWith('/') ? url.slice(1) : url);
 
 const mediaBases = new Map()
     .set('image-product', 'catalog/product/')

--- a/packages/peregrine/lib/util/makeUrl.js
+++ b/packages/peregrine/lib/util/makeUrl.js
@@ -31,7 +31,7 @@ const absoluteUrl = /^(data|http|https)?:/i;
 const joinUrls = (base, url) =>
     (base.endsWith('/') ? base.slice(0, -1) : base) +
     '/' +
-    (url&&url.startsWith('/') ? url.slice(1) : url);
+    (url && url.startsWith('/') ? url.slice(1) : url);
 
 const mediaBases = new Map()
     .set('image-product', 'catalog/product/')


### PR DESCRIPTION
The variable `url` can be undefined and it throws error. Faced it on the first run on a clean installation.
![image](https://user-images.githubusercontent.com/12933820/126757071-5d6d9867-bc2c-4596-b151-ae8fac42c802.png)
