### PR TITLE
Updated known issue with Safari toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ As mentioned above, we not only introduced metapackages in this release, we used
 
 ## Known Issues
 
-No known issues.
+-  Safari (macOS version) does not show toast messages or indicators when Venia switches between online and offline.
 
 ## Test Updates
 


### PR DESCRIPTION
## Description

Update to Changelog to include known issue for Safari (macOS) not displaying toast messages for offline/online changes.

## Related Issue

Closes JIRA PWA-2234

## Acceptance

### Verification Stakeholders

@supernova-at 
@davemacaulay 

## Verification Steps

Review change.
