### PR TITLE
PWA-2232 Updating default messages with variables to match EN

### DIFF
--- a/packages/venia-ui/lib/components/AddressBookPage/__tests__/__snapshots__/addressCard.spec.js.snap
+++ b/packages/venia-ui/lib/components/AddressBookPage/__tests__/__snapshots__/addressCard.spec.js.snap
@@ -44,6 +44,7 @@ exports[`renders a default address 1`] = `
       className="telephone"
     >
       <mock-FormattedMessage
+        defaultMessage="Phone {telephone}"
         id="addressBookPage.telephone"
         values={
           Object {
@@ -146,6 +147,7 @@ exports[`renders a non-default address 1`] = `
       className="telephone"
     >
       <mock-FormattedMessage
+        defaultMessage="Phone {telephone}"
         id="addressBookPage.telephone"
         values={
           Object {
@@ -321,6 +323,7 @@ exports[`renders an address with a middle name 1`] = `
       className="telephone"
     >
       <mock-FormattedMessage
+        defaultMessage="Phone {telephone}"
         id="addressBookPage.telephone"
         values={
           Object {
@@ -431,6 +434,7 @@ exports[`renders delete confirmation if isConfirmingDelete is true 1`] = `
       className="telephone"
     >
       <mock-FormattedMessage
+        defaultMessage="Phone {telephone}"
         id="addressBookPage.telephone"
         values={
           Object {
@@ -597,6 +601,7 @@ exports[`renders disabled delete confirmation if isConfirmingDelete and isDeleti
       className="telephone"
     >
       <mock-FormattedMessage
+        defaultMessage="Phone {telephone}"
         id="addressBookPage.telephone"
         values={
           Object {

--- a/packages/venia-ui/lib/components/AddressBookPage/addressCard.js
+++ b/packages/venia-ui/lib/components/AddressBookPage/addressCard.js
@@ -122,6 +122,7 @@ const AddressCard = props => {
                 <span className={classes.telephone}>
                     <FormattedMessage
                         id="addressBookPage.telephone"
+                        defaultMessage="Phone {telephone}"
                         values={{ telephone }}
                     />
                 </span>

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/__tests__/__snapshots__/productDetail.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/__tests__/__snapshots__/productDetail.spec.js.snap
@@ -25,7 +25,7 @@ exports[`renders product details with base price and in stock 1`] = `
   >
     <span>
       <mock-FormattedMessage
-        defaultMessage="SKU #"
+        defaultMessage="SKU # {sku}"
         id="productDetail.skuNumber"
         values={
           Object {
@@ -82,7 +82,7 @@ exports[`renders product details with unknown stock value 1`] = `
   >
     <span>
       <mock-FormattedMessage
-        defaultMessage="SKU #"
+        defaultMessage="SKU # {sku}"
         id="productDetail.skuNumber"
         values={
           Object {
@@ -139,7 +139,7 @@ exports[`renders product details with variant price and out of stock 1`] = `
   >
     <span>
       <mock-FormattedMessage
-        defaultMessage="SKU #"
+        defaultMessage="SKU # {sku}"
         id="productDetail.skuNumber"
         values={
           Object {

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/__tests__/__snapshots__/productForm.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/__tests__/__snapshots__/productForm.spec.js.snap
@@ -122,7 +122,7 @@ https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/media/catalog/produc
                 >
                   <span>
                     <mock-FormattedMessage
-                      defaultMessage="SKU #"
+                      defaultMessage="SKU # {sku}"
                       id="productDetail.skuNumber"
                       values={
                         Object {
@@ -468,7 +468,7 @@ https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/media/catalog/produc
                 >
                   <span>
                     <mock-FormattedMessage
-                      defaultMessage="SKU #"
+                      defaultMessage="SKU # {sku}"
                       id="productDetail.skuNumber"
                       values={
                         Object {

--- a/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/productDetail.js
+++ b/packages/venia-ui/lib/components/CartPage/ProductListing/EditModal/productDetail.js
@@ -61,7 +61,7 @@ const ProductDetail = props => {
                 <span>
                     <FormattedMessage
                         id={'productDetail.skuNumber'}
-                        defaultMessage={'SKU #'}
+                        defaultMessage={'SKU # {sku}'}
                         values={{ sku }}
                     />
                 </span>

--- a/packages/venia-ui/lib/components/CheckoutPage/ItemsReview/__tests__/__snapshots__/item.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/ItemsReview/__tests__/__snapshots__/item.spec.js.snap
@@ -24,7 +24,7 @@ exports[`Snapshot test 1`] = `
   />
   <span>
     <mock-FormattedMessage
-      defaultMessage="Qty :"
+      defaultMessage="Qty : {quantity}"
       id="checkoutPage.quantity"
       values={
         Object {
@@ -70,7 +70,7 @@ exports[`Snapshot test when configured to use variant image 1`] = `
   />
   <span>
     <mock-FormattedMessage
-      defaultMessage="Qty :"
+      defaultMessage="Qty : {quantity}"
       id="checkoutPage.quantity"
       values={
         Object {

--- a/packages/venia-ui/lib/components/CheckoutPage/ItemsReview/__tests__/__snapshots__/itemsReview.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/ItemsReview/__tests__/__snapshots__/itemsReview.spec.js.snap
@@ -66,7 +66,7 @@ https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/media/catalog/produc
       </dl>
       <span>
         <mock-FormattedMessage
-          defaultMessage="Qty :"
+          defaultMessage="Qty : {quantity}"
           id="checkoutPage.quantity"
           values={
             Object {
@@ -130,7 +130,7 @@ https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/media/catalog/produc
       </dl>
       <span>
         <mock-FormattedMessage
-          defaultMessage="Qty :"
+          defaultMessage="Qty : {quantity}"
           id="checkoutPage.quantity"
           values={
             Object {
@@ -194,7 +194,7 @@ https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/media/catalog/produc
       </dl>
       <span>
         <mock-FormattedMessage
-          defaultMessage="Qty :"
+          defaultMessage="Qty : {quantity}"
           id="checkoutPage.quantity"
           values={
             Object {

--- a/packages/venia-ui/lib/components/CheckoutPage/ItemsReview/item.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/ItemsReview/item.js
@@ -43,7 +43,7 @@ const Item = props => {
             <span className={classes.quantity}>
                 <FormattedMessage
                     id={'checkoutPage.quantity'}
-                    defaultMessage={'Qty :'}
+                    defaultMessage={'Qty : {quantity}'}
                     values={{ quantity }}
                 />
             </span>

--- a/packages/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/__tests__/__snapshots__/orderConfirmationPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/__tests__/__snapshots__/orderConfirmationPage.spec.js.snap
@@ -12,7 +12,7 @@ exports[`OrderConfirmationPage renders OrderConfirmationPage component 1`] = `
     </h2>
     <div>
       <mock-FormattedMessage
-        defaultMessage="Order Number"
+        defaultMessage="Order Number: {orderNumber}"
         id="checkoutPage.orderNumber"
         values={
           Object {

--- a/packages/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/orderConfirmationPage.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/OrderConfirmationPage/orderConfirmationPage.js
@@ -87,7 +87,7 @@ const OrderConfirmationPage = props => {
                 >
                     <FormattedMessage
                         id={'checkoutPage.orderNumber'}
-                        defaultMessage={'Order Number'}
+                        defaultMessage={'Order Number: {orderNumber}'}
                         values={{ orderNumber }}
                     />
                 </div>

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/braintreeSummary.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/braintreeSummary.js
@@ -39,7 +39,7 @@ const BraintreeSummary = props => {
         formatMessage(
             {
                 id: 'checkoutPage.paymentSummary',
-                defaultMessage: 'Card'
+                defaultMessage: '{cardType} ending in {lastFour}'
             },
             {
                 cardType: paymentNonce.details.cardType,

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/editModal.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/editModal.js
@@ -45,7 +45,7 @@ const EditModal = props => {
                     <FormattedMessage
                         id={'checkoutPage.paymentMethodStatus'}
                         defaultMessage={
-                            'The selected method is not supported for editing.'
+                            '{selectedPaymentMethod} is not supported for editing.'
                         }
                         values={{ selectedPaymentMethod }}
                     />

--- a/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
@@ -296,7 +296,10 @@ const CheckoutPage = props => {
             });
         } else {
             headerText = formatMessage(
-                { id: 'checkoutPage.greeting', defaultMessage: 'Welcome' },
+                {
+                    id: 'checkoutPage.greeting',
+                    defaultMessage: 'Welcome {firstname}!'
+                },
                 { firstname: customer.firstname }
             );
         }

--- a/packages/venia-ui/lib/components/FilterModal/CurrentFilters/currentFilter.js
+++ b/packages/venia-ui/lib/components/FilterModal/CurrentFilters/currentFilter.js
@@ -23,7 +23,7 @@ const CurrentFilter = props => {
     const ariaLabel = formatMessage(
         {
             id: 'filterModal.action.clearFilterItem.ariaLabel',
-            defaultMessage: 'Clear filter'
+            defaultMessage: 'Clear filter "{name}"'
         },
         {
             name: item.title

--- a/packages/venia-ui/lib/components/FilterModal/FilterList/filterDefault.js
+++ b/packages/venia-ui/lib/components/FilterModal/FilterList/filterDefault.js
@@ -17,7 +17,7 @@ const FilterDefault = props => {
         ? formatMessage(
               {
                   id: 'filterModal.item.applyFilter',
-                  defaultMessage: 'Apply filter'
+                  defaultMessage: 'Apply filter "{optionName}".'
               },
               {
                   optionName: label
@@ -26,7 +26,7 @@ const FilterDefault = props => {
         : formatMessage(
               {
                   id: 'filterModal.item.clearFilter',
-                  defaultMessage: 'Remove filter'
+                  defaultMessage: 'Remove filter "{optionName}".'
               },
               {
                   optionName: label

--- a/packages/venia-ui/lib/components/FilterModal/filterBlock.js
+++ b/packages/venia-ui/lib/components/FilterModal/filterBlock.js
@@ -36,7 +36,7 @@ const FilterBlock = props => {
     const itemAriaLabel = formatMessage(
         {
             id: 'filterModal.item.ariaLabel',
-            defaultMessage: 'Filter products by'
+            defaultMessage: 'Filter products by "{itemName}"'
         },
         {
             itemName: name
@@ -47,7 +47,7 @@ const FilterBlock = props => {
         ? formatMessage(
               {
                   id: 'filterModal.item.hideOptions',
-                  defaultMessage: 'Hide filter item options.'
+                  defaultMessage: 'Hide "{itemName}" filter item options.'
               },
               {
                   itemName: name
@@ -56,7 +56,7 @@ const FilterBlock = props => {
         : formatMessage(
               {
                   id: 'filterModal.item.showOptions',
-                  defaultMessage: 'Show filter item options.'
+                  defaultMessage: 'Show "{itemName}" filter item options.'
               },
               {
                   itemName: name

--- a/packages/venia-ui/lib/components/ForgotPassword/FormSubmissionSuccessful/formSubmissionSuccessful.js
+++ b/packages/venia-ui/lib/components/ForgotPassword/FormSubmissionSuccessful/formSubmissionSuccessful.js
@@ -14,7 +14,7 @@ const FormSubmissionSuccessful = props => {
         {
             id: 'formSubmissionSuccessful.textMessage',
             defaultMessage:
-                'If there is an account associated with your email address, you will receive an email with a link to change your password.'
+                'If there is an account associated with {email} you will receive an email with a link to change your password.'
         },
         { email }
     );

--- a/packages/venia-ui/lib/components/MiniCart/ProductList/__tests__/__snapshots__/item.spec.js.snap
+++ b/packages/venia-ui/lib/components/MiniCart/ProductList/__tests__/__snapshots__/item.spec.js.snap
@@ -67,7 +67,7 @@ exports[`Should disable delete icon while loading 1`] = `
     className="quantity"
   >
     <mock-FormattedMessage
-      defaultMessage="Qty :"
+      defaultMessage="Qty : {quantity}"
       id="productList.quantity"
       values={
         Object {
@@ -213,7 +213,7 @@ exports[`Should render correctly 1`] = `
     className="quantity"
   >
     <mock-FormattedMessage
-      defaultMessage="Qty :"
+      defaultMessage="Qty : {quantity}"
       id="productList.quantity"
       values={
         Object {
@@ -359,7 +359,7 @@ exports[`Should render correctly when configured to use variant thumbnail 1`] = 
     className="quantity"
   >
     <mock-FormattedMessage
-      defaultMessage="Qty :"
+      defaultMessage="Qty : {quantity}"
       id="productList.quantity"
       values={
         Object {
@@ -505,7 +505,7 @@ exports[`Should render correctly with out of stock product 1`] = `
     className="quantity"
   >
     <mock-FormattedMessage
-      defaultMessage="Qty :"
+      defaultMessage="Qty : {quantity}"
       id="productList.quantity"
       values={
         Object {

--- a/packages/venia-ui/lib/components/MiniCart/ProductList/item.js
+++ b/packages/venia-ui/lib/components/MiniCart/ProductList/item.js
@@ -89,7 +89,7 @@ const Item = props => {
             <span className={classes.quantity}>
                 <FormattedMessage
                     id={'productList.quantity'}
-                    defaultMessage={'Qty :'}
+                    defaultMessage={'Qty : {quantity}'}
                     values={{ quantity }}
                 />
             </span>

--- a/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/miniCart.spec.js.snap
+++ b/packages/venia-ui/lib/components/MiniCart/__tests__/__snapshots__/miniCart.spec.js.snap
@@ -46,7 +46,7 @@ exports[`it renders correctly 1`] = `
         className="quantity"
       >
         <mock-FormattedMessage
-          defaultMessage="Items"
+          defaultMessage="{totalQuantity} Items"
           id="miniCart.totalQuantity"
           values={
             Object {

--- a/packages/venia-ui/lib/components/MiniCart/miniCart.js
+++ b/packages/venia-ui/lib/components/MiniCart/miniCart.js
@@ -83,7 +83,7 @@ const MiniCart = React.forwardRef((props, ref) => {
             <span className={quantityClassName}>
                 <FormattedMessage
                     id={'miniCart.totalQuantity'}
-                    defaultMessage={'Items'}
+                    defaultMessage={'{totalQuantity} Items'}
                     values={{ totalQuantity }}
                 />
             </span>

--- a/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/__tests__/__snapshots__/item.spec.js.snap
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/__tests__/__snapshots__/item.spec.js.snap
@@ -57,7 +57,7 @@ https://www.venia.com/product1-thumbnail.jpg?auto=webp&format=pjpg&width=2560&he
   </dl>
   <span>
     <mock-FormattedMessage
-      defaultMessage="Qty"
+      defaultMessage="Qty : {quantity}"
       id="orderDetails.quantity"
       values={
         Object {

--- a/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/__tests__/__snapshots__/shippingMethod.spec.js.snap
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/__tests__/__snapshots__/shippingMethod.spec.js.snap
@@ -30,6 +30,7 @@ exports[`should render properly 1`] = `
   <div>
     <span>
       <mock-FormattedMessage
+        defaultMessage="<strong>Tracking number:</strong> {number}"
         id="orderDetails.trackingInformation"
         values={
           Object {
@@ -41,6 +42,7 @@ exports[`should render properly 1`] = `
     </span>
     <span>
       <mock-FormattedMessage
+        defaultMessage="<strong>Tracking number:</strong> {number}"
         id="orderDetails.trackingInformation"
         values={
           Object {
@@ -52,6 +54,7 @@ exports[`should render properly 1`] = `
     </span>
     <span>
       <mock-FormattedMessage
+        defaultMessage="<strong>Tracking number:</strong> {number}"
         id="orderDetails.trackingInformation"
         values={
           Object {

--- a/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/item.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/item.js
@@ -64,7 +64,7 @@ const Item = props => {
             <span className={classes.quantity}>
                 <FormattedMessage
                     id="orderDetails.quantity"
-                    defaultMessage="Qty"
+                    defaultMessage="Qty : {quantity}"
                     values={{
                         quantity: quantity_ordered
                     }}

--- a/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/shippingMethod.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/OrderDetails/shippingMethod.js
@@ -23,6 +23,7 @@ const ShippingMethod = props => {
                         <span className={classes.trackingRow} key={number}>
                             <FormattedMessage
                                 id="orderDetails.trackingInformation"
+                                defaultMessage="<strong>Tracking number:</strong> {number}"
                                 values={{
                                     number,
                                     strong: chunks => <strong>{chunks}</strong>

--- a/packages/venia-ui/lib/components/ProductOptions/__tests__/__snapshots__/option.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductOptions/__tests__/__snapshots__/option.spec.js.snap
@@ -17,7 +17,7 @@ exports[`renders Option component correctly 1`] = `
       className="selectionLabel"
     >
       <mock-FormattedMessage
-        defaultMessage="Selected Foo:"
+        defaultMessage="Selected {label}:"
         id="productOptions.selectedLabel"
         values={
           Object {

--- a/packages/venia-ui/lib/components/ProductOptions/__tests__/__snapshots__/options.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductOptions/__tests__/__snapshots__/options.spec.js.snap
@@ -20,7 +20,7 @@ Array [
         className="selectionLabel"
       >
         <mock-FormattedMessage
-          defaultMessage="Selected option-1:"
+          defaultMessage="Selected {label}:"
           id="productOptions.selectedLabel"
           values={
             Object {
@@ -52,7 +52,7 @@ Array [
         className="selectionLabel"
       >
         <mock-FormattedMessage
-          defaultMessage="Selected option-1:"
+          defaultMessage="Selected {label}:"
           id="productOptions.selectedLabel"
           values={
             Object {

--- a/packages/venia-ui/lib/components/ProductOptions/option.js
+++ b/packages/venia-ui/lib/components/ProductOptions/option.js
@@ -71,7 +71,7 @@ const Option = props => {
                 <dt className={classes.selectionLabel}>
                     <FormattedMessage
                         id="productOptions.selectedLabel"
-                        defaultMessage={`Selected ${label}:`}
+                        defaultMessage="Selected {label}:"
                         values={{ label }}
                     />
                 </dt>

--- a/packages/venia-ui/lib/components/SearchBar/suggestedCategory.js
+++ b/packages/venia-ui/lib/components/SearchBar/suggestedCategory.js
@@ -24,7 +24,7 @@ const SuggestedCategory = props => {
             <span className={classes.label}>
                 <FormattedMessage
                     id={'searchBar.label'}
-                    defaultMessage={' in category'}
+                    defaultMessage={' in {label}'}
                     values={{
                         label
                     }}

--- a/packages/venia-ui/lib/components/SearchPage/__tests__/__snapshots__/searchPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/SearchPage/__tests__/__snapshots__/searchPage.spec.js.snap
@@ -573,7 +573,7 @@ exports[`Search Page Component search results heading renders a specific message
         className="searchInfo"
       >
         <mock-FormattedMessage
-          defaultMessage="Showing results:"
+          defaultMessage="Showing results for <highlight>{term}</highlight>{category, select, null {} other { in <highlight>{category}</highlight>}}:"
           id="searchPage.searchTerm"
           values={
             Object {

--- a/packages/venia-ui/lib/components/SearchPage/searchPage.js
+++ b/packages/venia-ui/lib/components/SearchPage/searchPage.js
@@ -152,7 +152,7 @@ const SearchPage = props => {
                 category: searchCategory,
                 term: searchTerm
             }}
-            defaultMessage={'Showing results:'}
+            defaultMessage="Showing results for <highlight>{term}</highlight>{category, select, null {} other { in <highlight>{category}</highlight>}}:"
         />
     ) : (
         <FormattedMessage
@@ -167,7 +167,7 @@ const SearchPage = props => {
                 {formatMessage(
                     {
                         id: 'searchPage.totalPages',
-                        defaultMessage: `items`
+                        defaultMessage: '{totalCount} items'
                     },
                     { totalCount: productsCount }
                 )}

--- a/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlistPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlistPage.spec.js.snap
@@ -8,7 +8,7 @@ exports[`empty single wishlist 1`] = `
     className="heading"
   >
     <mock-FormattedMessage
-      defaultMessage="Favorites Lists"
+      defaultMessage="{count, plural, one {Favorites List} other {Favorites Lists}}"
       id="wishlistPage.headingText"
       values={
         Object {
@@ -30,7 +30,7 @@ exports[`renders a single wishlist without visibility toggle 1`] = `
     className="heading"
   >
     <mock-FormattedMessage
-      defaultMessage="Favorites Lists"
+      defaultMessage="{count, plural, one {Favorites List} other {Favorites Lists}}"
       id="wishlistPage.headingText"
       values={
         Object {
@@ -60,7 +60,7 @@ exports[`renders disabled feature error 1`] = `
     className="heading"
   >
     <mock-FormattedMessage
-      defaultMessage="Favorites Lists"
+      defaultMessage="{count, plural, one {Favorites List} other {Favorites Lists}}"
       id="wishlistPage.headingText"
       values={
         Object {
@@ -90,7 +90,7 @@ exports[`renders general fetch error 1`] = `
     className="heading"
   >
     <mock-FormattedMessage
-      defaultMessage="Favorites Lists"
+      defaultMessage="{count, plural, one {Favorites List} other {Favorites Lists}}"
       id="wishlistPage.headingText"
       values={
         Object {
@@ -202,7 +202,7 @@ exports[`renders wishlist data 1`] = `
     className="heading"
   >
     <mock-FormattedMessage
-      defaultMessage="Favorites Lists"
+      defaultMessage="{count, plural, one {Favorites List} other {Favorites Lists}}"
       id="wishlistPage.headingText"
       values={
         Object {

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistPage.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistPage.js
@@ -85,7 +85,9 @@ const WishlistPage = props => {
                 <FormattedMessage
                     values={{ count: wishlists.length }}
                     id={'wishlistPage.headingText'}
-                    defaultMessage={'Favorites Lists'}
+                    defaultMessage={
+                        '{count, plural, one {Favorites List} other {Favorites Lists}}'
+                    }
                 />
             </h1>
             {content}

--- a/packages/venia-ui/lib/util/formValidators.js
+++ b/packages/venia-ui/lib/util/formValidators.js
@@ -11,7 +11,7 @@ const SUCCESS = undefined;
 export const hasLengthAtLeast = (value, values, minimumLength) => {
     const message = {
         id: 'validation.hasLengthAtLeast',
-        defaultMessage: 'Must contain more characters',
+        defaultMessage: 'Must contain at least {value} character(s).',
         value: minimumLength
     };
     if (!value || value.length < minimumLength) {
@@ -25,7 +25,7 @@ export const hasLengthAtMost = (value, values, maximumLength) => {
     if (value && value.length > maximumLength) {
         const message = {
             id: 'validation.hasLengthAtMost',
-            defaultMessage: 'Must have less characters',
+            defaultMessage: 'Must not exceed {value} character(s).',
             value: maximumLength
         };
         return message;
@@ -38,7 +38,7 @@ export const hasLengthExactly = (value, values, length) => {
     if (value && value.length !== length) {
         const message = {
             id: 'validation.hasLengthExactly',
-            defaultMessage: 'Does not have exact number of characters',
+            defaultMessage: 'Must contain exactly {value} character(s).',
             value: length
         };
         return message;
@@ -86,7 +86,7 @@ export const validateRegionCode = (value, values, countries) => {
     if (!country) {
         const invalidCountry = {
             id: 'validation.invalidCountry',
-            defaultMessage: `Country "${countryCode}" is not an available country.`,
+            defaultMessage: 'Country "{value}" is not an available country.',
             value: countryCode
         };
         return invalidCountry;
@@ -96,7 +96,8 @@ export const validateRegionCode = (value, values, countries) => {
     if (!(Array.isArray(regions) && regions.length)) {
         const invalidRegions = {
             id: 'validation.invalidRegions',
-            defaultMessage: `Country "${countryCode}" does not contain any available regions.`,
+            defaultMessage:
+                'Country "{value}" does not contain any available regions.',
             value: countryCode
         };
         return invalidRegions;
@@ -106,7 +107,8 @@ export const validateRegionCode = (value, values, countries) => {
     if (!region) {
         const invalidAbbrev = {
             id: 'validation.invalidAbbreviation',
-            defaultMessage: 'That is not a valid state abbreviation.',
+            defaultMessage:
+                'State "{value}" is not a valid state abbreviation.',
             value: value
         };
         return invalidAbbrev;
@@ -145,7 +147,7 @@ export const validatePassword = value => {
 export const isEqualToField = (value, values, fieldKey) => {
     const message = {
         id: 'validation.isEqualToField',
-        defaultMessage: 'Fields must match',
+        defaultMessage: '{value} must match.',
         value: fieldKey
     };
     return value === values[fieldKey] ? SUCCESS : message;
@@ -154,7 +156,7 @@ export const isEqualToField = (value, values, fieldKey) => {
 export const isNotEqualToField = (value, values, fieldKey) => {
     const message = {
         id: 'validation.isNotEqualToField',
-        defaultMessage: 'Fields must be different',
+        defaultMessage: '{value} must be different',
         value: fieldKey
     };
     return value !== values[fieldKey] ? SUCCESS : message;


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Default messages whose EN version contained a variable were frequently missing the variable. This lead to messages like `Qty: ` in the mini-cart and elsewhere. This PR sets the default value for formatted texts to be equal to their EN values (containing the variables)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes PWA-2232

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

- Test a store view whose locale is not EN
- Make sure translation file was not loaded
- Mini-cart item's quantity should contain the number value

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

- [ ] ~I have added tests to cover my changes, if necessary.~
- [ ] ~I have added translations for new strings, if necessary.~
- [ ] ~I have updated the documentation accordingly, if necessary.~
