### PR TITLE
fix(scaffolding): find tarball with fs instead of npm output

### DIFF
--- a/packages/venia-concept/_buildpack/__tests__/create.spec.js
+++ b/packages/venia-concept/_buildpack/__tests__/create.spec.js
@@ -1,8 +1,5 @@
 jest.mock('child_process');
 const { execSync } = require('child_process');
-execSync.mockImplementation((cmd, { cwd }) =>
-    JSON.stringify([{ filename: `${cwd.split('/').pop()}.tgz` }])
-);
 
 const { dirname, resolve } = require('path');
 const packagesRoot = resolve(__dirname, '../../../');
@@ -197,7 +194,8 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
                 '@magento/venia-ui': '1.0.0'
             },
             devDependencies: {
-                '@magento/peregrine': '1.0.0'
+                '@magento/peregrine': '1.0.0',
+                '@magento/pwa-buildpack': '1.0.0'
             },
             scripts: {},
             optionalDependencies: {
@@ -221,43 +219,114 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
                 name: '@magento/pwa-buildpack'
             })
         });
+        execSync.mockImplementation((cmd, { cwd }) => {
+            if (!cmd.match(/npm.+pack/)) {
+                throw new Error(
+                    `Mock execSync expected passed command to be "npm pack", but it was "${cmd}"`
+                );
+            }
+            const pkgName = cwd.split('/').pop();
+            // as of NPM 7.21 npm pack produces this filename
+            fs.writeFileSync(
+                resolve(packagesRoot, pkgName, `magento-${pkgName}-1.0.0.tgz`),
+                `${pkgName} tarball contents`
+            );
+            // but it produces THIS in filename output. Hilarious!
+            return JSON.stringify([
+                { filename: `@magento/${pkgName}-1.0.0.tgz` }
+            ]);
+        });
     });
 
     afterEach(() => {
         process.env.DEBUG_PROJECT_CREATION = old;
     });
