### PR TITLE
[PWA-2554] - Long wishlist name length breaks layout

### DIFF
--- a/packages/venia-ui/lib/components/Wishlist/WishlistDialog/WishlistLineItem/__tests__/__snapshots__/wishlistLineItem.spec.js.snap
+++ b/packages/venia-ui/lib/components/Wishlist/WishlistDialog/WishlistLineItem/__tests__/__snapshots__/wishlistLineItem.spec.js.snap
@@ -6,5 +6,9 @@ exports[`renders the correct tree 1`] = `
   disabled={false}
   onClick={[Function]}
   type="button"
-/>
+>
+  <h2
+    className="lineItemName"
+  />
+</button>
 `;

--- a/packages/venia-ui/lib/components/Wishlist/WishlistDialog/WishlistLineItem/wishlistLineItem.js
+++ b/packages/venia-ui/lib/components/Wishlist/WishlistDialog/WishlistLineItem/wishlistLineItem.js
@@ -20,7 +20,13 @@ const WishlistLineItem = props => {
             onClick={handleClick}
             data-cy="WishlistLineItem-button"
         >
-            {props.children}
+            <h2
+                className={classes.lineItemName}
+                data-cy="WishlistLineItem-name"
+                title={props.children}
+            >
+                {props.children}
+            </h2>
         </button>
     );
 };

--- a/packages/venia-ui/lib/components/Wishlist/WishlistDialog/WishlistLineItem/wishlistLineItem.module.css
+++ b/packages/venia-ui/lib/components/Wishlist/WishlistDialog/WishlistLineItem/wishlistLineItem.module.css
@@ -6,3 +6,10 @@
     font-weight: var(--venia-global-fontWeight-semibold);
     height: 3.5rem;
 }
+
+.lineItemName {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 600px;
+}

--- a/packages/venia-ui/lib/components/Wishlist/WishlistDialog/__tests__/__snapshots__/wishlistDialog.spec.js.snap
+++ b/packages/venia-ui/lib/components/Wishlist/WishlistDialog/__tests__/__snapshots__/wishlistDialog.spec.js.snap
@@ -41,7 +41,12 @@ exports[`renders existing wishlists 1`] = `
           onClick={[Function]}
           type="button"
         >
-          "Scott's Wishlist"
+          <h2
+            className="lineItemName"
+            title="\\"Scott's Wishlist\\""
+          >
+            "Scott's Wishlist"
+          </h2>
         </button>
       </li>
     </ul>

--- a/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlist.spec.js.snap
+++ b/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlist.spec.js.snap
@@ -12,6 +12,7 @@ exports[`hides visibility toggle 1`] = `
     >
       <h2
         className="name"
+        title="Favorites List"
       >
         Favorites List
       </h2>
@@ -79,6 +80,7 @@ exports[`render closed with items 1`] = `
     >
       <h2
         className="name"
+        title="Favorites List"
       >
         Favorites List
       </h2>
@@ -146,6 +148,7 @@ exports[`render loading state 1`] = `
     >
       <h2
         className="name"
+        title="Favorites List"
       >
         Favorites List
       </h2>
@@ -289,6 +292,7 @@ exports[`render open with no items 1`] = `
     >
       <h2
         className="name"
+        title="Favorites List"
       >
         Favorites List
       </h2>

--- a/packages/venia-ui/lib/components/WishlistPage/wishlist.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlist.js
@@ -91,7 +91,7 @@ const Wishlist = props => {
 
     const wishlistName = name ? (
         <div className={classes.nameContainer}>
-            <h2 className={classes.name} data-cy="Wishlist-name">
+            <h2 className={classes.name} data-cy="Wishlist-name" title={name}>
                 {name}
             </h2>
         </div>

--- a/packages/venia-ui/lib/components/WishlistPage/wishlist.module.css
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlist.module.css
@@ -27,6 +27,9 @@
 
 .name {
     font-weight: var(--venia-global-fontWeight-semibold);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .buttonsContainer {


### PR DESCRIPTION
## Description

Fixed overflow of text for custom wishlist name

## Related Issue

Closes PWA-2554

## Acceptance

### Verification Stakeholders

Project Maintainers

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

Wishlist should account for custom names that are too long for the viewable UI.

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

1. Log into Venia
2. Navigate to "Favorite List"
3. Add a custom  favorite list name that is super long
4. Notice that the name should now truncate when it reaches the end of the line, but will have a hover over with the full name

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

N/A

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->
1. Verify that new and existing Jest tests pass
1. Verify that Cypress test passes

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

Yes

#### Any ad-hoc/edge case scenarios that need to be considered?

No

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)



## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

No breaking changes

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
