### PR TITLE
PWA-2376: Add redirect to new developer.adobe.com docs site

### DIFF
--- a/pwa-devdocs/Gemfile.lock
+++ b/pwa-devdocs/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     ffi (1.15.4)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.11)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.1)
       addressable (~> 2.4)
@@ -67,11 +67,11 @@ GEM
     unicode-display_width (1.8.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   devdocs!
   jekyll-redirect-from
 
 BUNDLED WITH
-   1.17.2
+   2.2.27

--- a/pwa-devdocs/Gemfile.lock
+++ b/pwa-devdocs/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     ffi (1.15.4)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.1)
       addressable (~> 2.4)
@@ -67,11 +67,11 @@ GEM
     unicode-display_width (1.8.0)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   devdocs!
   jekyll-redirect-from
 
 BUNDLED WITH
-   2.2.27
+   1.17.2

--- a/pwa-devdocs/src/_includes/layout/header.html
+++ b/pwa-devdocs/src/_includes/layout/header.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang }}" dir="ltr" class="spectrum spectrum--medium spectrum--lightest">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  {% if page.adobeio %}
+  <meta http-equiv="refresh" content="0;URL='https://developer.adobe.com/commerce/pwa-studio{{ page.adobeio }}'" />
+  {% else %}
+  <meta http-equiv="refresh" content="0;URL='https://developer.adobe.com/commerce/pwa-studio/'" />
+  {% endif %}
+
+  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <meta name="description" content="{{ site.description }}">
+
+  <link rel="stylesheet" href="https://use.typekit.net/iaw1apr.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css?ver=14" />
+  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/print.css?ver=14" media="print" />
+  <script src="//assets.adobedtm.com/a7d65461e54e/f87b70cb627a/launch-b042bff6c581.min.js" async></script>
+
+  {% include layout/header-styles.html %}
+  {% include layout/header-scripts.html %}
+
+  <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://magento.com/favicon.ico">
+  <link rel="apple-touch-icon" type="image/png" href="https://magento.com/apple-touch-icon.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="57x57" href="https://magento.com/apple-touch-icon-57x57.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="72x72" href="https://magento.com/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="76x76" href="https://magento.com/apple-touch-icon-76x76.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="114x114" href="https://magento.com/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="120x120" href="https://magento.com/apple-touch-icon-120x120.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="144x144" href="https://magento.com/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="152x152" href="https://magento.com/apple-touch-icon-152x152.png">
+  <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="https://magento.com/apple-touch-icon-180x180.png">
+
+</head>
+
+<body class="layout-{{ page.layout }}">
+
+  <header class="site-header">
+
+    {% include layout/site-nav.html %}
+
+  </header>
+
+  <div class="global-wrapper">
+
+    {% include layout/after-site-header.html %}
+
+    <div class="main-container">
+      <a id="main-content"></a>

--- a/pwa-devdocs/src/pagebuilder/components/banner/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/banner/index.md
@@ -1,5 +1,6 @@
 ---
 title: Banner
+adobeio: /integrations/pagebuilder/components/Banner/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/block/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/block/index.md
@@ -1,5 +1,6 @@
 ---
 title: Block
+adobeio: /integrations/pagebuilder/components/Block/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/buttons/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/buttons/index.md
@@ -1,5 +1,6 @@
 ---
 title: Buttons
+adobeio: /integrations/pagebuilder/components/Buttons/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/column/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/column/index.md
@@ -1,5 +1,6 @@
 ---
 title: Column
+adobeio: /integrations/pagebuilder/components/Column/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/divider/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/divider/index.md
@@ -1,5 +1,6 @@
 ---
 title: Divider
+adobeio: /integrations/pagebuilder/components/Divider/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/heading/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/heading/index.md
@@ -1,5 +1,6 @@
 ---
 title: Heading
+adobeio: /integrations/pagebuilder/components/Heading/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/html/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/html/index.md
@@ -1,5 +1,6 @@
 ---
 title: HTML Code
+adobeio: /integrations/pagebuilder/components/HTML-Code/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/image/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/image/index.md
@@ -1,5 +1,6 @@
 ---
 title: Image
+adobeio: /integrations/pagebuilder/components/Image/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/map/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/map/index.md
@@ -1,5 +1,6 @@
 ---
 title: Map
+adobeio: /integrations/pagebuilder/components/Map/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/products/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/products/index.md
@@ -1,5 +1,6 @@
 ---
 title: Products