+    describe('scaffolds using the current state of the other packages as dependencies, instead of the published release', () => {
+        const fileScheme = 'file://';
 
-    test('forces yarn client, local deps, and console debugging if DEBUG_PROJECT_CREATION is set', async () => {
-        // mock the yarn workspaces response
-        execSync.mockReturnValueOnce(mockWorkspaceResponse);
+        const createDebugScaffold = async () => {
+            execSync.mockReturnValueOnce(mockWorkspaceResponse);
 
-        await runCreate(fs, {
-            name: 'foo',
-            author: 'bar',
-            npmClient: 'npm'
+            await runCreate(fs, {
+                name: 'foo',
+                author: 'bar',
+                npmClient: 'npm',
+                testScaffolding: true
+            });
+
+            return fs.readJsonSync('/project/package.json');
+        };
+
+        test('sets the created package.json to use local tarballs for those dependencies', async () => {
+            const {
+                dependencies,
+                devDependencies,
+                resolutions
+            } = await createDebugScaffold();
+            expect(devDependencies['@magento/pwa-buildpack']).toMatch(
+                fileScheme
+            );
+            expect(dependencies['@magento/create-pwa']).toBeUndefined();
+            expect(resolutions['@magento/peregrine']).toMatch(fileScheme);
         });
+        test('uses npm to create the local tarballs it references', async () => {
+            const {
+                dependencies,
+                devDependencies
+            } = await createDebugScaffold();
+            const tryReadTarball = dep => {
+                const tarballPath = dep.replace(fileScheme, '');
+                try {
+                    return fs.readFileSync(tarballPath, 'utf8');
+                } catch (e) {
+                    throw new Error(
+                        `Expected npm to have created ${tarballPath}, but: ${
+                            e.message
+                        }`
+                    );
+                }
+            };
 
-        const packageJSON = fs.readJsonSync('/project/package.json');
-
-        expect(packageJSON.dependencies['@magento/pwa-buildpack']).toMatch(
-            /^file/
-        );
-        expect(packageJSON.dependencies['@magento/create-pwa']).toBeUndefined();
-        expect(packageJSON.resolutions['@magento/peregrine']).toMatch(/^file/);
-    });
-
-    test('handles unexpected child process responses', async () => {
-        execSync.mockReturnValueOnce('bad { json');
-        await expect(
-            runCreate(fs, { name: 'foo', author: 'bar', npmClient: 'yarn' })
-        ).rejects.toThrowError('workspaces');
-
-        execSync
-            .mockReturnValueOnce(mockWorkspaceResponse)
-            .mockReturnValueOnce('very bad { json');
-        await expect(
-            runCreate(fs, { name: 'foo', author: 'bar', npmClient: 'yarn' })
-        ).rejects.toThrowError('pack');
+            expect(
+                tryReadTarball(devDependencies['@magento/pwa-buildpack'])
+            ).toBe('pwa-buildpack tarball contents');
+            expect(tryReadTarball(devDependencies['@magento/peregrine'])).toBe(
+                'peregrine tarball contents'
+            );
+            expect(tryReadTarball(dependencies['@magento/venia-ui'])).toBe(
+                'venia-ui tarball contents'
+            );
+        });
+        test('handles lots of older tarballs in the dep directories', async () => {
+            const debugPkgJson = await createDebugScaffold();
+            fs.writeFileSync(
+                resolve(
+                    packagesRoot,
+                    'peregrine',
+                    'magento-peregrine-0.0.1.tgz'
+                ),
+                'older peregrine tarball'
+            );
+            fs.writeFileSync(
+                resolve(
+                    packagesRoot,
+                    'peregrine',
+                    'magento-peregrine-0.0.2.tgz'
+                ),
+                'old peregrine tarball'
+            );
+            fs.writeFileSync(
+                resolve(
+                    packagesRoot,
+                    'pwa-buildpack',
+                    'magento-pwa-buildpack-0.0.1.tgz'
+                ),
+                'old buildpack tarball'
+            );
+            // now try again, but with too many tarballs.
+            // did it get the right ones (the same ones as before)?
+            await expect(createDebugScaffold()).resolves.toEqual(debugPkgJson);
+        });
     });
 
     test('handles missing scripts section or zero overrides', async () => {
@@ -276,17 +345,5 @@ describe('when DEBUG_PROJECT_CREATION is set', () => {
         expect(fs.readJsonSync('/project/package.json')).not.toHaveProperty(
             'resolutions'
         );
-    });
-
-    test('works with modern versions of NPM that spit out the tarball name', async () => {
-        // Arrange.
-        execSync
-            .mockReturnValueOnce(mockWorkspaceResponse)
-            .mockReturnValueOnce('unit_test.tgz');
-
-        // Act & Assert.
-        await expect(
-            runCreate(fs, { name: 'foo', author: 'bar', npmClient: 'yarn' })
-        ).resolves.not.toThrow();
     });
 });

--- a/packages/venia-concept/_buildpack/create.js
+++ b/packages/venia-concept/_buildpack/create.js
@@ -148,7 +148,7 @@ async function createProjectFromVenia({ fs, tasks, options, sampleBackends }) {
                 });
 
                 if (process.env.DEBUG_PROJECT_CREATION) {
-                    setDebugDependencies(pkg);
+                    setDebugDependencies(pkg, fs);
                 }
 
                 fs.outputJsonSync(targetPath, pkg, {
@@ -168,7 +168,7 @@ async function createProjectFromVenia({ fs, tasks, options, sampleBackends }) {
     };
 }
 
-function setDebugDependencies(pkg) {
+function setDebugDependencies(pkg, fs) {
     console.warn(
         'DEBUG_PROJECT_CREATION: Debugging Venia _buildpack/create.js, so we will assume we are inside the pwa-studio repo and replace those package dependency declarations with local file paths.'
     );
@@ -210,6 +210,24 @@ function setDebugDependencies(pkg) {
         'optionalDependencies'
     ].filter(type => pkg.hasOwnProperty(type));
 
+    const getNewestTarballIn = dir => {
+        const tarballsInDir = fs
+            .readdirSync(dir)
+            .filter(filename => filename.endsWith('.tgz'));
+        if (tarballsInDir.length === 0) {
+            throw new Error('Found no new .tgz files in ${dir}.');
+        }
+        // turn filename into a tuple of filename and modified time
+        const tarballsWithModifiedTime = tarballsInDir.map(filename => ({
+            filename,
+            modified: fs.statSync(resolve(dir, filename)).mtime
+        }));
+        // find the newest one (no need to sort, we only want the newest)
+        return tarballsWithModifiedTime.reduce((newest, candidate) =>
+            candidate.modified > newest.modified ? candidate : newest
+        ).filename;
+    };
+
     // Modify the new project's package.json file to use our generated local
     // dependencies instead of going to the NPM registry and getting the old
     // versions of packages that haven't yet been released.
@@ -229,21 +247,19 @@ function setDebugDependencies(pkg) {
         // aren't reliable in this case, because of the monorepo structure.
         // So instead, we use `npm pack` to make a tarball of each dependency,
         // which the scaffolded project will unzip and install.
+        //
+        // ADDENDUM 2021-09-14:
+        // NPM 7 has a bug where the JSON output "filename" is wrong. It says
+        // "@magento/package-name-X.X.X.tgz" when the actual filename is
+        // "magento-package-name-X.X.X.tgz". The most reliable way to find the
+        // newly generated tarball is to scan packageDir for new tarball files.
         let filename;
         let packOutput;
         try {
-            packOutput = execSync('npm pack -s --ignore-scripts --json', {
+            packOutput = execSync('npm pack -s --ignore-scripts', {
                 cwd: packageDir
-            })
-                .toString('utf-8')
-                .trim();
-            // NPM tells you where it saved the tarball it made
-            // modern versions just spit out the tarball name:
-            if (packOutput.endsWith('.tgz')) {
-                filename = packOutput;
-            } else {
-                filename = JSON.parse(packOutput)[0].filename;
-            }
+            });
+            filename = getNewestTarballIn(packageDir);
         } catch (e) {
             throw new Error(
                 `DEBUG_PROJECT_CREATION: npm pack in ${name} package failed: output was ${packOutput}\n\nerror was ${


### PR DESCRIPTION
## Description

- I changed the Venia scaffolding behavior in "debug mode" to find the new `.tar.gz` files using filesystem calls, instead of using the filename reported by NPM.

The Venia `_buildpack/create.js` special test flag `DEBUG_PROJECT_CREATION` breaks on NPM >=7.23.0, because it relies on specific output from `npm pack --json` and NPM changed that JSON.

JSON output from the `npm` command isn't reliable; it doesn't have an official spec or contract, so we shouldn't be relying on it. Instead, we should rely only on the assumption that `npm pack` will create a `.tar.gz` file in the working directory in which it was run (package root). The new process during the `DEBUG_PROJECT_CREATION` work flow is, for each Venia dependency in the `packages` folder:

1. Run `npm pack`
2. Get a directory listing
3. Filter it for `.tgz` files
4. Find the most recently modified one (presumably seconds ago)

This seems to work with all NPM and Yarn (classic) versions I've tested.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes PWA-2131.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

An internal team member and a RAP representative, at least, should reproduce the bug using `develop` and then observe the fix from this branch.

### Verification Stakeholders

![image](https://user-images.githubusercontent.com/1643758/135766960-243a10e8-7603-4bba-8427-0a52a337bdf0.png)

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

Best to repro right before checking the fix, to compare results.

#### Repro
1. In your PWA Studio root directory, switch to the `develop` branch.
2. Run `npm --version`. If it not version 7.x.x, run `npm install -g npm@7` to install NPM7. (You can reverse this later, or do it in NVM.)
3. Run `DEBUG_PROJECT_CREATION=true ./packages/pwa-buildpack/bin/buildpack create-project "scaffold-venia-develop" --template "packages/venia-concept" --name "scaffold-venia-develop" --author "pwa-ci <pwatest-ci@example.com>" --npm-client "yarn"`
4. The install phase should fail. You should see an error like `Package "" refers to a non-existing file`. This is because `npm pack --json` output a different filename than the one it actually created on disk.

#### Verification
5. Run `rm -rf ./scaffold-venia-develop && rm -rf ./packages/*/*.tgz` to remove scaffolding artifacts.
6. Check out this branch: `git checkout zetlen/PWA-2131-scaffold-debug-tarball-fix`
7. Run `npm --version` to make sure you're still on NPM 7
8. Run the create-project command from step 3 above

#### Is Browser/Device testing needed?

No, this is tooling-side only.

#### Any ad-hoc/edge case scenarios that need to be considered?

This should work on all supported versions of Node and NPM.


## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
