### PR TITLE
Source Docs update for 12.3.0

### DIFF
--- a/packages/pagebuilder/lib/utils.js
+++ b/packages/pagebuilder/lib/utils.js
@@ -194,9 +194,12 @@ export function cssToJSXStyle(style) {
 }
 
 /**
+ * Retrieve media queries from a master format node
  *
- * @param  node
- * @returns {{mediaQueries: [{media: string, style: string}]}}
+ * @param node
+ * @param {Array} mediaQueries
+ *
+ * @returns {{mediaQueries: {media: string, style: string}}}
  */
 export function getMediaQueries(node) {
     const response = [];

--- a/pwa-devdocs/scripts/create-reference-docs/config/pagebuilder.js
+++ b/pwa-devdocs/scripts/create-reference-docs/config/pagebuilder.js
@@ -59,6 +59,10 @@ module.exports = [
         type: 'function'
     },
     {
+        target: 'pagebuilder/lib/ContentTypes/DynamicBlock/dynamicBlock.ee.js',
+        type: 'function'
+    },
+    {
         target: 'pagebuilder/lib/ContentTypes/Html/html.js',
         type: 'function'
     },


### PR DESCRIPTION
## Description

This PR adds the DynamicBlocks source code to the auto-generated output for inclusion in the docs. 
It also fixes a jsDocs error (perhaps poorly). So please offer suggestions for a different fix. I did some research, but couldn't find a reason for the jsDocs build failure I was getting: 

```
JSDOC_ERROR: ERROR: Unable to parse a tag's type expression for source file /Users/bdenham/All_Repos/PWA/pwa-studio/packages/pagebuilder/lib/utils.js in line 196 with tag title "returns" and text "{{mediaQueries: [{media: string, style: string}]}}": Invalid type expression "{mediaQueries: [{media: string, style: string}]}": Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter, or [1-9] but "[" found.
ERROR: Unable to parse a tag's type expression for source file /Users/bdenham/All_Repos/PWA/pwa-studio/packages/pagebuilder/lib/utils.js in line 202 with tag title "returns" and text "{{mediaQueries: [{media: string, style: string}]}}": Invalid type expression "{mediaQueries: [{media: string, style: string}]}": Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter, or [1-9] but "[" found.
    at Explain.verifyOutput (/Users/bdenham/All_Repos/PWA/pwa-studio/pwa-devdocs/node_modules/jsdoc-api/lib/jsdoc-command.js:112:19)
    at ChildProcess.<anonymous> (/Users/bdenham/All_Repos/PWA/pwa-studio/pwa-devdocs/node_modules/jsdoc-api/lib/explain.js:45:38)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1058:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)
```

## Related Issue

Closes #NoIssue.

## Acceptance

### Verification Stakeholders

@jcalcaben 

## Verification Steps

1. See jsDocs build error in `release/12.3.0` branch, navigate to `pwa-devdocs` and run `yarn build:reference-doc-snippets`. You should see the error posted above.
2. To verify the fix (which is not ideal), navigate to `pwa-devdocs` and run `yarn build:reference-doc-snippets` again. The error should be gone, but the output may be misleading.
