### PR TITLE
[PWA-2575] Wishlist page error when configured variant added

### DIFF
--- a/packages/peregrine/lib/Apollo/policies/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/peregrine/lib/Apollo/policies/__tests__/__snapshots__/index.spec.js.snap
@@ -151,10 +151,7 @@ Object {
     },
   },
   "SelectedConfigurableOption": Object {
-    "keyFields": Array [
-      "configurable_product_option_uid",
-      "configurable_product_option_value_uid",
-    ],
+    "keyFields": [Function],
   },
   "SelectedPaymentMethod": Object {
     "keyFields": Array [

--- a/packages/peregrine/lib/Apollo/policies/__tests__/index.spec.js
+++ b/packages/peregrine/lib/Apollo/policies/__tests__/index.spec.js
@@ -46,6 +46,22 @@ describe('keyArgs property for Query.fields entries', () => {
     });
 });
 
+test('SelectedConfigurableOption returns correct key fields base on available data', () => {
+    const { SelectedConfigurableOption } = typePolicies;
+    expect(SelectedConfigurableOption.keyFields({ id: 1 })).toStrictEqual([
+        'id',
+        'value_id'
+    ]);
+    expect(
+        SelectedConfigurableOption.keyFields({
+            configurable_product_option_uid: 1
+        })
+    ).toStrictEqual([
+        'configurable_product_option_uid',
+        'configurable_product_option_value_uid'
+    ]);
+});
+
 describe('Cart type provides the correct values', () => {
     const { keyFields, fields } = typePolicies.Cart;
 
@@ -368,7 +384,8 @@ test('wishlist entities have correct keys', () => {
         BundleWishlistItem,
         GroupedProductWishlistItem,
         ConfigurableWishlistItem,
-        GiftCardWishlistItem
+        GiftCardWishlistItem,
+        SelectedConfigurableOption
     } = typePolicies;
     expect(Wishlist.keyFields({ id: 1 })).toBe('CustomerWishlist:1');
     expect(WishlistItem.keyFields({ id: 1 })).toBe('CustomerWishlistItem:1');
@@ -393,6 +410,10 @@ test('wishlist entities have correct keys', () => {
     expect(GiftCardWishlistItem.keyFields({ id: 1 })).toBe(
         'CustomerGiftCardWishlistItem:1'
     );
+    expect(SelectedConfigurableOption.keyFields({ id: 1 })).toStrictEqual([
+        'id',
+        'value_id'
+    ]);
 });
 
 test('local customerWishlistProducts field returns expected data', () => {

--- a/packages/peregrine/lib/Apollo/policies/index.js
+++ b/packages/peregrine/lib/Apollo/policies/index.js
@@ -177,10 +177,15 @@ const typePolicies = {
     SelectedConfigurableOption: {
         // id alone is not enough to identify a selected option as it can refer
         // to something like "size" where value_id refers to "large".
-        keyFields: [
-            'configurable_product_option_uid',
-            'configurable_product_option_value_uid'
-        ]
+        // TODO: Use configurable_product_option_uid for ConfigurableWishlistItem when available in 2.4.5
+        keyFields: fields => {
+            return fields.configurable_product_option_uid
+                ? [
+                      'configurable_product_option_uid',
+                      'configurable_product_option_value_uid'
+                  ]
+                : ['id', 'value_id'];
+        }
     },
     SelectedPaymentMethod: {
         keyFields: ['code']

--- a/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlistItem.spec.js
+++ b/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlistItem.spec.js
@@ -84,8 +84,8 @@ test('mutation passes options for configurable item', () => {
             ...baseProps.item,
             configurable_options: [
                 {
-                    configurable_product_option_uid: 'option-1',
-                    configurable_product_option_value_uid: 'value-1'
+                    id: 'option-1',
+                    value_id: 'value-1'
                 }
             ],
             product: {

--- a/packages/peregrine/lib/talons/WishlistPage/useWishlistItem.js
+++ b/packages/peregrine/lib/talons/WishlistPage/useWishlistItem.js
@@ -80,9 +80,10 @@ export const useWishlistItem = props => {
         ) {
             const selectedOptionsArray = selectedConfigurableOptions.map(
                 selectedOption => {
+                    // TODO: Use configurable_product_option_uid for ConfigurableWishlistItem when available in 2.4.5
                     const {
-                        configurable_product_option_uid: attributeId,
-                        configurable_product_option_value_uid: selectedValueId
+                        id: attributeId,
+                        value_id: selectedValueId
                     } = selectedOption;
                     const configurableOption = configurableOptions.find(
                         option => option.attribute_id_v2 === attributeId

--- a/packages/peregrine/lib/talons/WishlistPage/wishlistItemFragments.gql.js
+++ b/packages/peregrine/lib/talons/WishlistPage/wishlistItemFragments.gql.js
@@ -47,6 +47,7 @@ export const WishlistItemFragment = gql`
                 }
             }
         }
+        # TODO: Use configurable_product_option_uid for ConfigurableWishlistItem when available in 2.4.5
         ... on ConfigurableWishlistItem {
             configurable_options {
                 id

--- a/venia-integration-tests/src/fixtures/productPage/index.js
+++ b/venia-integration-tests/src/fixtures/productPage/index.js
@@ -8,6 +8,11 @@ export const productCarminaEarrings = {
     url: '/carmina-earrings.html'
 };
 
+export const productJunoSweater = {
+    name: 'Juno Sweater',
+    url: '/juno-sweater.html'
+};
+
 export const productValeriaTwoLayeredTank = {
     name: 'Valeria Two-Layer Tank',
     url: '/valeria-two-layer-tank.html',

--- a/venia-integration-tests/src/tests/e2eTests/wishList/singleWishlistAddRemoveProduct.spec.js
+++ b/venia-integration-tests/src/tests/e2eTests/wishList/singleWishlistAddRemoveProduct.spec.js
@@ -34,6 +34,7 @@ const { cartPageRoute } = cartPageFixtures;
 const { homePage } = homePageFixtures;
 const { wishlistRoute } = wishlistFixtures;
 const {
+    productJunoSweater,
     productValeriaTwoLayeredTank,
     silverAmorBangleSet
 } = productPageFixtures;
@@ -44,7 +45,8 @@ const { goToMyAccount } = myAccountMenuActions;
 const { addProductToWishlistFromCategoryPage } = categoryPageActions;
 const {
     addProductToWishlistFromProductPage,
-    addToCartFromProductPage
+    addToCartFromProductPage,
+    selectOptionsFromProductPage
 } = productPageActions;
 const { removeProductFromSingleWishlist } = wishlistPageActions;
 
@@ -92,6 +94,7 @@ describe('PWA-1781: verify single wishlist basic features', () => {
         assertWishlistHeading(wishlistPage);
         assertEmptyWishlistExists('Wish List');
 
+        // Add Configurable Product from Catalog Page
         cy.visitPage(categorySweaters);
         addProductToWishlistFromCategoryPage(productCarinaCardigan);
 
@@ -105,7 +108,17 @@ describe('PWA-1781: verify single wishlist basic features', () => {
 
         assertProductInWishlist(productCarinaCardigan);
 
+        // Add Configurable Product from Product Detail Page without options selected
         cy.visitPage(productValeriaTwoLayeredTank.url);
+        addProductToWishlistFromProductPage();
+
+        cy.wait(['@gqlAddProductToWishlistFromGalleryMutation'], {
+            timeout: 60000
+        });
+
+        // Add Configurable Product from Product Detail Page with options selected
+        cy.visitPage(productJunoSweater.url);
+        selectOptionsFromProductPage();
         addProductToWishlistFromProductPage();
 
         cy.wait(['@gqlAddProductToWishlistFromGalleryMutation'], {
@@ -116,7 +129,9 @@ describe('PWA-1781: verify single wishlist basic features', () => {
 
         assertProductInWishlist(productCarinaCardigan);
         assertProductInWishlist(productValeriaTwoLayeredTank.name);
+        assertProductInWishlist(productJunoSweater.name);
 
+        // Add Simple Product to Cart
         cy.visitPage(silverAmorBangleSet.url);
         addToCartFromProductPage();
 
@@ -124,6 +139,7 @@ describe('PWA-1781: verify single wishlist basic features', () => {
             timeout: 60000
         });
 
+        // Move Simple Product from Cart
         cy.visitPage(cartPageRoute);
         moveProductFromCartToSingleWishlist(silverAmorBangleSet.name);
 
@@ -137,6 +153,7 @@ describe('PWA-1781: verify single wishlist basic features', () => {
         assertProductInWishlist(productValeriaTwoLayeredTank.name);
         assertProductInWishlist(silverAmorBangleSet.name);
 
+        // Remove Product
         removeProductFromSingleWishlist(productCarinaCardigan);
 
         cy.wait(['@gqlRemoveProductsFromWishlistMutation'], {


### PR DESCRIPTION
…ishlist

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

`ConfigurableWishlistItem` cannot get `configurable_product_option_uid` and `configurable_product_option_value_uid` until fix planned for 2.4.5.
This fix will use the previous way to get the options data by using `id` and `value_id` instead.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes https://jira.corp.magento.com/browse/PWA-2575.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

- Add Simple Product on "Favorites List" from Catalog Page.
- Add Configurable Product on "Favorites List" from Catalog Page.
- Add Simple Product on "Favorites List" from Product Detail Page.
- Add Configurable Product on "Favorites List" from Product Detail Page.
- Go to Favorites List Page and validate products are there.
- Remove products from list.
- Move products from list to cart and vice-versa.
- Test multiple wishlist feature.
- Run updated Cypress test `venia-integration-tests/src/tests/e2eTests/wishList/singleWishlistAddRemoveProduct.spec.js`.

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
