### PR TITLE
PWA-1686: [bug]: fix quantity field warning

### DIFF
--- a/packages/peregrine/lib/talons/CartPage/ProductListing/useQuantity.js
+++ b/packages/peregrine/lib/talons/CartPage/ProductListing/useQuantity.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState, useEffect } from 'react';
-import { useFieldState, useFieldApi } from 'informed';
+import { useFieldApi } from 'informed';
 import debounce from 'lodash.debounce';
 
 /**
@@ -24,12 +24,11 @@ import debounce from 'lodash.debounce';
  * import { useQuantity } from '@magento/peregrine/lib/talons/CartPage/ProductListing/useQuantity';
  */
 export const useQuantity = props => {
-    const { initialValue, min, onChange } = props;
-
+    const { field, fieldState, initialValue, min, onChange } = props;
     const [prevQuantity, setPrevQuantity] = useState(initialValue);
 
-    const quantityFieldApi = useFieldApi('quantity');
-    const { value: quantity } = useFieldState('quantity');
+    const quantityFieldApi = useFieldApi(field);
+    const { value: quantity } = fieldState;
 
     const isIncrementDisabled = useMemo(() => !quantity, [quantity]);
 
@@ -65,24 +64,21 @@ export const useQuantity = props => {
 
     const handleBlur = useCallback(() => {
         // Only submit the value change if it has changed.
-        if (typeof quantity === 'number' && quantity != prevQuantity) {
+        if (typeof quantity === 'number' && quantity !== prevQuantity) {
             debouncedOnChange(quantity);
         }
     }, [debouncedOnChange, prevQuantity, quantity]);
 
     const maskInput = useCallback(
         value => {
-            try {
-                // For some storefronts decimal values are allowed.
-                const nextVal = parseFloat(value);
-                if (value && isNaN(nextVal))
-                    throw new Error(`${value} is not a number.`);
-                if (nextVal < min) return min;
-                else return nextVal;
-            } catch (err) {
-                console.error(err);
+            // For some storefronts decimal values are allowed.
+            const nextVal = parseFloat(value);
+            if (value && isNaN(nextVal)) {
+                console.error(new Error(`${value} is not a number.`));
                 return prevQuantity;
             }
+            if (nextVal < min) return min;
+            else return nextVal;
         },
         [min, prevQuantity]
     );

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/quantity.js
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/quantity.js
@@ -1,23 +1,33 @@
-import React, { Fragment } from 'react';
+import React, {Fragment} from 'react';
 import { useIntl } from 'react-intl';
-import { Form } from 'informed';
+import {Form, useField} from 'informed';
 import { func, number, string } from 'prop-types';
 import { Minus as MinusIcon, Plus as PlusIcon } from 'react-feather';
 import { useQuantity } from '@magento/peregrine/lib/talons/CartPage/ProductListing/useQuantity';
 
 import { useStyle } from '../../../classify';
 import Icon from '../../Icon';
-import TextInput from '../../TextInput';
-import { Message } from '../../Field';
+import {FieldIcons, Message} from '../../Field';
 import defaultClasses from './quantity.css';
 
 export const QuantityFields = props => {
-    const { initialValue, itemId, label, min, onChange, message } = props;
-    const { formatMessage } = useIntl();
-    const classes = useStyle(defaultClasses, props.classes);
-    const iconClasses = { root: classes.icon };
+    const field = 'quantity';
+    const { fieldState, fieldApi, render, ref } = useField({...props, field});
+    const {
+        initialValue,
+        min,
+        onChange,
+        after,
+        before,
+        itemId,
+        message,
+        label,
+        ...rest
+    } = props;
 
     const talonProps = useQuantity({
+        field,
+        fieldState,
         initialValue,
         min,
         onChange
@@ -32,9 +42,14 @@ export const QuantityFields = props => {
         maskInput
     } = talonProps;
 
+    const { value } = fieldState;
+    const classes = useStyle(defaultClasses, props.classes);
+    const iconClasses = { root: classes.icon };
+    const inputClass = fieldState.error ? classes.input_error : classes.input;
     const errorMessage = message ? <Message>{message}</Message> : null;
+    const { formatMessage } = useIntl();
 
-    return (
+    return render(
         <Fragment>
             <div className={classes.root}>
                 <label className={classes.label} htmlFor={itemId}>
@@ -52,20 +67,30 @@ export const QuantityFields = props => {
                 >
                     <Icon classes={iconClasses} src={MinusIcon} size={22} />
                 </button>
-                <TextInput
-                    aria-label={formatMessage({
-                        id: 'quantity.input',
-                        defaultMessage: 'Item Quantity'
-                    })}
-                    classes={{ input: classes.input }}
-                    field="quantity"
-                    id={itemId}
-                    inputMode="numeric"
-                    mask={maskInput}
-                    min={min}
-                    onBlur={handleBlur}
-                    pattern="[0-9]*"
-                />
+                <FieldIcons after={after} before={before}>
+                    <input
+                        {...rest}
+                        aria-label={formatMessage({
+                            id: 'quantity.input',
+                            defaultMessage: 'Item Quantity'
+                        })}
+                        id={itemId}
+                        inputMode="numeric"
+                        min={min}
+                        onBlur={handleBlur}
+                        pattern="[0-9]*"
+                        ref={ref}
+                        value={!value ? '' : value}
+                        onChange={e => {
+                            fieldApi.setValue(maskInput(e.target.value));
+                            if (onChange) {
+                                onChange(e);
+                            }
+                        }}
+                        className={inputClass}
+                    />
+                </FieldIcons>
+                <Message fieldState={fieldState}>{message}</Message>
                 <button
                     aria-label={formatMessage({
                         id: 'quantity.buttonIncrement',
@@ -82,7 +107,7 @@ export const QuantityFields = props => {
             {errorMessage}
         </Fragment>
     );
-};
+}
 
 const Quantity = props => {
     return (

--- a/packages/venia-ui/lib/components/TextInput/textInput.js
+++ b/packages/venia-ui/lib/components/TextInput/textInput.js
@@ -1,28 +1,48 @@
 import React, { Fragment } from 'react';
 import { node, shape, string } from 'prop-types';
-import { Text as InformedText, useFieldState } from 'informed';
+import {useField} from 'informed';
 
 import { useStyle } from '../../classify';
 import { FieldIcons, Message } from '../Field';
 import defaultClasses from './textInput.css';
 
 const TextInput = props => {
-    const {
-        after,
+    const { fieldState, fieldApi, render, ref, userProps } = useField(props);
+    const { after,
         before,
         classes: propClasses,
-        field,
         message,
+        onChange,
+        onBlur,
         ...rest
-    } = props;
-    const fieldState = useFieldState(field);
+    } = userProps;
+
+    const { value } = fieldState;
+    const { setValue, setTouched } = fieldApi;
     const classes = useStyle(defaultClasses, propClasses);
     const inputClass = fieldState.error ? classes.input_error : classes.input;
 
-    return (
+    return render(
         <Fragment>
             <FieldIcons after={after} before={before}>
-                <InformedText {...rest} className={inputClass} field={field} />
+                <input
+                    {...rest}
+                    value={!value && value !== 0 ? '' : value}
+                    onChange={e => {
+                        setValue(e.target.value);
+                        if (onChange) {
+                            onChange(e);
+                        }
+                    }}
+                    onBlur={e => {
+                        setTouched(true);
+                        if (onBlur) {
+                            onBlur(e);
+                        }
+                    }}
+                    className={inputClass}
+                    ref={ref}
+                />
             </FieldIcons>
             <Message fieldState={fieldState}>{message}</Message>
         </Fragment>
@@ -35,7 +55,8 @@ TextInput.propTypes = {
     after: node,
     before: node,
     classes: shape({
-        input: string
+        input: string,
+        input_error: string,
     }),
     field: string.isRequired,
     message: node


### PR DESCRIPTION
- Updated TextInput and QuantityFields component to use useField hook instead of useFieldState to ensure the field is rendered prior to asking for its fieldState.

RCA: Currently the way we are using informed libraries useFieldState will cause it to fire prior to the field being rendered due to the intention is for the field already rendered and then to add logic on top of the rendered input. This in effect actually will still work as intended as per https://github.com/joepuzzo/informed/issues/287 since it will just keep checking for it until the said field is rendered since it is made to be intentionally non-blocking. 

I resolved this issue in the TextInput component and the QuantityFields component.

As a fix, I had switched out the usage of useFieldState and opted in for the useField hook so the fieldState is generated alongside the component which we can ensure the field is rendered prior to getting the field state.

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

*Describe the bug*

This warning is spammed several times when you load a (product?) page:

!https://user-images.githubusercontent.com/1278869/116105745-38407700-a677-11eb-84ec-99d54bcbd3f7.png!

*To reproduce*

Steps to reproduce the behavior:
 1. Go to {{/default/night-out-collection.html}}
 2. Look at console warnings

*Expected behavior*

Should not see this warning in console.
h3. Acceptance Criteria
 * Visiting the product page does not cause warnings to be logged to the browser console
 * Root cause analysis: does this happen on all product pages? If not, why not?

h3. Test Plan
 1. Visit a PDP for each product type (simple, configurable, virtual, bundled)
 2. {{Bundled: /night-out-collection.html}}
 3. Open the browser console and verify that no warnings of the above type appear

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes #ISSUE_NUMBER.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
