### PR TITLE
Adding publishConfig to the venia theme package.json file

### DIFF
--- a/packages/pwa-theme-venia/package.json
+++ b/packages/pwa-theme-venia/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@magento/pwa-theme-venia",
   "version": "1.0.0-alpha.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Venia theme for a PWA Studio storefront",
   "main": "tailwind.preset.js",
   "scripts": {


### PR DESCRIPTION
## Description

The release script is failing with the following error because the new package `pwa-theme-venia` does not have `publishConfig` in its package.json file.

![image](https://user-images.githubusercontent.com/35203638/136582607-c3f9ad41-a222-4c85-b706-c9dd192e70e3.png)

## Related Issue

Closes None (Hot Fix)

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

@supernova-at 

## Verification Steps

None

## Breaking Changes (if any)

None

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
