### PR TITLE
PWA-2447-redirect to table page on new docs site

### DIFF
--- a/pwa-devdocs/src/technologies/features/index.md
+++ b/pwa-devdocs/src/technologies/features/index.md
@@ -1,5 +1,6 @@
 ---
 title: Commerce features
+adobeio: /integrations/adobe-commerce/features/
 ---
 
 PWA Studio's storefront app — Venia — provides the following out-of-the-box coverage for Adobe Commerce and Magento Open Source features. The icons show the current and planned coverage of each Commerce feature. Features that are not implemented — and not yet on our roadmap — show that custom implementation is required.


### PR DESCRIPTION
## Description

This PR adds a page redirect for the Commerce features table to the new page in the PWA adobeio docs site.

## Related Issue

Closes JIRA PWA-2447

## Acceptance

### Verification Stakeholders

@jcalcaben 

## Verification Steps

Already deployed from branch so the redirect can be tested by clicking this link to see if the redirection works (it does): 
https://magento.github.io/pwa-studio/technologies/features/
