### PR TITLE
[PWA-2131] Stop relying on NPM output to locate tarball file in scaffolding debug mode

### DIFF
--- a/packages/pwa-buildpack/bin/buildpack
+++ b/packages/pwa-buildpack/bin/buildpack
@@ -15,8 +15,11 @@ require('yargs')
         // https://github.com/yargs/yargs/issues/1102
         // In the meantime, this handler only pretty-prints the exception when
         // you provided no command or an unrecognized command.
-        const error = err || msg;
-        prettyLogger.error(error.toString());
+        const trace = err.stack;
+        const error = msg
+            ? new Error(`${msg}. Original error: ${trace}`)
+            : trace;
+        prettyLogger.error(error);
         // eslint-disable-next-line no-process-exit
         process.exit(1);
     })

--- a/packages/pwa-buildpack/lib/Utilities/TemplateRepository.js
+++ b/packages/pwa-buildpack/lib/Utilities/TemplateRepository.js
@@ -1,0 +1,237 @@
+const { resolve } = require('path');
+const os = require('os');
+const fs = require('fs');
+const fetch = require('node-fetch');
+const tar = require('tar');
+const findCacheDir = require('find-cache-dir');
+const prettyLogger = require('../util/pretty-logger');
+
+/**
+ * @typedef {import('fs')} NodeFS
+ */
+
+/**
+ *
+ * Retrieves, caches, and provides paths to `buildpack create` "templates".
+ *
+ * @class TemplateRepository
+ *
+ */
+class TemplateRepository {
+    /**
+     * Create a TemplateRepository.
+     * @param {Object} config
+     * @param {string} [config.cwd=process.cwd()] - Working directory from which to resolve caches and other paths.
+     * @param {boolean} [cache=true] - Try local cache before fetching remote
+     * packages.
+     * @param {NodeFS} [fs=require('fs')] - Filesystem to use; must conform to
+     * Node's `fs` module.
+     * @param {string} [registry=https://registry.npmjs.com] - NPM registry to
+     * use to look up and download templates.
+     * @param {boolean} [local=false] - Skip cache and remote resolution;
+     * resolve package from local filesystem only.
+     */
+    constructor(config) {
+        Object.assign(this, this.defaultConfig, config);
+    }
+
+    /**
+     * @ignore
+     */
+    get defaultConfig() {
+        return {
+            cwd: process.cwd(),
+            cache: true,
+            fs,
+            registry: 'https://registry.npmjs.com',
+            local: false
+        };
+    }
+
+    /**
+     * Local filesystem directory where cached templates are kept.
+     *
+     * @readonly
+     * @memberof TemplateRepository
+     * @type string
+     */
+    get cacheDir() {
+        if (this._cacheDir === undefined) {
+            const foundCacheDir = findCacheDir({
+                name: '@magento/pwa-buildpack',
+                cwd: this.cwd,
+                create: true
+            });
+            this._cacheDir =
+                foundCacheDir && resolve(foundCacheDir, 'scaffold-templates');
+        }
+        return this._cacheDir;
+    }
+
+    /**
+     * Looks up package in cache. Returns false if none is found.
+     *
+     * @async
+     * @param {string} packageName - Package name, e.g. `@magento/venia-concept`
+     * @returns {Promise<(string|false)>} Path to cached package; `false` if
+     * package isn't cached.
+     */
+    async getPackageFromCache(packageName) {
+        const packageDir = resolve(this.cacheDir, packageName);
+        // NPM extracts a tarball to './package'
+        const packageRoot = resolve(packageDir, 'package');
+        let packageRootFiles;
+        try {
+            packageRootFiles = this.fs.readdirSync(packageRoot);
+        } catch (e) {
+            // Not cached, which is not an error.
+            return false;
+        }
+        if (packageRootFiles.includes('package.json')) {
+            prettyLogger.info(`Found ${packageName} template in cache`);
+            return packageRoot;
+        }
+        return false;
+    }
+
+    /**
+     * Looks up package name on NPM registry. Downloads and extract that package into cache, or into a temp dir if cache is disabled.
+     *
+     * @async
+     * @param {string} packageName - Package name, e.g. `@magento/venia-concept`
+     * @returns {Promise<string>} - Path to the newly downloaded template package.
+     */
+    async getPackageFromRegistry(packageName) {
+        const packageVersion = 'latest'; // TODO: make configurable
+        const cacheDir = (this.cache && this.cacheDir) || os.tmpdir();
+        const packageDir = resolve(cacheDir, packageName);
+        let tarballUrl;
+        try {
+            prettyLogger.info(`Finding ${packageName} tarball on NPM`);
+            const registryResponse = await fetch(
+                new URL(`${packageName}/${packageVersion}`, this.registry).href
+            );
+            const registryJson = await registryResponse.json();
+            tarballUrl = registryJson.dist.tarball;
+        } catch (e) {
+            throw new Error(
+                `Invalid template: could not get tarball url from npm: ${
+                    e.message
+                }`
+            );
+        }
+
+        let tarballStream;
+        try {
+            prettyLogger.info(`Downloading and unpacking ${tarballUrl}`);
+            tarballStream = (await fetch(tarballUrl)).body;
+        } catch (e) {
+            throw new Error(
+                `Invalid template: could not download tarball from NPM: ${
+                    e.message
+                }`
+            );
+        }
+        try {
+            await this.extractToDir(tarballStream, packageDir);
+            prettyLogger.info(`Unpacked ${packageName}`);
+            return resolve(packageDir, 'package');
+        } catch (e) {
+            throw new Error(
+                `Could not extract ${tarballUrl} to ${packageDir}: ${e.message}`
+            );
+        }
+    }
+
+    /**
+     * Extracts tarball to directory.
+     *
+     * @async
+     * @param {import('stream').Readable} tarballStream
+     * @param {string} targetDir
+     * @protected
+     * @returns {Promise<void>}
+     */
+    async extractToDir(tarballStream, targetDir) {
+        this.fs.mkdirSync(targetDir, { recursive: true });
+        return new Promise((res, rej) => {
+            const untarStream = tar.extract({
+                cwd: targetDir
+            });
+            tarballStream.pipe(untarStream);
+            untarStream.on('finish', () => {
+                // NPM extracts a tarball to './package'
+                const packageRoot = resolve(targetDir, 'package');
+                res(packageRoot);
+            });
+            untarStream.on('error', rej);
+            tarballStream.on('error', rej);
+        });
+    }
+
+    /**
+     * Validates and returns local directory of template. Currently is only called
+     * in scaffolding debug mode. **Currently works only for Venia; will throw
+     * unless its argument is `@magento/venia-concept`.**
+     *
+     * @todo Make this support Git repos and other local folders.
+     * @async
+     * @private
+     * @param {string} packageName - Package name, e.g. `@magento/venia-concept`
+     * @returns {Promise<string>} Path to package on disk.
+     */
+    async makeDirFromDevPackage(packageName) {
+        // assume we are in pwa-studio repo
+        // todo: support git urls
+        prettyLogger.warn(`Bypassing cache and NPM registry.`);
+        if (packageName !== '@magento/venia-concept') {
+            throw new Error(
+                `Local template mode currently only works using "@magento/venia-concept" as the template. Supplied template name "${packageName}" is unsupported.`
+            );
+        }
+        return resolve(__dirname, '../../../venia-concept');
+    }
+
+    /**
+     * Get or create a directory on the local filesystem containing the
+     * requested template package.  If `local: true` in this instance, will skip
+     * all resolution and return the absolute path to the local package.  Tries
+     * cache first unless this instance was created with `cache` set to `false`.
+     * Then tries remote registry.
+     *
+     * Order of operations:
+     *
+     * - **Local mode**: Provided a local path, will confirm that the package contains a package.json and then return its
+     * argument unchanged.
+     * - **Cache mode**: Unless this instance has `cache` set to `false`, will run {@link TemplateRepository#getPackageFromPath}.
+     * - **Remote mode**: If `cache` is `false`, OR the template was not found in cache, will run {@link TemplateRepository#getPackageFromRegistry}.
+     *
+     * @async
+     * @param {string} templateName - Name of template, or local path to
+     * template.
+     * @returns {Promise<string>} Local path to retrieved or created package.
+     */
+    async findTemplateDir(templateName) {
+        try {
+            this.fs.readdirSync(templateName);
+            prettyLogger.info(`Found ${templateName} directory`);
+            // if that succeeded, then...
+            this.fs.readFileSync(resolve(templateName, 'package.json'));
+            // And if that succeeded, then
+            return templateName;
+        } catch (e) {
+            let packageDir;
+            if (this.local) {
+                return this.makeDirFromDevPackage(templateName);
+            }
+            if (!this.cache) {
+                prettyLogger.warn(`Bypassing cache to get "${templateName}"`);
+            } else {
+                packageDir = await this.getPackageFromCache(templateName);
+            }
+            return packageDir || this.getPackageFromRegistry(templateName);
+        }
+    }
+}
+
+module.exports = TemplateRepository;

