### PR TITLE
[PWA-2433] Fixes console warning for currency

### DIFF
--- a/packages/peregrine/lib/Apollo/policies/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/peregrine/lib/Apollo/policies/__tests__/__snapshots__/index.spec.js.snap
@@ -79,6 +79,9 @@ Object {
   "ConfigurableWishlistItem": Object {
     "keyFields": [Function],
   },
+  "Currency": Object {
+    "merge": true,
+  },
   "Customer": Object {
     "fields": Object {
       "addresses": Object {

--- a/packages/peregrine/lib/Apollo/policies/index.js
+++ b/packages/peregrine/lib/Apollo/policies/index.js
@@ -165,6 +165,9 @@ const typePolicies = {
             }
         }
     },
+    Currency: {
+        merge: true
+    },
     ProductImage: {
         keyFields: ['url']
     },


### PR DESCRIPTION
## Description

- Fixes console warning for currency after upgrading Apollo

## Related Issue

Closes [#2433](https://jira.corp.magento.com/browse/PWA-2433)

## Acceptance

### Verification Stakeholders

### Specification

## Verification Steps

#### Test scenario(s) for direct fix/feature

#### Test scenario(s) for any existing impacted features/areas