+adobeio: /integrations/pagebuilder/components/Products/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/row/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/row/index.md
@@ -1,5 +1,6 @@
 ---
 title: Row
+adobeio: /integrations/pagebuilder/components/Row/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/slider/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/slider/index.md
@@ -1,5 +1,6 @@
 ---
 title: Slider
+adobeio: /integrations/pagebuilder/components/Slider/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/tabs/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/tabs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Tabs
+adobeio: /integrations/pagebuilder/components/Tabs/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/text/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/text/index.md
@@ -1,5 +1,6 @@
 ---
 title: Text
+adobeio: /integrations/pagebuilder/components/Text/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/components/video/index.md
+++ b/pwa-devdocs/src/pagebuilder/components/video/index.md
@@ -1,5 +1,6 @@
 ---
 title: Video
+adobeio: /integrations/pagebuilder/components/Video/
 ---
 
 <!--

--- a/pwa-devdocs/src/pagebuilder/custom-components/add-aggregator/index.md
+++ b/pwa-devdocs/src/pagebuilder/custom-components/add-aggregator/index.md
@@ -1,5 +1,6 @@
 ---
 title: Add aggregator
+adobeio: /integrations/pagebuilder/custom-components/add-aggregator/
 ---
 
 The purpose of the configuration aggregator (`configAggregator`) is to retrieve properties from a content type's HTML and return those properties as a flat object of `key:values`. The framework (specifically the `<ContentTypeFactory />`) then passes this object to your component, where you can assign the properties to your component's corresponding properties for rendering within a PWA Studio app.

--- a/pwa-devdocs/src/pagebuilder/custom-components/add-component/index.md
+++ b/pwa-devdocs/src/pagebuilder/custom-components/add-component/index.md
@@ -1,5 +1,6 @@
 ---
 title: Add component
+adobeio: /integrations/pagebuilder/custom-components/add-component/
 ---
 
 The purpose of a Page Builder component is to recreate a Page Builder content type (from your Magento instance) to display inside a PWA app. Developing this component is similar to developing other React components in PWA Studio. However, the properties defined within a Page Builder component are determined by the properties returned from your configuration aggregator. The following steps highlight how to put these properties to use in your component:

--- a/pwa-devdocs/src/pagebuilder/custom-components/add-stylesheet/index.md
+++ b/pwa-devdocs/src/pagebuilder/custom-components/add-stylesheet/index.md
@@ -1,5 +1,6 @@
 ---
 title: Add stylesheet
+adobeio: /integrations/pagebuilder/custom-components/add-stylesheet/
 ---
 
 Styling your Page Builder components is the same as styling any other component in PWA Studio. However, the CSS stylesheet for your component should define CSS classes that are comparable to the CSS classes you use on the frontend for original content type (`view/frontend/web/css/source/content-type/<your-content-type>/_import.less`). The following steps highlight the tasks for setting up the CSS classes for your component:

--- a/pwa-devdocs/src/pagebuilder/custom-components/debugging/index.md
+++ b/pwa-devdocs/src/pagebuilder/custom-components/debugging/index.md
@@ -1,5 +1,6 @@
 ---
 title: Debugging tips
+adobeio: /integrations/pagebuilder/custom-components/debugging/
 ---
 
 If you haven't yet modified the config object and setup the references you'll see the following console warning, telling you the component is missing:

--- a/pwa-devdocs/src/pagebuilder/custom-components/overview/index.md
+++ b/pwa-devdocs/src/pagebuilder/custom-components/overview/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+adobeio: /integrations/pagebuilder/custom-components/
 ---
 
 Let's assume you have at least one _custom_ Page Builder content type rendering content on your Magento storefront. But now you want that content to show up in your PWA app as well. What do you do? Short answer: You create a custom PWA Page Builder component (also know as a "content type component"). The long answer is described in this series of topics. The steps shown here describe the recommended process for developing content type components:

--- a/pwa-devdocs/src/pagebuilder/custom-components/setup-component/index.md
+++ b/pwa-devdocs/src/pagebuilder/custom-components/setup-component/index.md
@@ -1,5 +1,6 @@
 ---
 title: Set up component
+adobeio: /integrations/pagebuilder/custom-components/setup/
 ---
 
 Setting up your component is about getting the essential component files in place so that your component is actively participating in the Page Builder component framework. After you create these files and wire them into the component framework, you can focus all your attention on developing each file to faithfully recreate your content type as a PWA component. The following steps highlight the tasks for setting up your component:

--- a/pwa-devdocs/src/pagebuilder/index.md
+++ b/pwa-devdocs/src/pagebuilder/index.md
@@ -1,5 +1,6 @@
 ---
 title: Page Builder to PWA integration
+adobeio: /integrations/pagebuilder/
 ---
 
 {: .bs-callout-info}

--- a/pwa-devdocs/src/pagebuilder/known-limitations/index.md
+++ b/pwa-devdocs/src/pagebuilder/known-limitations/index.md
@@ -1,5 +1,6 @@
 ---
 title: Known limitations
+adobeio: /integrations/pagebuilder/limitations/
 ---
 
 The following items are known limitations to implementing PWA Studio components for Page Builder content types:

--- a/pwa-devdocs/src/pagebuilder/utility-functions/index.md
+++ b/pwa-devdocs/src/pagebuilder/utility-functions/index.md
@@ -1,5 +1,6 @@
 ---
 title: Utility functions
+adobeio: /integrations/pagebuilder/utility-functions/
 ---
 
 The utility functions help with retrieving commonly stored data in a content type. For example, the `getAdvanced(node)` wrapper function retrieves all the content type's Advanced form section settings so you do not have to worry about retrieving each one separately. Retrieving background images and associated properties is also made easy with the `getBackgroundImages(node)` function.