--- a/packages/pwa-buildpack/lib/Utilities/__tests__/TemplateRepository.spec.js
+++ b/packages/pwa-buildpack/lib/Utilities/__tests__/TemplateRepository.spec.js
@@ -1,0 +1,272 @@
+jest.mock('find-cache-dir');
+jest.mock('tar');
+jest.mock('node-fetch');
+
+class TempFS extends require('memory-fs') {
+    constructor({ emptyDirs = [], files = {} }) {
+        super();
+        for (const dir of emptyDirs) {
+            this.mkdirpSync(dir);
+        }
+        for (const [filePath, contents] of Object.entries(files)) {
+            this.mkdirpSync(dirname(filePath));
+            this.writeFileSync(filePath, contents, 'utf8');
+        }
+        TempFS.current = this;
+    }
+    mkdirSync(...args) {
+        return super.mkdirpSync(...args);
+    }
+}
+
+const findCacheDir = require('find-cache-dir');
+const { resolve, dirname } = require('path');
+const fetch = require('node-fetch');
+const stream = require('stream');
+const tar = require('tar');
+
+function mockFetchBodyOnce(body) {
+    fetch.mockResolvedValueOnce({
+        body: stream.Readable.from([body])
+    });
+}
+
+function mockFetchJsonOnce(json) {
+    fetch.mockResolvedValueOnce({
+        json: () => Promise.resolve(json)
+    });
+}
+
+const TemplateRepository = require('../TemplateRepository');
+describe('TemplateRepository for scaffolding', () => {
+    beforeAll(() => {
+        tar.extract.mockImplementation(({ cwd }) => {
+            const fs = TempFS.current;
+            fs.mkdirpSync(resolve(cwd, 'package'));
+            return fs.createWriteStream(
+                resolve(cwd, 'package', 'package.json')
+            );
+        });
+        findCacheDir.mockReturnValue('/thecache');
+    });
+
+    test('finds and stores local cache directory with find-cache-dir', () => {
+        const repo = new TemplateRepository();
+        expect(repo.cacheDir).toBe('/thecache/scaffold-templates');
+    });
+
+    describe('#getPackageFromCache', () => {
+        test('gets the local path of a cached package', async () => {
+            const repo = new TemplateRepository({
+                fs: new TempFS({
+                    files: {
+                        '/thecache/scaffold-templates/@testns/testpkg/package/package.json': JSON.stringify(
+                            {
+                                name: '@testns/testpkg'
+                            }
+                        )
+                    }
+                })
+            });
+            await expect(
+                repo.getPackageFromCache('@testns/testpkg')
+            ).resolves.toBe(
+                '/thecache/scaffold-templates/@testns/testpkg/package'
+            );
+        });
+        test('returns false if no cached package dir is found', async () => {
+            const repo = new TemplateRepository({ fs: new TempFS({}) });
+            await expect(
+                repo.getPackageFromCache('@testns/nonexistent')
+            ).resolves.toBe(false);
+        });
+        test('returns false if cached package dir has no package.json in it', async () => {
+            const repo = new TemplateRepository({
+                fs: new TempFS({
+                    emptyDirs: [
+                        '/thecache/scaffold-templates/@testns/nonexistent/package'
+                    ]
+                })
+            });
+            await expect(
+                repo.getPackageFromCache('@testns/nonexistent')
+            ).resolves.toBe(false);
+        });
+        test('does not search for cache path more than once per instance', async () => {
+            const repo = new TemplateRepository({
+                fs: new TempFS({})
+            });
+            await expect(repo.getPackageFromCache('absent')).resolves.toBe(
+                false
+            );
+            await expect(repo.getPackageFromCache('absent')).resolves.toBe(
+                false
+            );
+            expect(findCacheDir).toHaveBeenCalledTimes(1);
+        });
+    });
+    describe('#getPackageFromRegistry', () => {
+        describe('looks up tarball on registry', () => {
+            test('downloads and extracts tarball from registry', async () => {
+                const repo = new TemplateRepository({ fs: new TempFS({}) });
+                const packageToWrite = { name: '@testns/remote' };
+                mockFetchJsonOnce({
+                    dist: {
+                        tarball: 'http://example.com/tarball.tgz'
+                    }
+                });
+                mockFetchBodyOnce(JSON.stringify(packageToWrite));
+                const expectedDir =
+                    '/thecache/scaffold-templates/@testns/remote/package';
+                await expect(
+                    repo.getPackageFromRegistry('@testns/remote')
+                ).resolves.toBe(expectedDir);
+
+                expect(fetch).toHaveBeenCalledWith(
+                    'https://registry.npmjs.com/@testns/remote/latest'
+                );
+                expect(fetch).toHaveBeenCalledWith(
+                    'http://example.com/tarball.tgz'
+                );
+                expect(
+                    JSON.parse(
+                        TempFS.current.readFileSync(
+                            `${expectedDir}/package.json`
+                        )
+                    )
+                ).toEqual(packageToWrite);
+            });
+            test('throws if package info fetch failed', async () => {
+                const repo = new TemplateRepository({ cache: false });
+                fetch.mockRejectedValueOnce(new Error('403'));
+                await expect(
+                    repo.getPackageFromRegistry('@testns/remote')
+                ).rejects.toThrowErrorMatchingSnapshot();
+            });
+            test('throws if tarball fetch failed', async () => {
+                mockFetchJsonOnce({
+                    dist: {
+                        tarball: 'http://example.com/tarball-nonexistent.tgz'
+                    }
+                });
+                fetch.mockRejectedValueOnce(new Error('404'));
+                const repo = new TemplateRepository({ cache: false });
+                await expect(
+                    repo.getPackageFromRegistry('@testns/remote')
+                ).rejects.toThrowErrorMatchingSnapshot();
+            });
+            test('downloads from custom registry', async () => {
+                fetch.mockRejectedValueOnce(new Error('who even are you'));
+                const repo = new TemplateRepository({
+                    fs: new TempFS({}),
+                    cache: false,
+                    registry: 'https://other-registry.com'
+                });
+                await expect(
+                    repo.getPackageFromRegistry('@testns/remote')
+                ).rejects.toThrow();
+                expect(fetch).toHaveBeenCalledWith(
+                    'https://other-registry.com/@testns/remote/latest'
+                );
+            });
+            test('throws if tarball extract failed', async () => {
+                mockFetchJsonOnce({
+                    dist: {
+                        tarball: 'http://example.com/tarball.tgz'
+                    }
+                });
+                mockFetchBodyOnce(JSON.stringify({ name: '@testns/remote' }));
+                const repo = new TemplateRepository({
+                    fs: new TempFS({})
+                });
+                repo.extractToDir = () => Promise.reject(new Error('oh no'));
+                await expect(
+                    repo.getPackageFromRegistry('@testns/remote')
+                ).rejects.toThrowErrorMatchingSnapshot();
+            });
+        });
+    });
+    describe('#makeDirFromDevPackage', () => {
+        test('provides local path to venia', async () => {
+            const repo = new TemplateRepository();
+            await expect(
+                repo.makeDirFromDevPackage('@magento/venia-concept')
+            ).resolves.toMatch(/pwa\-studio\/packages\/venia-concept$/);
+        });
+        test('currently errors if anything else is requested', async () => {
+            const repo = new TemplateRepository();
+            await expect(
+                repo.makeDirFromDevPackage('@anything/else')
+            ).rejects.toThrowErrorMatchingSnapshot();
+        });
+    });
+    describe('#findTemplateDir', () => {
+        const localTemplatePackage = '/path/to/local/template/';
+        const mockFs = new TempFS({
+            files: {
+                '/path/to/local/template/package.json': JSON.stringify({
+                    name: '@testns/testpkg'
+                })
+            }
+        });
+        const proto = TemplateRepository.prototype;
+        beforeEach(() => {
+            jest.spyOn(proto, 'makeDirFromDevPackage');
+            jest.spyOn(proto, 'getPackageFromCache');
+            jest.spyOn(proto, 'getPackageFromRegistry');
+        });
+        afterEach(() => {
+            proto.makeDirFromDevPackage.mockRestore();
+            proto.getPackageFromCache.mockRestore();
+            proto.getPackageFromRegistry.mockRestore();
+        });
+        test('Returns its argument if it is a real local path with a package.json in it', async () => {
+            const repo = new TemplateRepository({
+                fs: mockFs
+            });
+            await expect(
+                repo.findTemplateDir(localTemplatePackage)
+            ).resolves.toBe(localTemplatePackage);
+        });
+        test('Runs this.makeDirFromDevPackage if local is set', async () => {
+            const repo = new TemplateRepository({ local: true });
+            repo.makeDirFromDevPackage.mockResolvedValueOnce('/path/to/venia');
+            await expect(
+                repo.findTemplateDir('@magento/venia-concept')
+            ).resolves.toMatch('/path/to/venia');
+            expect(repo.getPackageFromCache).not.toHaveBeenCalled();
+            expect(repo.getPackageFromRegistry).not.toHaveBeenCalled();
+        });
+        test('Runs this.getPackageFromCache first', async () => {
+            const repo = new TemplateRepository({ fs: mockFs });
+            repo.getPackageFromCache.mockResolvedValueOnce('/path/to/venia');
+            await expect(
+                repo.findTemplateDir('@magento/venia-concept')
+            ).resolves.toMatch('/path/to/venia');
+            expect(repo.getPackageFromRegistry).not.toHaveBeenCalled();
+        });
+        test('If no cache present, runs this.getPackageFromRegistry', async () => {
+            const repo = new TemplateRepository({});
+            repo.getPackageFromRegistry.mockResolvedValueOnce(
+                '/path/to/remote'
+            );
+            repo.getPackageFromCache.mockResolvedValueOnce(false);
+            await expect(
+                repo.findTemplateDir('@magento/venia-concept')
+            ).resolves.toMatch('/path/to/remote');
+            expect(repo.getPackageFromCache).toHaveBeenCalled();
+            expect(repo.getPackageFromRegistry).toHaveBeenCalled();
+        });
+        test('If cache is set to false, goes directly to registry', async () => {
+            const repo = new TemplateRepository({ cache: false });
+            repo.getPackageFromRegistry.mockResolvedValueOnce(
+                '/path/to/remote'
+            );
+            await expect(
+                repo.findTemplateDir('@magento/venia-concept')
+            ).resolves.toMatch('/path/to/remote');
+            expect(repo.getPackageFromCache).not.toHaveBeenCalled();
+            expect(repo.getPackageFromRegistry).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/pwa-buildpack/lib/Utilities/__tests__/__snapshots__/TemplateRepository.spec.js.snap
+++ b/packages/pwa-buildpack/lib/Utilities/__tests__/__snapshots__/TemplateRepository.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TemplateRepository for scaffolding #getPackageFromRegistry looks up tarball on registry throws if package info fetch failed 1`] = `"Invalid template: could not get tarball url from npm: 403"`;
+
+exports[`TemplateRepository for scaffolding #getPackageFromRegistry looks up tarball on registry throws if tarball extract failed 1`] = `"Could not extract http://example.com/tarball.tgz to /thecache/scaffold-templates/@testns/remote: oh no"`;
+
+exports[`TemplateRepository for scaffolding #getPackageFromRegistry looks up tarball on registry throws if tarball fetch failed 1`] = `"Invalid template: could not download tarball from NPM: 404"`;
+
+exports[`TemplateRepository for scaffolding #makeDirFromDevPackage currently errors if anything else is requested 1`] = `"Local template mode currently only works using \\"@magento/venia-concept\\" as the template. Supplied template name \\"@anything/else\\" is unsupported."`;

--- a/packages/pwa-buildpack/lib/__tests__/__snapshots__/cli-create-project.spec.js.snap
+++ b/packages/pwa-buildpack/lib/__tests__/__snapshots__/cli-create-project.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`errors out on a bad npm package 1`] = `"could not download"`;

--- a/packages/pwa-buildpack/lib/__tests__/cli-create-project.spec.js
+++ b/packages/pwa-buildpack/lib/__tests__/cli-create-project.spec.js
@@ -1,25 +1,19 @@
 jest.mock('execa');
 jest.mock('fs-extra');
-jest.mock('node-fetch');
-jest.mock('tar');
 jest.mock('../Utilities/createProject');
 jest.mock('../cli/create-env-file');
+jest.mock('../Utilities/TemplateRepository');
 const yargs = require('yargs');
-const { shellSync, shell } = require('execa');
 const createProject = require('../Utilities/createProject');
+const TemplateRepository = require('../Utilities/TemplateRepository');
 const fse = require('fs-extra');
-const fetch = require('node-fetch');
-const tar = require('tar');
 const createProjectCliBuilder = require('../cli/create-project');
 
+const repo = TemplateRepository.prototype;
 beforeEach(() => {
     fse.ensureDir.mockReset();
-    fse.readdir.mockReset();
-    fetch.mockReset();
+    jest.spyOn(repo, 'findTemplateDir');
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-    tar.extract.mockReturnValueOnce({
-        on: (e, cb) => e === 'finish' && setImmediate(cb)
-    });
 });
 afterEach(() => {
     jest.restoreAllMocks();
@@ -49,9 +43,10 @@ test('is a yargs builder', async () => {
     expect(() => createProjectCliBuilder.builder(yargs)).toThrow('positional');
 });
 
-test('locates builtin package', async () => {
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockResolvedValueOnce(true);
+test('locates package with TemplateRepository', async () => {
+    repo.findTemplateDir.mockResolvedValueOnce(
+        '/path/to/@magento/venia-concept'
+    );
     await expect(
         createProjectCliBuilder.handler({
             name: 'goo',
@@ -65,131 +60,32 @@ test('locates builtin package', async () => {
             template: expect.stringMatching('@magento/venia-concept')
         })
     );
+    expect(TemplateRepository).toHaveBeenCalled();
+    expect(repo.findTemplateDir).toHaveBeenCalledWith('@magento/venia-concept');
 });
 
-test('locates template dir on disk', async () => {
-    fse.readdir.mockResolvedValueOnce(true);
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockResolvedValueOnce(true);
-    await expect(
-        createProjectCliBuilder.handler({
-            template: 'other-template-on-fs',
-            directory: 'project'
-        })
-    ).resolves.not.toThrow();
-    expect(createProject).toHaveBeenCalledWith(
-        expect.objectContaining({
-            name: 'project',
-            template: expect.stringMatching('other-template-on-fs')
-        })
-    );
-});
-
-test('locates cached template dir', async () => {
-    fse.readdir.mockRejectedValueOnce(new Error('ENOENT'));
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockResolvedValueOnce(['package.json']);
+test('configures TemplateRepository to local only if --debug-scaffolding is set', async () => {
+    repo.findTemplateDir.mockResolvedValueOnce('/path/to/venia');
     await expect(
         createProjectCliBuilder.handler({
             name: 'goo',
-            template: '@vendor/npm-template',
-            directory: '/project'
+            template: '@magento/venia',
+            directory: '/project',
+            testScaffolding: true
         })
     ).resolves.not.toThrow();
     expect(createProject).toHaveBeenCalledWith(
         expect.objectContaining({
             name: 'goo',
-            template: expect.stringMatching('@vendor/npm-template')
+            template: '/path/to/venia'
         })
     );
-});
-
-test('locates template dir on npm', async () => {
-    fse.readdir.mockRejectedValueOnce(new Error('ENOENT'));
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockResolvedValueOnce([]);
-    shellSync.mockImplementation(() => ({
-        stdout: JSON.stringify({ dist: { tarball: 'https://tgzfile' } })
-    }));
-    fetch.mockResolvedValueOnce({ body: { pipe: () => {}, on: () => {} } });
-    await expect(
-        createProjectCliBuilder.handler({
-            name: 'goo',
-            template: '@vendor/npm-template',
-            directory: '/project'
-        })
-    ).resolves.not.toThrow();
-    expect(createProject).toHaveBeenCalledWith(
+    expect(TemplateRepository).toHaveBeenCalledWith(
         expect.objectContaining({
-            name: 'goo',
-            template: expect.stringMatching('@vendor/npm-template')
+            cache: false,
+            local: true
         })
     );
-});
-
-test('uses monorepo assets in DEBUG_PROJECT_CREATION mode', async () => {
-    shellSync.mockImplementation(() => ({
-        stdout: JSON.stringify({ dist: { tarball: 'https://tgzfile' } })
-    }));
-    fetch.mockResolvedValueOnce({ body: { pipe: () => {}, on: () => {} } });
-    const old = process.env.DEBUG_PROJECT_CREATION;
-    process.env.DEBUG_PROJECT_CREATION = 1;
-    fse.readdir.mockRejectedValueOnce(new Error('ENOENT'));
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockRejectedValueOnce(new Error('no!'));
-
-    await expect(
-        createProjectCliBuilder.handler({
-            name: 'goo',
-            template: '@vendor/npm-template',
-            directory: '/project'
-        })
-    ).resolves.not.toThrow();
-    expect(createProject).toHaveBeenCalledWith(
-        expect.objectContaining({
-            name: 'goo',
-            template: expect.stringMatching('@vendor/npm-template')
-        })
-    );
-    expect(shellSync).toHaveBeenCalled();
-    process.env.DEBUG_PROJECT_CREATION = old;
-});
-
-test('throws errors if npm view or tarball fetch error', async () => {
-    const old = process.env.DEBUG_PROJECT_CREATION;
-    process.env.DEBUG_PROJECT_CREATION = 1;
-    shellSync.mockImplementationOnce(() => ({
-        stdout: 'bad json'
-    }));
-    fse.readdir.mockRejectedValueOnce(new Error('ENOENT'));
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockRejectedValueOnce(new Error('no!'));
-
-    await expect(
-        createProjectCliBuilder.handler({
-            name: 'goo',
-            template: '@vendor/npm-template',
-            directory: '/project'
-        })
-    ).rejects.toThrow('could not get tarball url');
-
-    shellSync.mockImplementationOnce(() => ({
-        stdout: JSON.stringify({ dist: { tarball: 'https://tgzfile' } })
-    }));
-    fetch.mockRejectedValueOnce(new Error('404'));
-    fse.readdir.mockRejectedValueOnce(new Error('ENOENT'));
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockRejectedValueOnce(new Error('no!'));
-
-    await expect(
-        createProjectCliBuilder.handler({
-            name: 'goo',
-            template: '@vendor/npm-template',
-            directory: '/project'
-        })
-    ).rejects.toThrow('could not download tarball');
-
-    process.env.DEBUG_PROJECT_CREATION = old;
 });
 
 test('warns if backendUrl does not match env', async () => {
@@ -314,8 +210,6 @@ test('does not warn if braintreeToken matches env', async () => {
 });
 
 test('runs install with yarn', async () => {
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockResolvedValueOnce(true);
     await expect(
         createProjectCliBuilder.handler({
             name: 'goo',
@@ -329,8 +223,6 @@ test('runs install with yarn', async () => {
 });
 
 test('runs install with npm', async () => {
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockResolvedValueOnce(true);
     await expect(
         createProjectCliBuilder.handler({
             name: 'goo',
@@ -344,9 +236,7 @@ test('runs install with npm', async () => {
 });
 
 test('errors out on a bad npm package', async () => {
-    fse.readdir.mockRejectedValueOnce(new Error('ENOENT'));
-    fse.ensureDir.mockResolvedValueOnce(true);
-    fse.readdir.mockRejectedValueOnce(new Error('no!'));
+    repo.findTemplateDir.mockRejectedValueOnce(new Error('could not download'));
     await expect(
         createProjectCliBuilder.handler({
             name: 'package-name',
@@ -355,5 +245,5 @@ test('errors out on a bad npm package', async () => {
             install: true,
             npmClient: 'yarn'
         })
-    ).rejects.toThrow('Invalid template');
+    ).rejects.toThrowErrorMatchingSnapshot();
 });

--- a/packages/pwa-buildpack/lib/cli/create-project.js
+++ b/packages/pwa-buildpack/lib/cli/create-project.js
@@ -1,81 +1,13 @@
 const { resolve } = require('path');
-const fetch = require('node-fetch');
-const os = require('os');
-const tar = require('tar');
 const camelspace = require('camelspace');
 const fse = require('fs-extra');
 const prettyLogger = require('../util/pretty-logger');
 const chalk = require('chalk');
 const createProject = require('../Utilities/createProject');
+const TemplateRepository = require('../Utilities/TemplateRepository');
 const { handler: createEnvFile } = require('./create-env-file');
 const execa = require('execa');
 const sampleBackends = require('../../sampleBackends.json');
-
-const tmpDir = os.tmpdir();
-
-async function makeDirFromNpmPackage(packageName) {
-    const packageDir = resolve(tmpDir, packageName);
-    // NPM extracts a tarball to './package'
-    const packageRoot = resolve(packageDir, 'package');
-    try {
-        if ((await fse.readdir(packageRoot)).includes('package.json')) {
-            prettyLogger.info(`Found ${packageName} template in cache`);
-            return packageRoot;
-        }
-    } catch (e) {
-        // Not cached.
-    }
-    let tarballUrl;
-    try {
-        prettyLogger.info(`Finding ${packageName} tarball on NPM`);
-        tarballUrl = JSON.parse(
-            execa.shellSync(`npm view --json ${packageName}`, {
-                encoding: 'utf-8'
-            }).stdout
-        ).dist.tarball;
-    } catch (e) {
-        throw new Error(
-            `Invalid template: could not get tarball url from npm: ${e.message}`
-        );
-    }
-
-    let tarballStream;
-    try {
-        prettyLogger.info(`Downloading and unpacking ${tarballUrl}`);
-        tarballStream = (await fetch(tarballUrl)).body;
-    } catch (e) {
-        throw new Error(
-            `Invalid template: could not download tarball from NPM: ${
-                e.message
-            }`
-        );
-    }
-
-    await fse.ensureDir(packageDir);
-    return new Promise((res, rej) => {
-        const untarStream = tar.extract({
-            cwd: packageDir
-        });
-        tarballStream.pipe(untarStream);
-        untarStream.on('finish', () => {
-            prettyLogger.info(`Unpacked ${packageName}`);
-            res(packageRoot);
-        });
-        untarStream.on('error', rej);
-        tarballStream.on('error', rej);
-    });
-}
-
-async function findTemplateDir(templateName) {
-    try {
-        await fse.readdir(templateName);
-        prettyLogger.info(`Found ${templateName} directory`);
-        // if that succeeded, then...
-        return templateName;
-    } catch (e) {
-        return makeDirFromNpmPackage(templateName);
-    }
-}
 
 module.exports.sampleBackends = sampleBackends;
 
@@ -129,7 +61,7 @@ module.exports.builder = yargs =>
                     'Name and (optionally <email address>) of the author to put in the package.json "author" field.'
             }
         })
-        .group(['install', 'npmClient'], 'Package management:')
+        .group(['install', 'npmClient', 'cache'], 'Package management:')
         .options({
             install: {
                 boolean: true,
@@ -140,15 +72,39 @@ module.exports.builder = yargs =>
                 describe: 'NPM package management client to use.',
                 choices: ['npm', 'yarn'],
                 default: 'npm'
+            },
+            cache: {
+                boolean: true,
+                describe: 'Use cache for template packages and dependencies.',
+                default: true
+            }
+        })
+        .options({
+            // Only added as an argument for testing. It's never necessary in
+            // the CLI itself; just set DEBUG_PROJECT_CREATION in the env.
+            testScaffolding: {
+                boolean: true,
+                hidden: true,
+                default: !!process.env.DEBUG_PROJECT_CREATION
             }
         })
         .help();
 
 module.exports.handler = async function buildpackCli(argv) {
+    const repoConfig = {
+        cache: argv.cache
+    };
+    if (argv.testScaffolding) {
+        repoConfig.cache = false;
+        repoConfig.local = true;
+    }
+
+    const templateRepo = new TemplateRepository(repoConfig);
+
     const params = {
         ...argv,
         name: argv.name || argv.directory,
-        template: await findTemplateDir(argv.template)
+        template: await templateRepo.findTemplateDir(argv.template)
     };
     const { directory, name } = params;
     await fse.ensureDir(directory);

--- a/packages/pwa-buildpack/package.json
+++ b/packages/pwa-buildpack/package.json
@@ -43,6 +43,7 @@
     "errorhandler": "~1.5.1",
     "execa": "~1.0.0",
     "figures": "~2.0.0",
+    "find-cache-dir": "~3.3.2",
     "fs-extra": "~7.0.1",
     "gitignore-to-glob": "~0.3.0",
     "graphql-playground-middleware-express": "~1.7.18",

--- a/packages/venia-concept/_buildpack/__tests__/create.spec.js
+++ b/packages/venia-concept/_buildpack/__tests__/create.spec.js
@@ -1,8 +1,5 @@
 jest.mock('child_process');
 const { execSync } = require('child_process');
-execSync.mockImplementation((cmd, { cwd }) =>
-    JSON.stringify([{ filename: `${cwd.split('/').pop()}.tgz` }])
-);
 
 const { dirname, resolve } = require('path');
 const packagesRoot = resolve(__dirname, '../../../');
@@ -175,8 +172,7 @@ test.skip('outputs package-lock or yarn.lock based on npmClient', async () => {
     });
 });
 
-describe('when DEBUG_PROJECT_CREATION is set', () => {
-    const old = process.env.DEBUG_PROJECT_CREATION;
+describe('when testScaffolding is set', () => {
     const mockWorkspaceResponse = JSON.stringify({
         foo: { location: '/repo/packages/me' },
         '@magento/create-pwa': { location: 'packages/create-pwa' },
@@ -189,7 +185,6 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
     let pkg;
 
     beforeEach(() => {
-        process.env.DEBUG_PROJECT_CREATION = 1;
         pkg = {
             name: 'foo',
             author: 'bar',
@@ -197,7 +192,8 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
                 '@magento/venia-ui': '1.0.0'
             },
             devDependencies: {
-                '@magento/peregrine': '1.0.0'
+                '@magento/peregrine': '1.0.0',
+                '@magento/pwa-buildpack': '1.0.0'
             },
             scripts: {},
             optionalDependencies: {
@@ -221,43 +217,111 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
                 name: '@magento/pwa-buildpack'
             })
         });
-    });
-
-    afterEach(() => {
-        process.env.DEBUG_PROJECT_CREATION = old;
-    });
-
-    test('forces yarn client, local deps, and console debugging if DEBUG_PROJECT_CREATION is set', async () => {
-        // mock the yarn workspaces response
-        execSync.mockReturnValueOnce(mockWorkspaceResponse);
-
-        await runCreate(fs, {
-            name: 'foo',
-            author: 'bar',
-            npmClient: 'npm'
+        execSync.mockImplementation((cmd, { cwd }) => {
+            if (!cmd.match(/npm.+pack/)) {
+                throw new Error(
+                    `Mock execSync expected passed command to be "npm pack", but it was "${cmd}"`
+                );
+            }
+            const pkgName = cwd.split('/').pop();
+            // as of NPM 7.21 npm pack produces this filename
+            fs.writeFileSync(
+                resolve(packagesRoot, pkgName, `magento-${pkgName}-1.0.0.tgz`),
+                `${pkgName} tarball contents`
+            );
+            // but it produces THIS in filename output. Hilarious!
+            return JSON.stringify([
+                { filename: `@magento/${pkgName}-1.0.0.tgz` }
+            ]);
         });
-
-        const packageJSON = fs.readJsonSync('/project/package.json');
-
-        expect(packageJSON.dependencies['@magento/pwa-buildpack']).toMatch(
-            /^file/
-        );
-        expect(packageJSON.dependencies['@magento/create-pwa']).toBeUndefined();
-        expect(packageJSON.resolutions['@magento/peregrine']).toMatch(/^file/);
     });
 
-    test('handles unexpected child process responses', async () => {
-        execSync.mockReturnValueOnce('bad { json');
-        await expect(
-            runCreate(fs, { name: 'foo', author: 'bar', npmClient: 'yarn' })
-        ).rejects.toThrowError('workspaces');
+    describe('scaffolds using the current state of the other packages as dependencies, instead of the published release', () => {
+        const fileScheme = 'file://';
 
-        execSync
-            .mockReturnValueOnce(mockWorkspaceResponse)
-            .mockReturnValueOnce('very bad { json');
-        await expect(
-            runCreate(fs, { name: 'foo', author: 'bar', npmClient: 'yarn' })
-        ).rejects.toThrowError('pack');
+        const createDebugScaffold = async () => {
+            execSync.mockReturnValueOnce(mockWorkspaceResponse);
+
+            await runCreate(fs, {
+                name: 'foo',
+                author: 'bar',
+                npmClient: 'npm',
+                testScaffolding: true
+            });
+
+            return fs.readJsonSync('/project/package.json');
+        };
+
+        test('sets the created package.json to use local tarballs for those dependencies', async () => {
+            const {
+                dependencies,
+                devDependencies,
+                resolutions
+            } = await createDebugScaffold();
+            expect(devDependencies['@magento/pwa-buildpack']).toMatch(
+                fileScheme
+            );
+            expect(dependencies['@magento/create-pwa']).toBeUndefined();
+            expect(resolutions['@magento/peregrine']).toMatch(fileScheme);
+        });
+        test('uses npm to create the local tarballs it references', async () => {
+            const {
+                dependencies,
+                devDependencies
+            } = await createDebugScaffold();
+            const tryReadTarball = dep => {
+                const tarballPath = dep.replace(fileScheme, '');
+                try {
+                    return fs.readFileSync(tarballPath, 'utf8');
+                } catch (e) {
+                    throw new Error(
+                        `Expected npm to have created ${tarballPath}, but: ${
+                            e.message
+                        }`
+                    );
+                }
+            };
+
+            expect(
+                tryReadTarball(devDependencies['@magento/pwa-buildpack'])
+            ).toBe('pwa-buildpack tarball contents');
+            expect(tryReadTarball(devDependencies['@magento/peregrine'])).toBe(
+                'peregrine tarball contents'
+            );
+            expect(tryReadTarball(dependencies['@magento/venia-ui'])).toBe(
+                'venia-ui tarball contents'
+            );
+        });
+        test('handles lots of older tarballs in the dep directories', async () => {
+            const debugPkgJson = await createDebugScaffold();
+            fs.writeFileSync(
+                resolve(
+                    packagesRoot,
+                    'peregrine',
+                    'magento-peregrine-0.0.1.tgz'
+                ),
+                'older peregrine tarball'
+            );
+            fs.writeFileSync(
+                resolve(
+                    packagesRoot,
+                    'peregrine',
+                    'magento-peregrine-0.0.2.tgz'
+                ),
+                'old peregrine tarball'
+            );
+            fs.writeFileSync(
+                resolve(
+                    packagesRoot,
+                    'pwa-buildpack',
+                    'magento-pwa-buildpack-0.0.1.tgz'
+                ),
+                'old buildpack tarball'
+            );
+            // now try again, but with too many tarballs.
+            // did it get the right ones (the same ones as before)?
+            await expect(createDebugScaffold()).resolves.toEqual(debugPkgJson);
+        });
     });
 
     test('handles missing scripts section or zero overrides', async () => {
@@ -276,17 +340,5 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
         expect(fs.readJsonSync('/project/package.json')).not.toHaveProperty(
             'resolutions'
         );
-    });
-
-    test('works with modern versions of NPM that spit out the tarball name', async () => {
-        // Arrange.
-        execSync
-            .mockReturnValueOnce(mockWorkspaceResponse)
-            .mockReturnValueOnce('unit_test.tgz');
-
-        // Act & Assert.
-        await expect(
-            runCreate(fs, { name: 'foo', author: 'bar', npmClient: 'yarn' })
-        ).resolves.not.toThrow();
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,7 +1865,7 @@
 
 "@graphql-tools/prisma-loader@6.3.0", "@graphql-tools/prisma-loader@^6.0.0":
   version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.3.0.tgz#c907e17751ff2b26e7c2bc75d0913ebf03f970da"
+  resolved "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-6.3.0.tgz#c907e17751ff2b26e7c2bc75d0913ebf03f970da"
   integrity sha512-9V3W/kzsFBmUQqOsd96V4a4k7Didz66yh/IK89B1/rrvy9rYj+ULjEqR73x9BYZ+ww9FV8yP8LasWAJwWaqqJQ==
   dependencies:
     "@graphql-tools/url-loader" "^6.8.2"
@@ -8670,9 +8670,9 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.3.1:
+find-cache-dir@^3.3.1, find-cache-dir@~3.3.2:
   version "3.3.2"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
   dependencies:
     commondir "^1.0.1"
@@ -10050,7 +10050,7 @@ https-browserify@^1.0.0:
 
 https-proxy-agent@^2.2.1, https-proxy-agent@^5.0.0, https-proxy-agent@~2.2.3:
   version "2.2.4"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
   integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
   dependencies:
     agent-base "^4.3.0"


### PR DESCRIPTION
## Description

Changes the method of obtaining tarballs in [`packages/venia-concept/_buildpack/create.js`][1] to use the filesystem module to look for newly created tarballs, instead of relying on unsupported and unreliable output logging from the `npm pack` comment to parse for the new filename.

### Additional

- Fixed fallback error handler in `buildpack` CLI to show a full stacktrace
- Added `cache` option to `buildpack create` to control cache usage and force re-download
- Changed how buildpack template cache is stored (made it more similar to the standard way babel, ava, etc do it, by using https://www.npmjs.com/package/find-cache-dir
- Added `TemplateRepository` to abstract template location away from `create-project` cli
- Consolidated usage of `process.env.DEBUG_PROJECT_CREATION`, which was littered everywhere, into a hidden flag on `buildpack create`. `DEBUG_PROJECT_CREATION` still works, but now it's easier to maintain.

### Background
_(Adapted from internal ticket PWA-2131)_
When testing scaffolding generation (either with `create-pwa` or with `buildpack create` directly), you're supposed to set the environment variable `DEBUG_PROJECT_CREATION=1`. This puts the Venia scaffolding script [`_buildpack/create.js`][1] into a special mode where instead of downloading the latest releases of our packages from NPM, it installs them directly from the local `pwa-studio` repository. This is necessary to test out scaffolding on the latest code!

This requires changing the scaffolded project's package.json to get its venia dependencies from a local tarball. (It doesn't work reliably with `npm link`, `yarn link`, or any other method.)

Normally, the generated package.json will have `@magento` dependencies like these:

```
    "@magento/peregrine": "~11.0.0",
    "@magento/venia-ui": "~8.0.0",
```

When `DEBUG_PROJECT_CREATION=1`, the `package/venia-concept/_buildpack/create.js` script edits the generated package.json file to use dependencies like these instead:

```
    "@magento/peregrine": "file:///path/to/pwa-studio/packages/peregrine/magento-peregrine-11.0.0.tgz",
    "@magento/venia-ui": "file:///path/to/pwa-studio/packages/venia-ui/magento-venia-ui-8.0.0.tgz"
```

In order to do that, it has to create that tarball. It uses `npm pack` to create the tarball, but `npm pack` chooses the filename and may not log the filename it chose.

**To fix that, [`packages/venia-concept/_buildpack/create.js`][1] now finds the generated tarball by examining the directory for newly created `*.tgz` files; it no longer parses NPM's output to get the filename.**


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes [PWA-2131](https://jira.corp.magento.com/browse/PWA-2131).

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

1. Scaffolding should work locally, both with `./packages/create-pwa/bin/create-pwa` and `./packages/pwa-buildpack/bin/buildpack create`, both with the `DEBUG_PROJECT_CREATION` env var set and without.
2. Scaffolding CI jobs should pass.

### Verification Stakeholders

@sharkySharks 
@revanth0212 

### Specification

N/A

## Verification Steps

From your local `pwa-studio` repository, try the following four commands. All of them should work and not exit with unexpected errors.

#### Test scenario(s) for direct fix/feature

1. Ensure you have supported Node (v12) installed, _and_ the latest version of npm installed (currently 7.24.0).
2. From your local `pwa-studio` repo, run the following command:
    `DEBUG_PROJECT_CREATION=1 ./packages/create-pwa/bin/create-pwa`
3. Your new project should successfully scaffold and build. Check `package.json` for file links.


#### Test scenario(s) for any existing impacted features/areas

From your local `pwa-studio` repo, try the following commands. All of them should work an not exit with unexpected errors.

`buildpack create-project scaffold-test --name "scaffold-test" --author "Untitled Geese <jzetlen@adobe.com>" --template "@magento/venia-concept" --backend-url "https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/" --backend-edition "EE" --braintree-token "sandbox_8yrzsvtm_s2bg8fs563crhqzk" --npm-client "npm" --no-install`  


#### Test scenario(s) for any Magento Backend Supported Configurations

N/A

#### Is Browser/Device testing needed?

No

#### Any ad-hoc/edge case scenarios that need to be considered?

Should work for all supported versions of Node, and any NPM above 6.

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.

[1]: packages/venia-concept/_buildpack/create.js