### PR TITLE
[PWA-1962] Back-merge - Force resolution of Workbox to v6.0.2

### DIFF
--- a/packages/pwa-buildpack/package.json
+++ b/packages/pwa-buildpack/package.json
@@ -97,6 +97,9 @@
     "webpack": "~4.46.0",
     "workbox-webpack-plugin": "~6.0.2"
   },
+  "resolutions": {
+    "workbox-build": "~6.0.2"
+  },
   "engines": {
     "node": ">=10.x",
     "yarn": ">=1.12.0"

--- a/packages/venia-concept/_buildpack/create.js
+++ b/packages/venia-concept/_buildpack/create.js
@@ -41,6 +41,7 @@ async function createProjectFromVenia({ fs, tasks, options, sampleBackends }) {
         'dependencies',
         'devDependencies',
         'optionalDependencies',
+        'resolutions',
         'engines',
         'pwa-studio'
     ];

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -126,6 +126,9 @@
   "optionalDependencies": {
     "sharp": "~0.23.3"
   },
+  "resolutions": {
+    "workbox-build": "~6.0.2"
+  },
   "engines": {
     "node": ">=10.x",
     "yarn": ">=1.12.0"


### PR DESCRIPTION
## Description

Back-merge of https://github.com/magento/pwa-studio/pull/3329 so we can unblock develop.
The fix is already merged in `release/11.0`.

Workbox 6.2.0 was released yesterday, and our workbox-webpack-plugin dependency has a minor constraint on workbox-build: ^6.0.2, so it’s now picking up workbox-build@6.2.0 which is not backward compatible with 6.0.2.

This causes `yarn build` to fail in scaffolded projects, which our CI picked up.

This is a temporary fix, a better solution will be found in the future.

## Related Issue

Related to https://jira.corp.magento.com/browse/PWA-1962

## Acceptance

### Verification Stakeholders

@tjwiebell 

### Specification

## Verification Steps

#### Test scenario(s) for direct fix/feature

`yarn build` should no longer fail in scaffolding.
