### PR TITLE
Release 11.0 Sign-out cache clear bug fix

### DIFF
--- a/packages/peregrine/lib/context/user.js
+++ b/packages/peregrine/lib/context/user.js
@@ -1,9 +1,10 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 
 import actions from '../store/actions/user/actions';
 import * as asyncActions from '../store/actions/user/asyncActions';
 import bindActionCreators from '../util/bindActionCreators';
+import BrowserPersistence from '../util/simplePersistence';
 
 const UserContext = createContext();
 
@@ -22,6 +23,22 @@ const UserContextProvider = props => {
         userApi,
         userState
     ]);
+
+    useEffect(() => {
+        // check if the user's token is not expired
+        const storage = new BrowserPersistence();
+        const item = storage.getRawItem('signin_token');
+
+        if (item) {
+            const { ttl, timeStored } = JSON.parse(item);
+            const now = Date.now();
+
+            // if the token's TTYL has expired, we need to sign out
+            if (ttl && now - timeStored > ttl * 1000) {
+                asyncActions.signOut();
+            }
+        }
+    }, [asyncActions]);
 
     return (
         <UserContext.Provider value={contextValue}>

--- a/packages/peregrine/lib/store/actions/user/asyncActions.js
+++ b/packages/peregrine/lib/store/actions/user/asyncActions.js
@@ -38,20 +38,6 @@ export const getUserDetails = ({ fetchUserDetails }) =>
     async function thunk(...args) {
         const [dispatch, getState] = args;
 
-        // check if the user's token is not expired
-        const storage = new BrowserPersistence();
-        const now = Date.now();
-        const item = storage.getRawItem('signin_token');
-        if (item) {
-            const { ttl, timeStored } = JSON.parse(item);
-            if (ttl && now - timeStored > ttl * 1000) {
-                // if the token's TTYL has expired, we need to sign out
-                dispatch(signOut());
-
-                return;
-            }
-        }
-
         const { user } = getState();
 
         if (user.isSignedIn) {

--- a/packages/peregrine/lib/store/actions/user/asyncActions.js
+++ b/packages/peregrine/lib/store/actions/user/asyncActions.js
@@ -37,7 +37,6 @@ export const signOut = (payload = {}) =>
 export const getUserDetails = ({ fetchUserDetails }) =>
     async function thunk(...args) {
         const [dispatch, getState] = args;
-
         const { user } = getState();
 
         if (user.isSignedIn) {

--- a/packages/peregrine/lib/store/actions/user/asyncActions.js
+++ b/packages/peregrine/lib/store/actions/user/asyncActions.js
@@ -37,6 +37,21 @@ export const signOut = (payload = {}) =>
 export const getUserDetails = ({ fetchUserDetails }) =>
     async function thunk(...args) {
         const [dispatch, getState] = args;
+
+        // check if the user's token is not expired
+        const storage = new BrowserPersistence();
+        const now = Date.now();
+        const item = storage.getRawItem('signin_token');
+        if (item) {
+            const { ttl, timeStored } = JSON.parse(item);
+            if (ttl && now - timeStored > ttl * 1000) {
+                // if the token's TTYL has expired, we need to sign out
+                dispatch(signOut());
+
+                return;
+            }
+        }
+
         const { user } = getState();
 
         if (user.isSignedIn) {

--- a/packages/peregrine/lib/util/__tests__/simplePersistence.spec.js
+++ b/packages/peregrine/lib/util/__tests__/simplePersistence.spec.js
@@ -57,24 +57,6 @@ describe('getItem', () => {
         // Make assertions.
         expect(result).toBeUndefined();
     });
-
-    test('it removes the item and returns undefined if the item has expired', () => {
-        // Test setup: an expired item.
-        mockGetItem.mockImplementationOnce(() =>
-            shape({
-                value: MOCK_VALUE,
-                timeStored: 0,
-                ttl: 1
-            })
-        );
-
-        // Call the function.
-        const result = instance.getItem(NAME);
-
-        // Make assertions.
-        expect(mockRemoveItem).toHaveBeenCalledWith(KEY);
-        expect(result).toBeUndefined();
-    });
 });
 
 describe('setItem', () => {

--- a/packages/peregrine/lib/util/simplePersistence.js
+++ b/packages/peregrine/lib/util/simplePersistence.js
@@ -42,16 +42,12 @@ export default class BrowserPersistence {
         return this.storage.getItem(name);
     }
     getItem(name) {
-        const now = Date.now();
         const item = this.storage.getItem(name);
         if (!item) {
             return undefined;
         }
-        const { value, ttl, timeStored } = JSON.parse(item);
-        if (ttl && now - timeStored > ttl * 1000) {
-            this.storage.removeItem(name);
-            return undefined;
-        }
+        const { value } = JSON.parse(item);
+
         return JSON.parse(value);
     }
     setItem(name, value, ttl) {


### PR DESCRIPTION
## Description

While performing the release regression of PWA 11.0 we figured a bug that comes up in a very weird edge case. If the TTYL of the token expires and the user tries to open/refresh the app, a side effect is causing the user to log out without clearing the apollo cache.

Because of this, the cart and customer details are leftover in the cache and UI enters a corrupted state. For instance, user has logged out but the wishlist details are left behind as shown below:

![image](https://user-images.githubusercontent.com/35203638/127226863-3e4c432a-4b49-44f2-9903-d4b955d99aee.png)

![image](https://user-images.githubusercontent.com/35203638/127227365-8758b7e1-9445-4f28-82f8-ce8e0b516614.png)

This PR fixes the issue by moving the side effect into a `useEffect` of the `UserContext` and signs the user out resetting the UI to a consistent initial state.

## Related Issue

Closes PWA-1888

## Acceptance

Cache and UI should reset to the initial state after signout or TTYL expiry.

### Verification Stakeholders

@jimbo 
@supernova-at 
@eug123 

## Verification Steps

To reproduce the error state:

1. Log in
2. Changed ttl of signing token to something small, for instance 5 (to make it expire faster)
3. Refresh the page after your expiry, in this case after 5 seconds
4. Check apollo cache, no customer or cart data should persist from before

Try the same on Develop or https://pr-3282.pwa-venia.com/ which is our release 11.0 instance.

## Breaking Changes (if any)

Need to figure out if this change breaks any old version. On top of my head, it doesnt.

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