--- a/pwa-devdocs/src/product-recs/index.md
+++ b/pwa-devdocs/src/product-recs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integrating Product Recommendations
+adobeio: /integrations/product-recommendations/
 ---
 
 You can integrate Product Recommendations powered by [Adobe Sensei](https://www.adobe.com/sensei.html) into your PWA Studio storefront.

--- a/pwa-devdocs/src/technologies/upward/index.md
+++ b/pwa-devdocs/src/technologies/upward/index.md
@@ -1,5 +1,6 @@
 ---
 title: UPWARD
+adobeio: /guides/packages/upward/
 ---
 
 **UPWARD** is an acronym for Unified Progressive Web App Response Definition.
@@ -23,7 +24,7 @@ It acts as the backend service for a PWA frontend that is able to proxy requests
 
 ![UPWARD server diagram]({% link technologies/upward/images/upward-server-diagram.png %})
 
-See [RATIONALE.md][] in the `upward-spec` package for a more detailed explanation of the need for an UPWARD server. 
+See [RATIONALE.md][] in the `upward-spec` package for a more detailed explanation of the need for an UPWARD server.
 ### UPWARD definition file
 
 An UPWARD server uses a definition file to determine the appropriate process or service for a request from an application shell.

--- a/pwa-devdocs/src/tutorials/cloud-deploy/index.md
+++ b/pwa-devdocs/src/tutorials/cloud-deploy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Magento Cloud deployment
+adobeio: /tutorials/production-deployment/adobe-commerce/
 ---
 
 [Magento Commerce Cloud][] is a managed, automated hosting platform for the Magento Commerce software.

--- a/pwa-devdocs/src/tutorials/enable-sass-less-support/index.md
+++ b/pwa-devdocs/src/tutorials/enable-sass-less-support/index.md
@@ -1,5 +1,6 @@
 ---
 title: Enable SASS or LESS support
+adobeio: /tutorials/basic-modifications/enable-sass-less/
 ---
 
 This tutorial provides the steps to enable SASS or LESS support in your storefront project.

--- a/pwa-devdocs/src/tutorials/extension-development/index.md
+++ b/pwa-devdocs/src/tutorials/extension-development/index.md
@@ -1,5 +1,6 @@
 ---
 title: Extension development
+adobeio: /tutorials/extensions/
 ---
 
 PWA Studio follows the Magento way of merging third-party code to build web functionality on a simple platform.
@@ -133,7 +134,7 @@ module.exports = (targets) => {
 
 For more information on the Targetables API used in this example, see the following reference pages:
 
-- [Targetables manager][]  
+- [Targetables manager][]
 - [TargetableModule][]
 - [TargetablePublisher][]
 
@@ -214,7 +215,7 @@ yarn add file:../relative/path/to/my-extension
 ```
 
 ```sh
-npm install -S ../relative/path/to/my-extension 
+npm install -S ../relative/path/to/my-extension
 ```
 
 ### Adding as a build dependency

--- a/pwa-devdocs/src/tutorials/extension-development/taglist/index.md
+++ b/pwa-devdocs/src/tutorials/extension-development/taglist/index.md
@@ -1,5 +1,6 @@
 ---
 title: Create a tag list extension
+adobeio: /tutorials/extensions/taglist/
 ---
 
 A tag list is a group of tags associated with a product.
@@ -380,7 +381,6 @@ Next, edit your `package.json` file to point to the location of this extension's
 +     }
     }
   }
-
 ```
 
 ## Install extension locally
@@ -459,12 +459,14 @@ Now, when you start your storefront application and navigate to a product page, 
 
 You can see this extension running live in this [CodeSandbox instance][] or you can check out the source repository in the [`taglist-extension-tutorial`][] branch in the **magento-devdocs/pwa-studio-code-sandbox** GitHub project.
 
+```html
 <iframe src="https://codesandbox.io/embed/github/magento-devdocs/pwa-studio-code-sandbox/tree/taglist-extension-tutorial/?fontsize=12&hidenavigation=1&module=%2Fextensions%2FtagList%2Fpackage.json&moduleview=1&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="dev-sandbox"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
+```
 
 [setup your project]: <{%link tutorials/pwa-studio-fundamentals/project-setup/index.md %}>
 [targets and targetables]: <{%link pwa-buildpack/extensibility-framework/index.md %}>

--- a/pwa-devdocs/src/tutorials/index.md
+++ b/pwa-devdocs/src/tutorials/index.md
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+adobeio: /tutorials/
 ---
 
 PWA Studio is a library of tools and packages designed to help you create a Magento PWA storefront.

--- a/pwa-devdocs/src/tutorials/intercept-a-target/add-new-environment-variable/index.md
+++ b/pwa-devdocs/src/tutorials/intercept-a-target/add-new-environment-variable/index.md
@@ -1,5 +1,6 @@
 ---
 title: Add a new environment variable
+adobeio: /tutorials/targets/add-environment-variable/
 ---
 
 Environment variables provide values that may vary across different instances of the same project.
@@ -241,12 +242,14 @@ module.exports = localIntercept
 
 Now, when you start your project, you can navigate to `/placeholder-image-demo` and see the PlaceholderImage component in action.
 
+```html
 <iframe src="https://codesandbox.io/embed/environment-variable-tutorial-9z0rb?fontsize=11&hidenavigation=1&initialpath=%2Fplaceholder-image-demo&module=%2Fsrc%2Fcomponents%2FPlaceholderImageDemo%2FplaceholderImageDemo.js&theme=dark"
      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
      title="environment-variable-tutorial"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
+```
 
 [core environment variable definitions]: <{%link pwa-buildpack/reference/environment-variables/core-definitions/index.md %}>
 

--- a/pwa-devdocs/src/tutorials/intercept-a-target/index.md
+++ b/pwa-devdocs/src/tutorials/intercept-a-target/index.md
@@ -1,5 +1,6 @@
 ---
 title: Target interception
+adobeio: /tutorials/targets/
 ---
 
 Target interception is a feature provided by PWA Studio's extensibility framework.

--- a/pwa-devdocs/src/tutorials/intercept-a-target/modify-talon-results/index.md
+++ b/pwa-devdocs/src/tutorials/intercept-a-target/modify-talon-results/index.md
@@ -1,5 +1,6 @@
 ---
 title: Modify talon results
+adobeio: /tutorials/targets/modify-talon-results/
 ---
 
 In core Magento development:
@@ -272,4 +273,4 @@ To test the new props data the wrapped talon returns, you will need to create a 
 
 [`npm init`]: https://docs.npmjs.com/cli/init
 [`yarn init`]: https://classic.yarnpkg.com/en/docs/cli/init/
-[plugins (interceptors)]: https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html 
+[plugins (interceptors)]: https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html

--- a/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/add-a-static-route/index.md
+++ b/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/add-a-static-route/index.md
@@ -1,5 +1,6 @@
 ---
 title: Add a static route
+adobeio: /tutorials/basic-modifications/add-static-route/
 ---
 
 Magento's built in CMS system and [PageBuilder][] feature lets you create highly customized content pages for your storefront, but

--- a/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/index.md
+++ b/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/index.md
@@ -1,5 +1,6 @@
 ---
 title: PWA Studio fundamentals
+adobeio: /tutorials/setup-storefront/
 ---
 
 ## Overview

--- a/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/modify-site-footer/index.md
+++ b/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/modify-site-footer/index.md
@@ -1,5 +1,6 @@
 ---
 title: Modify the Footer component
+adobeio: /tutorials/basic-modifications/modify-footer/
 ---
 
 One way to customize a storefront is to modify its UI components.

--- a/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/production-launch-checklist/index.md
+++ b/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/production-launch-checklist/index.md
@@ -1,5 +1,6 @@
 ---
 title: Production launch checklist
+adobeio: /tutorials/production-deployment/checklist/
 ---
 
 Launching a production site is the final step in the storefront development process.

--- a/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/project-setup/index.md
+++ b/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/project-setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Project setup
+adobeio: /tutorials/setup-storefront/
 ---
 
 This tutorial provides the first steps for working with PWA Studio.

--- a/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/project-structure/index.md
+++ b/pwa-devdocs/src/tutorials/pwa-studio-fundamentals/project-structure/index.md
@@ -1,5 +1,6 @@
 ---
 title: Project structure
+adobeio: /tutorials/setup-storefront/file-structure/
 ---
 
 This topic covers the project structure created using the steps outlined in the [Project setup][] tutorial.

--- a/pwa-devdocs/src/venia-ui/reference/components/Button/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Button/index.md
@@ -1,5 +1,6 @@
 ---
 title: Button
+adobeio: /api/venia/components/general/Button/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/ButtonGroup/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/ButtonGroup/index.md
@@ -1,5 +1,6 @@
 ---
 title: ButtonGroup
+adobeio: /api/venia/components/general/ButtonGroup/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/CartPage/GiftCards/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/CartPage/GiftCards/index.md
@@ -1,5 +1,6 @@
 ---
 title: Gift Cards component
+adobeio: /api/venia/components/CartPage/GiftCards/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/CartPage/PriceAdjustments/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/CartPage/PriceAdjustments/index.md
@@ -1,5 +1,6 @@
 ---
 title: Price Adjustments components
+adobeio: /api/venia/components/CartPage/PriceAdjustments/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/CartPage/PriceSummary/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/CartPage/PriceSummary/index.md
@@ -1,5 +1,6 @@
 ---
 title: Price Summary component
+adobeio: /api/venia/components/CartPage/PriceSummary/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/CartPage/ProductListing/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/CartPage/ProductListing/index.md
@@ -1,5 +1,6 @@
 ---
 title: Product Listing components
+adobeio: /api/venia/components/CartPage/ProductListing/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/CartPage/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/CartPage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Cart Page component
+adobeio: /api/venia/components/CartPage/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/Logo/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Logo/index.md
@@ -1,5 +1,6 @@
 ---
 title: Logo
+adobeio: /api/venia/components/general/Logo/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/Mask/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Mask/index.md
@@ -1,5 +1,6 @@
 ---
 title: Mask
+adobeio: /api/venia/components/general/Mask/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/Portal/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Portal/index.md
@@ -1,5 +1,6 @@
 ---
 title: Portal
+adobeio: /api/venia/components/general/Portal/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/ProductImageCarousel/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/ProductImageCarousel/index.md
@@ -1,5 +1,6 @@
 ---
 title: ProductImageCarousel
+adobeio: /api/venia/components/general/ProductImageCarousel/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/ToastContainer/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/ToastContainer/index.md
@@ -1,5 +1,6 @@
 ---
 title: ToastContainer
+adobeio: /api/venia/components/general/ToastContainer/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/components/Trigger/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/components/Trigger/index.md
@@ -1,5 +1,6 @@
 ---
 title: Trigger
+adobeio: /api/venia/components/general/Trigger/
 ---
 
 <!--

--- a/pwa-devdocs/src/venia-ui/reference/targets/index.md
+++ b/pwa-devdocs/src/venia-ui/reference/targets/index.md
@@ -1,5 +1,6 @@
 ---
 title: Venia UI Extensibility Targets
+adobeio: /api/venia/targets/
 ---
 
 This page lists the Targets declared in the Venia UI package. Access these in your intercept files by calling `targets.of('@magento/venia-ui')` on the TargetProvider object.


### PR DESCRIPTION
## Description

Add redirect script pointing to new developer.adobe.com docs site. 

## Related Issue

Closes [PWA-2376](https://jira.corp.magento.com/browse/PWA-2376).

## Acceptance

### Verification Stakeholders

@jcalcaben 

## Verification Steps

1. Pull down the docs/PWA-2376-add-redirect branch locally.
2. `cd` into `pwa-devdocs`. 
3. Run `yarn clean && yarn develop`.
4. You should see a brief flash of the current PWA docs site, followed by a redirect to the home page of https://developer.adobe.com/commerce/pwa-studio/ 

