### PR TITLE
Updates compatibility table for v12

### DIFF
--- a/magento-compatibility.js
+++ b/magento-compatibility.js
@@ -4,6 +4,7 @@
 
 // PWA Studio version -> Magento version.
 module.exports = {
+    '12.0.0': '2.4.3',
     '11.0.0': '2.4.3',
     '10.0.0': '2.4.2',
     '9.0.1': '2.4.2',


### PR DESCRIPTION
This PR updates the compatibility table for version `12.0.0`. It is compatible with Magento `2.4.3`.

The docs site builds its [compatibility table](https://magento.github.io/pwa-studio/technologies/magento-compatibility/?itm_source=pwa-devdocs&itm_medium=quick_search&itm_campaign=federated_search&itm_term=comp) from this file.