### PR TITLE
Image not showing

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Image/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Image/configAggregator.js
@@ -19,10 +19,10 @@ export default node => {
 
     const mobileImageSrc = () => {
         if (imageNode[1]) {
-            return imageNode[1].getAttribute('src');
+            return imageNode[1].getAttribute('data-src');
         }
         if (imageNode[0]) {
-            return imageNode[0].getAttribute('src');
+            return imageNode[0].getAttribute('data-src');
         }
         return null;
     };
@@ -30,7 +30,7 @@ export default node => {
     const props = {
         desktopImage:
             imageNode[0] && imageNode[1]
-                ? imageNode[0].getAttribute('src')
+                ? imageNode[0].getAttribute('data-src')
                 : null,
         mobileImage: mobileImageSrc(),
         altText: imageNode[0] ? imageNode[0].getAttribute('alt') : null,


### PR DESCRIPTION
Image tag from pagebuilder won't show in frontend. 
Image tag has "data-set" attribute when getting from pagebuilder, it is "src" attribute written the code file. 
We are getting wrong attribute, so we had to override this "configAggregator.js" to change ".getAttribute("src")" to ".getAttribute("data-src")" for image tag to show.

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->




### Resolved issues:
1. [x] resolves magento/pwa-studio#3718: Image not showing