### PR TITLE
PWA-1674: View Product Attributes values on PDP - Text input, Multi-s…

### DIFF
--- a/packages/peregrine/lib/talons/ProductFullDetail/__tests__/__snapshots__/useProductFullDetail.spec.js.snap
+++ b/packages/peregrine/lib/talons/ProductFullDetail/__tests__/__snapshots__/useProductFullDetail.spec.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`custom attribute is sorted 1`] = `
+Array [
+  Object {
+    "attribute_metadata": Object {
+      "attribute_labels": Array [
+        Object {
+          "label": "Default Label 1",
+          "store_code": "default",
+        },
+      ],
+      "code": "attribute_code_1",
+      "entity_type": "PRODUCT",
+      "label": "Attribute Label 1",
+      "ui_input": Object {
+        "is_html_allowed": true,
+        "ui_input_type": "TEXT",
+      },
+      "uid": "attribute-uid-1",
+      "used_in_components": Array [],
+    },
+    "entered_attribute_value": Object {
+      "value": "Custom Attribute 1",
+    },
+  },
+  Object {
+    "attribute_metadata": Object {
+      "attribute_labels": Array [
+        Object {
+          "label": "default label 2",
+          "store_code": "default",
+        },
+      ],
+      "code": "attribute_code_2",
+      "entity_type": "PRODUCT",
+      "label": "attribute label 2",
+      "ui_input": Object {
+        "is_html_allowed": true,
+        "ui_input_type": "TEXT",
+      },
+      "uid": "attribute-uid-2",
+      "used_in_components": Array [],
+    },
+    "entered_attribute_value": Object {
+      "value": "custom attribute 2",
+    },
+  },
+  Object {
+    "attribute_metadata": Object {
+      "attribute_labels": Array [
+        Object {
+          "label": "Default Label 3",
+          "store_code": "default",
+        },
+      ],
+      "code": "attribute_code_3",
+      "entity_type": "PRODUCT",
+      "label": "Attribute Label 3",
+      "ui_input": Object {
+        "is_html_allowed": true,
+        "ui_input_type": "TEXT",
+      },
+      "uid": "attribute-uid-3",
+      "used_in_components": Array [],
+    },
+    "entered_attribute_value": Object {
+      "value": "Custom Attribute 3",
+    },
+  },
+]
+`;

--- a/packages/peregrine/lib/talons/ProductFullDetail/__tests__/useProductFullDetail.spec.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/__tests__/useProductFullDetail.spec.js
@@ -260,6 +260,83 @@ const configurableProductProps = {
     }
 };
 
