### PR TITLE
[PWA-1941] SetBillingAddress mutation requires valid string in line2

### DIFF
--- a/packages/peregrine/lib/talons/AddressBookPage/useAddressBookPage.js
+++ b/packages/peregrine/lib/talons/AddressBookPage/useAddressBookPage.js
@@ -152,7 +152,13 @@ export const useAddressBookPage = (props = {}) => {
                     await updateCustomerAddress({
                         variables: {
                             addressId: formAddress.id,
-                            updated_address: formValues
+                            updated_address: {
+                                ...formValues,
+                                // Sends value as empty if none are provided
+                                middlename: formValues.middlename || '',
+                                // Cleans up the street array when values are null or undefined
+                                street: formValues.street.filter(e => e)
+                            }
                         },
                         refetchQueries: [{ query: getCustomerAddressesQuery }],
                         awaitRefetchQueries: true
@@ -171,7 +177,15 @@ export const useAddressBookPage = (props = {}) => {
             } else {
                 try {
                     await createCustomerAddress({
-                        variables: { address: formValues },
+                        variables: {
+                            address: {
+                                ...formValues,
+                                // Sends value as empty if none are provided
+                                middlename: formValues.middlename || '',
+                                // Cleans up the street array when values are null or undefined
+                                street: formValues.street.filter(e => e)
+                            }
+                        },
                         refetchQueries: [{ query: getCustomerAddressesQuery }],
                         awaitRefetchQueries: true
                     });

--- a/packages/peregrine/lib/talons/CheckoutPage/BillingAddress/__tests__/useBillingAddress.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/BillingAddress/__tests__/useBillingAddress.spec.js
@@ -260,6 +260,90 @@ test('Should return isBillingAddress and billingAddress from cache as initialVal
     });
 });
 
+test('Should return empty street2 value when not provided', () => {
+    const billingAddress = {
+        firstName: 'test',
+        lastName: 'test',
+        country: {
+            code: 'test'
+        },
+        street: ['test'],
+        city: 'test',
+        region: { code: 'test' },
+        postcode: 'test',
+        phoneNumber: 'test'
+    };
+
+    getBillingAddress.mockReturnValueOnce({
+        data: {
+            cart: {
+                billingAddress: {
+                    __typename: 'Billing Address',
+                    ...billingAddress
+                }
+            }
+        },
+        loading: false,
+        called: true
+    });
+
+    getIsBillingAddressSame.mockReturnValueOnce({
+        data: { cart: { isBillingAddressSame: false } }
+    });
+
+    const { talonProps } = getTalonProps({
+        shouldSubmit: false,
+        resetShouldSubmit: jest.fn().mockName('resetShouldSubmit'),
+        operations,
+        onBillingAddressChangedError: () => {},
+        onBillingAddressChangedSuccess: () => {}
+    });
+
+    expect(talonProps.initialValues.street2).toEqual('');
+});
+
+test('Should return street2 value when provided', () => {
+    const billingAddress = {
+        firstName: 'test',
+        lastName: 'test',
+        country: {
+            code: 'test'
+        },
+        street: ['test', 'test street2'],
+        city: 'test',
+        region: { code: 'test' },
+        postcode: 'test',
+        phoneNumber: 'test'
+    };
+
+    getBillingAddress.mockReturnValueOnce({
+        data: {
+            cart: {
+                billingAddress: {
+                    __typename: 'Billing Address',
+                    ...billingAddress
+                }
+            }
+        },
+        loading: false,
+        called: true
+    });
+
+    getIsBillingAddressSame.mockReturnValueOnce({
+        data: { cart: { isBillingAddressSame: false } }
+    });
+
+    const { talonProps } = getTalonProps({
+        shouldSubmit: false,
+        resetShouldSubmit: jest.fn().mockName('resetShouldSubmit'),
+        operations,
+        onBillingAddressChangedError: () => {},
+        onBillingAddressChangedSuccess: () => {}
+    });
+
+    expect(talonProps.initialValues.street2).toEqual('test street2');
+});
+
 test('Should set billingAddress to {} if isBillingAddress is true in initialValues', () => {
     const billingAddress = {
         firstName: 'test',

--- a/packages/peregrine/lib/talons/CheckoutPage/BillingAddress/useBillingAddress.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/BillingAddress/useBillingAddress.js
@@ -33,7 +33,7 @@ export const mapAddressData = rawAddressData => {
             postcode,
             phoneNumber,
             street1: street[0],
-            street2: street[1],
+            street2: street[1] || '',
             country: country.code,
             region: region.code
         };
@@ -215,7 +215,7 @@ export const useBillingAddress = props => {
                 lastName,
                 country,
                 street1,
-                street2,
+                street2: street2 || '',
                 city,
                 region,
                 postcode,

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/useCreditCard.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/useCreditCard.spec.js
@@ -537,6 +537,106 @@ describe('Testing payment nonce request workflow', () => {
         });
     });
 
+    test('Should return empty Shipping Address street2 value when not provided', () => {
+        const shippingAddress = {
+            firstName: 'test value',
+            lastName: 'test value',
+            country: {
+                code: 'test value'
+            },
+            street: ['test value'],
+            city: 'test value',
+            region: { code: 'test value' },
+            postcode: 'test value',
+            phoneNumber: 'test value'
+        };
+        getShippingAddress.mockReturnValueOnce({
+            data: {
+                cart: {
+                    shippingAddresses: [
+                        {
+                            __typename: 'Shipping Address',
+                            ...shippingAddress
+                        }
+                    ]
+                }
+            }
+        });
+        useFormState.mockReturnValueOnce({
+            values: {
+                isBillingAddressSame: true
+            },
+            errors: {}
+        });
+
+        getTalonProps({
+            shouldSubmit: true,
+            operations,
+            onSuccess: () => {},
+            onReady: () => {},
+            onError: () => {},
+            resetShouldSubmit: () => {}
+        });
+
+        expect(setBillingAddress).toBeCalledWith({
+            variables: {
+                ...mapAddressData(shippingAddress),
+                sameAsShipping: true,
+                cartId: '123',
+                street2: ''
+            }
+        });
+    });
+
+    test('Should return empty Billing Address street2 value when not provided', () => {
+        const billingAddress = {
+            firstName: 'test value',
+            lastName: 'test value',
+            country: 'test value',
+            street1: 'test value',
+            city: 'test value',
+            region: {
+                region_id: 20
+            },
+            postcode: 'test value',
+            phoneNumber: 'test value'
+        };
+        useFormState
+            .mockReturnValueOnce({
+                values: {
+                    ...billingAddress,
+                    isBillingAddressSame: false
+                },
+                errors: {}
+            })
+            .mockReturnValueOnce({
+                values: {
+                    ...billingAddress,
+                    isBillingAddressSame: false
+                },
+                errors: {}
+            });
+
+        getTalonProps({
+            shouldSubmit: true,
+            operations,
+            onSuccess: () => {},
+            onReady: () => {},
+            onError: () => {},
+            resetShouldSubmit: () => {}
+        });
+
+        expect(setBillingAddress).toBeCalledWith({
+            variables: {
+                ...billingAddress,
+                sameAsShipping: false,
+                cartId: '123',
+                region: 20,
+                street2: ''
+            }
+        });
+    });
+
     test('Should save isBillingAddressSame in apollo cache', () => {
         useFormState.mockReturnValueOnce({
             values: {

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/useCreditCard.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/useCreditCard.js
@@ -38,7 +38,7 @@ export const mapAddressData = rawAddressData => {
             postcode,
             phoneNumber,
             street1: street[0],
-            street2: street[1],
+            street2: street[1] || '',
             country: country.code,
             region: getRegion(region)
         };
@@ -258,7 +258,7 @@ export const useCreditCard = props => {
                 lastName,
                 country,
                 street1,
-                street2,
+                street2: street2 || '',
                 city,
                 region: getRegion(region),
                 postcode,

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/__snapshots__/useCustomerForm.spec.js.snap
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/__snapshots__/useCustomerForm.spec.js.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`return correct shape for address with street2 as null 1`] = `
+Object {
+  "errors": Map {
+    "createCustomerAddressMutation" => undefined,
+    "updateCustomerAddressMutation" => undefined,
+  },
+  "handleCancel": [Function],
+  "handleSubmit": [Function],
+  "hasDefaultShipping": true,
+  "initialValues": Object {
+    "country": "US",
+    "region": Object {
+      "id": null,
+    },
+  },
+  "isLoading": true,
+  "isSaving": false,
+  "isUpdate": false,
+}
+`;
+
+exports[`return correct shape for address with street2 as null 2`] = `
+Object {
+  "refetchQueries": Array [
+    Object {
+      "query": "getCustomerAddressesQuery",
+    },
+    Object {
+      "query": "getCustomerAddressesQuery",
+    },
+  ],
+  "variables": Object {
+    "address": Object {
+      "country_code": "US",
+      "firstname": "Philip",
+      "region": Object {
+        "region_id": 2,
+      },
+      "street": Array [
+        "Street 1",
+      ],
+    },
+  },
+}
+`;
+
 exports[`return correct shape for initial address entry 1`] = `
 Object {
   "errors": Map {
@@ -62,6 +108,9 @@ Object {
       "region": Object {
         "region_id": 2,
       },
+      "street": Array [
+        "Street 1",
+      ],
     },
   },
 }
@@ -104,6 +153,9 @@ Object {
       "region": Object {
         "region": 5,
       },
+      "street": Array [
+        "Street 1",
+      ],
     },
     "addressId": 66,
   },

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/__snapshots__/useGuestForm.spec.js.snap
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/__snapshots__/useGuestForm.spec.js.snap
@@ -22,7 +22,7 @@ Object {
 }
 `;
 
-exports[`handle submit fires mutation with street2 as null 1`] = `
+exports[`handle submit fires mutation with street[1] as null 1`] = `
 Object {
   "variables": Object {
     "address": Object {

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/__snapshots__/useGuestForm.spec.js.snap
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/__snapshots__/useGuestForm.spec.js.snap
@@ -22,6 +22,29 @@ Object {
 }
 `;
 
+exports[`handle submit fires mutation with street2 as null 1`] = `
+Object {
+  "variables": Object {
+    "address": Object {
+      "city": "Manhattan",
+      "country_code": Object {
+        "code": "US",
+      },
+      "firstname": "Philip",
+      "lastname": "Fry",
+      "postcode": "10019",
+      "region": 12,
+      "street": Array [
+        "3000 57th Street",
+      ],
+      "telephone": "(123) 456-7890",
+    },
+    "cartId": "cart123",
+    "email": "fry@planet.express",
+  },
+}
+`;
+
 exports[`returns Apollo error 1`] = `undefined`;
 
 exports[`returns correct shape 1`] = `

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/useCustomerForm.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/useCustomerForm.spec.js
@@ -79,7 +79,8 @@ test('return correct shape for new address and fire create mutation', async () =
                 default_shipping: 5,
                 email: 'fry@planet.express',
                 firstname: 'Philip',
-                lastname: 'Fry'
+                lastname: 'Fry',
+                street: 'Street 1'
             }
         },
         error: null,
@@ -100,7 +101,8 @@ test('return correct shape for new address and fire create mutation', async () =
         firstname: 'Philip',
         region: {
             region_id: 2
-        }
+        },
+        street: ['Street 1']
     });
 
     expect(mockCreateCustomerAddress).toHaveBeenCalled();
@@ -114,7 +116,8 @@ test('return correct shape for update address and fire update mutation', async (
                 default_shipping: 5,
                 email: 'fry@planet.express',
                 firstname: 'Philip',
-                lastname: 'Fry'
+                lastname: 'Fry',
+                street: 'Street 1'
             }
         },
         error: null,
@@ -140,12 +143,50 @@ test('return correct shape for update address and fire update mutation', async (
         firstname: 'Bender',
         region: {
             region: 5
-        }
+        },
+        street: ['Street 1']
     });
 
     expect(mockUpdateCustomerAddress).toHaveBeenCalled();
     expect(mockUpdateCustomerAddress.mock.calls[0][0]).toMatchSnapshot();
     expect(afterSubmit).toHaveBeenCalled();
+});
+
+test('return correct shape for address with street2 as null', async () => {
+    useQuery.mockReturnValueOnce({
+        data: {
+            customer: {
+                default_shipping: 5,
+                email: 'fry@planet.express',
+                firstname: 'Philip',
+                lastname: 'Fry',
+                street: 'Street 1'
+            }
+        },
+        error: null,
+        loading: true
+    });
+
+    const tree = createTestInstance(<Component {...mockProps} />);
+    const { root } = tree;
+    const { talonProps } = root.findByType('i').props;
+
+    expect(talonProps).toMatchSnapshot();
+
+    const { handleSubmit } = talonProps;
+
+    await handleSubmit({
+        country: 'US',
+        email: 'fry@planet.express',
+        firstname: 'Philip',
+        region: {
+            region_id: 2
+        },
+        street: ['Street 1', null]
+    });
+
+    expect(mockCreateCustomerAddress).toHaveBeenCalled();
+    expect(mockCreateCustomerAddress.mock.calls[0][0]).toMatchSnapshot();
 });
 
 test('update isSaving while mutations are in flight', () => {
@@ -198,7 +239,8 @@ test('does not call afterSubmit if mutation fails', async () => {
         firstname: 'Philip',
         region: {
             region_id: 2
-        }
+        },
+        street: ['Street 1']
     });
 
     expect(mockCreateCustomerAddress).toHaveBeenCalled();
@@ -219,7 +261,8 @@ test('does not call afterSubmit() if it is undefined', async () => {
         firstname: 'Philip',
         region: {
             region_id: 2
-        }
+        },
+        street: ['Street 1']
     });
 
     expect(mockCreateCustomerAddress).toHaveBeenCalled();

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/useGuestForm.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/useGuestForm.spec.js
@@ -134,6 +134,30 @@ test('handle submit does not fire callback on error', async () => {
     expect(afterSubmit).not.toHaveBeenCalled();
 });
 
+test('handle submit fires mutation with street2 as null', async () => {
+    const setShippingInformation = jest.fn();
+    useMutation.mockReturnValueOnce([
+        setShippingInformation,
+        { called: true, loading: true }
+    ]);
+    const afterSubmit = jest.fn();
+
+    const tree = createTestInstance(
+        <Component
+            afterSubmit={afterSubmit}
+            mutations={{}}
+            shippingData={shippingData}
+        />
+    );
+    const { root } = tree;
+    const { talonProps } = root.findByType('i').props;
+    const { handleSubmit } = talonProps;
+
+    await handleSubmit({ ...shippingData, street: ['3000 57th Street', null] });
+    expect(setShippingInformation).toHaveBeenCalled();
+    expect(setShippingInformation.mock.calls[0][0]).toMatchSnapshot();
+});
+
 test('handle submit does not call afterSubmit() if it is not defined', async () => {
     const setShippingInformation = jest.fn();
     useMutation.mockReturnValueOnce([

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/useGuestForm.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/__tests__/useGuestForm.spec.js
@@ -134,7 +134,7 @@ test('handle submit does not fire callback on error', async () => {
     expect(afterSubmit).not.toHaveBeenCalled();
 });
 
-test('handle submit fires mutation with street2 as null', async () => {
+test('handle submit fires mutation with street[1] as null', async () => {
     const setShippingInformation = jest.fn();
     useMutation.mockReturnValueOnce([
         setShippingInformation,

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/useCustomerForm.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/useCustomerForm.js
@@ -81,6 +81,8 @@ export const useCustomerForm = props => {
             try {
                 const customerAddress = {
                     ...address,
+                    // Cleans up the street array when values are null or undefined
+                    street: address.street.filter(e => e),
                     country_code: country
                 };
 

--- a/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/useGuestForm.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/ShippingInformation/AddressForm/useGuestForm.js
@@ -44,6 +44,8 @@ export const useGuestForm = props => {
                         email,
                         address: {
                             ...address,
+                            // Cleans up the street array when values are null or undefined
+                            street: address.street.filter(e => e),
                             // region_id is used for field select and region is used for field input
                             region: region.region_id || region.region,
                             country_code: country


### PR DESCRIPTION
## Description

In all forms with certain optional fields:

- Filter `street` array to remove `null` or `undefined` data
- Send empty string when `street2` is `null` or `undefined`
- Send empty string when `middlename` is `null` or `undefined`

## Related Issue

Fixes issue https://jira.corp.magento.com/browse/PWA-1941
Not linked to any opened Github issue.

## Acceptance

### Verification Stakeholders

@tjwiebell @revanth0212 

## Verification Steps

#### Test scenario(s) for direct fix/feature

1. Checkout as Guest - Test Shipping Information form with and without a **Street Address 2** value.
2. Checkout as Customer - Test Shipping Information form with and without a **Street Address 2** value.
3. Checkout  - Test Credit Card form with and without a **Street Address 2** value. Also test with "Same as shipping".
4. Checkout  - Test Money Order form with and without a **Street Address 2** value. Also test with "Same as shipping".
5. Customer Dashboard - Add and update an address with and without a **Street Address 2** value.
6. Customer Dashboard - Add and update an address with and without a **Middle Name** value.
7. Customer Dashboard - Make sure other fields still updates and there's no regression.

## Checklist

- [x] I have added tests to cover my changes, if necessary.