### PR TITLE
Add header file override with redirect logic

### DIFF
--- a/pwa-devdocs/src/_includes/layout/header.html
+++ b/pwa-devdocs/src/_includes/layout/header.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang }}" dir="ltr" class="spectrum spectrum--medium spectrum--lightest">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    {% if page.adobeio %}
+    <meta http-equiv="refresh" content="0;URL='https://adobe.io/commerce/pwa-studio{{ page.adobeio }}'" />
+    {% else %}
+    <meta http-equiv="refresh" content="0;URL='https://adobe.io/commerce/pwa-studio/'" />
+    {% endif %}
+
+	<title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+	<meta name="description" content="{{ site.description }}">
+
+	<link rel="stylesheet" href="https://use.typekit.net/iaw1apr.css">
+	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css?ver=14" />
+	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/print.css?ver=14" media="print"/>
+	<script src="//assets.adobedtm.com/a7d65461e54e/f87b70cb627a/launch-b042bff6c581.min.js" async></script>
+
+	{% include layout/header-styles.html %}
+	{% include layout/header-scripts.html %}
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://magento.com/favicon.ico">
+	<link rel="apple-touch-icon" type="image/png" href="https://magento.com/apple-touch-icon.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="57x57" href="https://magento.com/apple-touch-icon-57x57.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="72x72" href="https://magento.com/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="76x76" href="https://magento.com/apple-touch-icon-76x76.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="114x114" href="https://magento.com/apple-touch-icon-114x114.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="120x120" href="https://magento.com/apple-touch-icon-120x120.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="144x144" href="https://magento.com/apple-touch-icon-144x144.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="152x152" href="https://magento.com/apple-touch-icon-152x152.png">
+	<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="https://magento.com/apple-touch-icon-180x180.png">
+
+</head>
+<body class="layout-{{ page.layout }}">
+
+	<header class="site-header">
+
+		{% include layout/site-nav.html %}
+
+	</header>
+
+	<div class="global-wrapper">
+
+		{% include layout/after-site-header.html %}
+
+		<div class="main-container">
+			<a id="main-content"></a>


### PR DESCRIPTION
## Description

Add redirect script pointing to new developer.adobe.com docs site. 

## Related Issue

Closes [PWA-2376](https://jira.corp.magento.com/browse/PWA-2376).

## Acceptance

### Verification Stakeholders

@jcalcaben 

## Verification Steps

Navigate to the https://magento.github.io/pwa-studio/. If the script is working, it should resolve to https://developer.adobe.com/commerce/pwa-studio/

