### PR TITLE
[WIP] Adds Shimmer to CMSPage component - Don't merge

### DIFF
--- a/packages/venia-ui/lib/RootComponents/CMS/cms.js
+++ b/packages/venia-ui/lib/RootComponents/CMS/cms.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { shape, string } from 'prop-types';
 
-import { fullPageLoadingIndicator } from '../../components/LoadingIndicator';
+import Shimmer from '@magento/venia-ui/lib/components/Shimmer/shimmer.js';
 import { useCmsPage } from '@magento/peregrine/lib/talons/Cms/useCmsPage';
 import RichContent from '../../components/RichContent';
 import { Meta, StoreTitle } from '../../components/Head';
@@ -18,7 +18,12 @@ const CMSPage = props => {
     const classes = useStyle(defaultClasses, props.classes);
 
     if (shouldShowLoadingIndicator) {
-        return fullPageLoadingIndicator;
+        // return shimmer for CMSPage;
+        return (
+            <div className={rootClassName} aria-live="polite" aria-busy="true">
+                <Shimmer width="100%" height="880px" />
+            </div>
+        );
     }
 
     const {

--- a/packages/venia-ui/lib/RootComponents/Shimmer/shimmer.js
+++ b/packages/venia-ui/lib/RootComponents/Shimmer/shimmer.js
@@ -7,6 +7,8 @@ const RootShimmer = props => {
     const { type } = props;
 
     if (!type || typeof TYPES[type] === 'undefined') {
+        // Investigate why it still shows on CMSPages
+        // even when it was not called
         return fullPageLoadingIndicator;
     }
 


### PR DESCRIPTION
## Description

- Changes the `fullPageLoadingIndicator` on CMSPages with a Shimmer

## Related Issue

Closes [#2296](https://jira.corp.magento.com/browse/PWA-2296)

## Acceptance

1. Verify Loading spinner no more appears on CMS pages.
2. Verify shimmer display as per attached video mocks
3. Verify above Chrome, Safari, FF and mobile device
4. Verify lighthouse and webpage test scores.
5. Verify header elements if displayed are clickable even if actual page is still rendering.

### Verification Stakeholders

### Specification

## Verification Steps

#### Test scenario(s) for direct fix/feature

#### Test scenario(s) for any existing impacted features/areas

Verify user is able to sort data after applying filters on category page
Verify user is able to sort data after applying filters on search page
