### PR TITLE
[PWA-2483] Duplicated styles issue

### DIFF
--- a/packages/pwa-buildpack/lib/WebpackTools/configureWebpack/getModuleRules.js
+++ b/packages/pwa-buildpack/lib/WebpackTools/configureWebpack/getModuleRules.js
@@ -157,13 +157,15 @@ getModuleRules.css = async ({ hasFlag, mode }) => ({
                 {
                     loader: 'css-loader',
                     options: {
+                        importLoaders: 1,
                         modules: {
                             getLocalIdent,
                             localIdentName: `[name]-[local]-[hash:base64:3]`
                         },
                         sourceMap: mode === 'development'
                     }
-                }
+                },
+                'postcss-loader'
             ]
         },
         {
@@ -180,6 +182,7 @@ getModuleRules.css = async ({ hasFlag, mode }) => ({
                 {
                     loader: 'css-loader',
                     options: {
+                        importLoaders: 1,
                         modules: false,
                         sourceMap: mode === 'development'
                     }

--- a/packages/pwa-buildpack/lib/WebpackTools/configureWebpack/getModuleRules.js
+++ b/packages/pwa-buildpack/lib/WebpackTools/configureWebpack/getModuleRules.js
@@ -163,8 +163,7 @@ getModuleRules.css = async ({ hasFlag, mode }) => ({
                         },
                         sourceMap: mode === 'development'
                     }
-                },
-                'postcss-loader'
+                }
             ]
         },
         {


### PR DESCRIPTION
## Description

Fix duplicated styles on pages and components
Introduced in release 12.0.0 with Tailwind : https://github.com/magento/pwa-studio/pull/3341/files#diff-bbf9b70c8bd565e8bdb2418aebe2b72e01037971442894d4798ee71a93dc837a

## Related Issue

Closes PWA-2483
Closes #3634

---

Also related to PWA-2412 and issue #3547

## Acceptance


### Verification Stakeholders

Project maintainers

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps



#### Test scenario(s) for direct fix/feature

1. Inspect element on the "Add to Cart" button on the PDP and verify that its styles are not duplicated (example: class="button-content-[hash]" element)
2. Inspect element on the "Add to Cart" button on a Category landing page and verify that its styles are not duplicated (example: class="button-content-[hash]" element)
3. Inspect element on a product image on the Search results page and verify that its styles are not duplicated (example: class="item-image-[hash]" element)

#### Test scenario(s) for any existing impacted features/areas

1. Check that build is working properly
2. Check that Tailwind header is still showing properly

#### Test scenario(s) for any Magento Backend Supported Configurations

N/A

#### Is Browser/Device testing needed?

No

#### Any ad-hoc/edge case scenarios that need to be considered?

No

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

No breaking change

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
