### PR TITLE
[PWA-2157]: [bug]: Wrong variable name throwing graphQL Exception

### DIFF
--- a/packages/peregrine/lib/talons/CategoryList/categoryList.gql.js
+++ b/packages/peregrine/lib/talons/CategoryList/categoryList.gql.js
@@ -36,5 +36,5 @@ export const GET_CATEGORY_LIST = gql`
 
 export default {
     getCategoryListQuery: GET_CATEGORY_LIST,
-    getStoreConfig: GET_STORE_CONFIG_DATA
+    getStoreConfigQuery: GET_STORE_CONFIG_DATA
 };

--- a/packages/peregrine/lib/talons/CategoryList/useCategoryList.js
+++ b/packages/peregrine/lib/talons/CategoryList/useCategoryList.js
@@ -16,7 +16,7 @@ export const useCategoryList = props => {
     const { id } = props;
 
     const operations = mergeOperations(DEFAULT_OPERATIONS, props.operations);
-    const { getCategoryListQuery, getStoreConfigData } = operations;
+    const { getCategoryListQuery, getStoreConfigQuery } = operations;
 
     const { loading, error, data } = useQuery(getCategoryListQuery, {
         fetchPolicy: 'cache-and-network',
@@ -27,7 +27,7 @@ export const useCategoryList = props => {
         }
     });
 
-    const { data: storeConfigData } = useQuery(getStoreConfigData, {
+    const { data: storeConfigData } = useQuery(getStoreConfigQuery, {
         fetchPolicy: 'cache-and-network'
     });
 


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

This PR fixes wrong variable name `getStoreConfig` for graphQL operation in useCategoryList talon.
Bug was introduced in [PWA-1244](https://jira.corp.magento.com/browse/PWA-1244).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes PWA-2157


## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
See https://jira.corp.magento.com/browse/PWA-2157
### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->
See https://jira.corp.magento.com/browse/PWA-2157

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas
<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