+
+const outOfOrderCustomAttributeProductProps = {
+    ...defaultProps,
+    product: {
+        ...defaultProps.product,
+        custom_attributes: [
+            {
+                entered_attribute_value: {
+                    value: 'Custom Attribute 3'
+                },
+                attribute_metadata: {
+                    uid: 'attribute-uid-3',
+                    code: 'attribute_code_3',
+                    label: 'Attribute Label 3',
+                    attribute_labels: [
+                        {
+                            store_code: 'default',
+                            label: 'Default Label 3'
+                        }
+                    ],
+                    entity_type: 'PRODUCT',
+                    ui_input: {
+                        ui_input_type: 'TEXT',
+                        is_html_allowed: true
+                    },
+                    used_in_components: []
+                }
+            },
+            {
+                // Leave values un-capitalized as testing it doesn't sort by capitalization.
+                entered_attribute_value: {
+                    value: 'custom attribute 2'
+                },
+                attribute_metadata: {
+                    uid: 'attribute-uid-2',
+                    code: 'attribute_code_2',
+                    label: 'attribute label 2',
+                    attribute_labels: [
+                        {
+                            store_code: 'default',
+                            label: 'default label 2'
+                        }
+                    ],
+                    entity_type: 'PRODUCT',
+                    ui_input: {
+                        ui_input_type: 'TEXT',
+                        is_html_allowed: true
+                    },
+                    used_in_components: []
+                }
+            },
+            {
+                entered_attribute_value: {
+                    value: 'Custom Attribute 1'
+                },
+                attribute_metadata: {
+                    uid: 'attribute-uid-1',
+                    code: 'attribute_code_1',
+                    label: 'Attribute Label 1',
+                    attribute_labels: [
+                        {
+                            store_code: 'default',
+                            label: 'Default Label 1'
+                        }
+                    ],
+                    entity_type: 'PRODUCT',
+                    ui_input: {
+                        ui_input_type: 'TEXT',
+                        is_html_allowed: true
+                    },
+                    used_in_components: []
+                }
+            }
+        ]
+    }
+};
+
 const configurableOutOfStockProductProps = {
     ...defaultProps,
     product: {
@@ -692,4 +769,13 @@ test('it returns text when render prop is executed', () => {
     expect(
         talonProps.wishlistButtonProps.buttonText(false)
     ).toMatchInlineSnapshot(`"Add to Favorites"`);
+});
+
+test('custom attribute is sorted', () => {
+    const tree = createTestInstance(<Component {...outOfOrderCustomAttributeProductProps} />);
+
+    const { root } = tree;
+    const { talonProps } = root.findByType('i').props;
+
+    expect(talonProps.customAttributes).toMatchSnapshot();
 });

--- a/packages/peregrine/lib/talons/ProductFullDetail/__tests__/useProductFullDetail.spec.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/__tests__/useProductFullDetail.spec.js
@@ -260,7 +260,6 @@ const configurableProductProps = {
     }
 };
 
-
 const outOfOrderCustomAttributeProductProps = {
     ...defaultProps,
     product: {
@@ -772,7 +771,9 @@ test('it returns text when render prop is executed', () => {
 });
 
 test('custom attribute is sorted', () => {
-    const tree = createTestInstance(<Component {...outOfOrderCustomAttributeProductProps} />);
+    const tree = createTestInstance(
+        <Component {...outOfOrderCustomAttributeProductProps} />
+    );
 
     const { root } = tree;
     const { talonProps } = root.findByType('i').props;

--- a/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
@@ -171,6 +171,14 @@ const getConfigPrice = (product, optionCodes, optionSelections) => {
     return value;
 };
 
+const attributeLabelCompare = (attribute1, attribute2) => {
+    const label1 = attribute1['attribute_metadata']['label'].toLowerCase();
+    const label2 = attribute2['attribute_metadata']['label'].toLowerCase();
+    if (label1 < label2) return -1;
+    else if (label1 > label2) return 1;
+    else return 0;
+};
+
 const getCustomAttributes = (product, optionCodes, optionSelections) => {
     const { custom_attributes, variants } = product;
     const isConfigurable = isProductConfigurable(product);
@@ -185,10 +193,14 @@ const getCustomAttributes = (product, optionCodes, optionSelections) => {
             variants
         });
 
-        return item?.product?.custom_attributes || [];
+        return item && item.product
+            ? [...item.product.custom_attributes].sort(attributeLabelCompare)
+            : [];
     }
 
-    return custom_attributes;
+    return custom_attributes
+        ? [...custom_attributes].sort(attributeLabelCompare)
+        : [];
 };
 
 /**

--- a/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/__tests__/__snapshots__/multiSelect.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/__tests__/__snapshots__/multiSelect.spec.js.snap
@@ -15,9 +15,19 @@ Array [
   </div>,
   <div>
     <mock-RichContent
+      classes={
+        Object {
+          "root": undefined,
+        }
+      }
       html="<span>Option 1</span>"
     />
     <mock-RichContent
+      classes={
+        Object {
+          "root": undefined,
+        }
+      }
       html="<span>Option 2</span>"
     />
   </div>,

--- a/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/multiselect.js
+++ b/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/multiselect.js
@@ -33,7 +33,11 @@ const Multiselect = props => {
                 (option, key) => {
                     return (
                         // TODO: Get decoded wysiwyg widgets from GraphQl
-                        <RichContent key={key} html={option.label} />
+                        <RichContent
+                            classes={{ root: classes.option }}
+                            key={key}
+                            html={option.label}
+                        />
                     );
                 }
             );
@@ -79,7 +83,8 @@ Multiselect.propTypes = {
     classes: shape({
         label: string,
         content: string,
-        contentHtml: string
+        contentHtml: string,
+        option: string
     }),
     attribute_metadata: shape({
         label: string,

--- a/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/multiselect.module.css
+++ b/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/multiselect.module.css
@@ -17,6 +17,6 @@
     composes: break-words from global;
 }
 
-.option ~ .option::before {
-    content: ', ';
+.option:not(:last-child)::after {
+    content: ',\00a0';
 }

--- a/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/multiselect.module.css
+++ b/packages/venia-ui/lib/components/ProductFullDetail/CustomAttributes/AttributeType/Multiselect/multiselect.module.css
@@ -5,9 +5,18 @@
 }
 
 .content {
-    composes: inline-block from global;
+    composes: inline from global;
 }
 
 .contentHtml {
-    composes: block from global;
+    composes: inline from global;
+}
+
+.option {
+    composes: inline-block from global;
+    composes: break-words from global;
+}
+
+.option ~ .option::before {
+    content: ', ';
 }

--- a/venia-integration-tests/src/tests/e2eTests/category/verifyFilters.spec.js
+++ b/venia-integration-tests/src/tests/e2eTests/category/verifyFilters.spec.js
@@ -292,7 +292,7 @@ describe('PWA-1402: verify filter actions', () => {
         });
         assertCurrentFilter(filtersData.hasVideo.noLabel, isMobile);
         assertNotInCurrentFilter(filtersData.hasVideo.yesLabel, isMobile);
-        assertNumberOfProductsInResults(11);
+        assertNumberOfProductsInResults(10);
         assertBooleanFilterInputState(
             filtersData.hasVideo.name,
             isMobile,
@@ -369,7 +369,7 @@ describe('PWA-1402: verify filter actions', () => {
         });
 
         assertCategoryTitle(categoryAccessories.name);
-        assertNumberOfProductsInResults(11);
+        assertNumberOfProductsInResults(10);
 
         toggleFilterModal();
         assertNotInCurrentFilter(filtersData.hasVideo.yesLabel);
@@ -410,7 +410,7 @@ describe('PWA-1402: verify filter actions', () => {
         cy.wait(['@gqlGetCategoriesQuery'], {
             timeout: 60000
         });
-        assertNumberOfProductsInResults(15);
+        assertNumberOfProductsInResults(14);
 
         //Clean Up
         toggleFilterModal();


### PR DESCRIPTION
*In scope:* Multi-select, Boolean, Date
As a Merchant I want to show product attributes values on PWA Storefront using native capabilities *so that* I manage product information without ongoing developer help

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

*In scope:* Multi-select, Boolean, Date
As a Merchant I want to show product attributes values on PWA Storefront using native capabilities *so that* I manage product information without ongoing developer help

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes PWA-1674

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->
*Acceptance Criteria*
 1. User navigates to the product detail page and sees product attributes to be displayed in the _Details_ section of product information based on rank set in Store>Product>Attribute>Storefront Properties>Position. If the rank is not set to define position based on it, product attributes sorted alphabetically.

1. User sees attributes displayed with a label corresponding to a store view

1. User sees the date value in the localized vesting according to the store view setting 

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->
*Preconditions*
 1. Web store with 2 store views created
1. Product attributes with input types Multi-select, Boolean and Date created in Admin>Store>Attributes>Product
1. Product attributes are enabled for Product Detail Page in Admin>Store>Attributes> Visible on Catalog Pages on Storefront
1. Product attributes have labels localized for each store view in Admin>Store>Attributes>Manage Labels
1. Products that use product attributes above are created in Admin Panel
1. User is browsing  products mentioned above on Venia PWA Storefront


#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

*Test Plan*
1. Setup data in backend and verify - 
 ** Product attributes Multi-select, Boolean, Date are displayed for both simple and configurable products. (Virtual products also if that is delivered when this ticket hits board)
 ** Verify the display order is based on rank and if rank is not set then its alphabetical order
 ** Verify above scenario's for store view 2
 ** Verify localized label displayed per backend config.
1. Verify in different browser special date attribute.

*Cypress test coverage*
1. Add cypress integration mock data test to assert attributes display. (Update test if already exists)
 

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
