### PR TITLE
passing jfrog image only for CI build stage to overcome docker pull l…

### DIFF
--- a/venia-integration-tests/run-tests.js
+++ b/venia-integration-tests/run-tests.js
@@ -77,7 +77,7 @@ const dockerRuns = {};
 const port = new URL(baseUrl).port;
 
 let dockerCommand = null;
-
+let dockerImage = "cypress/included:8.3.1";
 if (process.env.CI) {
     dockerImage = process.env.DockerRegistry + dockerImage
 };

--- a/venia-integration-tests/run-tests.js
+++ b/venia-integration-tests/run-tests.js
@@ -78,7 +78,7 @@ const port = new URL(baseUrl).port;
 
 let dockerCommand = null;
 let dockerImage = "cypress/included:8.3.1";
-if (process.env.CI) {
+if (process.env.DockerRegistry) {
     dockerImage = process.env.DockerRegistry + dockerImage
 };
 

--- a/venia-integration-tests/run-tests.js
+++ b/venia-integration-tests/run-tests.js
@@ -78,10 +78,9 @@ const port = new URL(baseUrl).port;
 
 let dockerCommand = null;
 
-let dockerImage = "cypress/included:8.3.1";
 if (process.env.CI) {
-    dockerImage = "docker-hub-remote.dr-uw2.adobeitc.com/" + dockerImage;
-}
+    dockerImage = process.env.DockerRegistry + dockerImage
+};
 
 if (port) {
     // run docker on local instance

--- a/venia-integration-tests/run-tests.js
+++ b/venia-integration-tests/run-tests.js
@@ -78,20 +78,25 @@ const port = new URL(baseUrl).port;
 
 let dockerCommand = null;
 
+let dockerImage = "cypress/included:8.3.1";
+if (process.env.CI) {
+    dockerImage = "docker-hub-remote.dr-uw2.adobeitc.com/" + dockerImage;
+}
+
 if (port) {
     // run docker on local instance
     console.log(`Running tests on local instance ${baseUrl}`);
 
     dockerCommand = `docker run --rm -v ${
         process.env.PWD
-    }:/venia-integration-tests -w /venia-integration-tests --entrypoint=cypress cypress/included:8.3.1 run --browser chrome --config baseUrl=https://host.docker.internal:${port},screenshotOnRunFailure=false --config-file cypress.config.json --env updateSnapshots=${update} --headless --reporter mochawesome --reporter-options reportDir=cypress/results,overwrite=false,html=false,json=true`;
+    }:/venia-integration-tests -w /venia-integration-tests --entrypoint=cypress ${dockerImage} run --browser chrome --config baseUrl=https://host.docker.internal:${port},screenshotOnRunFailure=false --config-file cypress.config.json --env updateSnapshots=${update} --headless --reporter mochawesome --reporter-options reportDir=cypress/results,overwrite=false,html=false,json=true`;
 } else {
     // run docker on remote instance
     console.log(`Running tests on remote instance ${baseUrl}`);
 
     dockerCommand = `docker run --rm -v ${
         process.env.PWD
-    }:/venia-integration-tests -w /venia-integration-tests --entrypoint=cypress cypress/included:8.3.1 run --browser chrome --config baseUrl=${baseUrl},screenshotOnRunFailure=false --config-file cypress.config.json --env updateSnapshots=${update} --headless --reporter mochawesome --reporter-options reportDir=cypress/results,overwrite=false,html=false,json=true`;
+    }:/venia-integration-tests -w /venia-integration-tests --entrypoint=cypress ${dockerImage} run --browser chrome --config baseUrl=${baseUrl},screenshotOnRunFailure=false --config-file cypress.config.json --env updateSnapshots=${update} --headless --reporter mochawesome --reporter-options reportDir=cypress/results,overwrite=false,html=false,json=true`;
 }
 
 const start = process.hrtime();

--- a/venia-integration-tests/run-tests.js
+++ b/venia-integration-tests/run-tests.js
@@ -77,10 +77,10 @@ const dockerRuns = {};
 const port = new URL(baseUrl).port;
 
 let dockerCommand = null;
-let dockerImage = "cypress/included:8.3.1";
+let dockerImage = 'cypress/included:8.3.1';
 if (process.env.DockerRegistry) {
-    dockerImage = process.env.DockerRegistry + dockerImage
-};
+    dockerImage = process.env.DockerRegistry + dockerImage;
+}
 
 if (port) {
     // run docker on local instance


### PR DESCRIPTION
## Description
Pulling from public docker hub causing rate limit exceptions


## Related Issue

Closes JIRA-PWA-2085

## Acceptance

Any developer
Devops engineer

## Verification Steps

1. Go through the codebuild logs to check if the public image has been replaced with jfrog image
2. Build job should not fail due to rate docker pull limit error
