### PR TITLE
AC-2496::Contrast insufficient - light grey text (Checkout - Payment)

### DIFF
--- a/packages/venia-ui/lib/index.module.css
+++ b/packages/venia-ui/lib/index.module.css
@@ -124,20 +124,16 @@
     touch-action: none;
 }
 
-:global(
-    .braintree-sheet__content--form
-    .braintree-form__field-group
-    .braintree-form__field
-    .braintree-form__hosted-field
-    input.braintree-form__raw-input
-    ) {
-    color: #8F8F8F !important;
+:global(.braintree-sheet__content--form
+        .braintree-form__field-group
+        .braintree-form__field
+        .braintree-form__hosted-field
+        input.braintree-form__raw-input) {
+    color: #8f8f8f !important;
 }
 
-:global(
-    .braintree-sheet__content--form
-    .braintree-form__field-group
-    .braintree-form__descriptor
-    ) {
+:global(.braintree-sheet__content--form
+        .braintree-form__field-group
+        .braintree-form__descriptor) {
     color: #757575 !important;
 }

--- a/packages/venia-ui/lib/index.module.css
+++ b/packages/venia-ui/lib/index.module.css
@@ -123,3 +123,21 @@
     cursor: default;
     touch-action: none;
 }
+
+:global(
+    .braintree-sheet__content--form
+    .braintree-form__field-group
+    .braintree-form__field
+    .braintree-form__hosted-field
+    input.braintree-form__raw-input
+    ) {
+    color: #8F8F8F !important;
+}
+
+:global(
+    .braintree-sheet__content--form
+    .braintree-form__field-group
+    .braintree-form__descriptor
+    ) {
+    color: #757575 !important;
+}


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
Contrast insufficient - light grey text (Checkout - Payment)

**Reproduction Steps**
select "Blouses & Shirts" > select "Susanna Draped Tank" > add product to cart > select bag > select "Edit Shopping Bag" > select "Proceed to Checkout" > complete shipping information and continue to "Shipping Method" > complete shipping method and continue to "Payment Information" (TEST - Payment information][NODE][body>div:nth-of-type(1)>*:nth-child(1)>*:nth-child(3)>*:nth-child(1)>*:nth-child(1)>*:nth-child(5)>*:nth-child(1)>*:nth-child(1)>*:nth-child(1)>*:nth-child(1)]

1. Use a color contrast checker to compare foreground and background colors.

**Actual Behavior**
There are text elements or images of text that do not meet the WCAG 2.0 required minimum color contrast ratio of 4.5:1 for standard text of 18pt (24px) or 14pt (19px) if bolded. Examples include:

Expiration date format
CVV format

Foreground: #B5B5B5
Background: #ffffff
Contrast ratio: 2.1:1

Sufficient contrast ensures that people with low vision or color deficiencies, users viewing the page without color, and users of monochrome screens can see the page content.

**Expected Behavior**
All text and images of text should provide the following minimum contrast ratios:

For standard text less than 18pt (24px) or less than 14pt (19px) if bolded must have a luminosity contrast ratio of 4.5:1 or more.
For larger text 18pt (24px) or larger or 14pt (19px) if bolded must have a luminosity contrast ratio of 3:1 or more.
Refer to the Color Contrast Checker Tool for assistance:
https://www.levelaccess.com/compliance-resource/color-contrast-checker/

## Related Issue
Closes https://jira.corp.magento.com/browse/AC-2496.

## Verification Steps

**Pre-Conditions:**

1. Have Magento instance with sample data installed
2. Make sure to have pwa studio installed
3. Make sure to have a customer login for front end login

**Manual Steps executed:**

Login to venia > Navigate to global header accessories or other
Add product to cart > select bag > select "Edit Shopping Bag" > select "Proceed to Checkout" > complete shipping information and continue to "Shipping Method" > complete shipping method and continue to "Payment Information" (TEST - Payment information] 
select credit card option and check the constrast 
 
**✖️ Behaviour Before The Fix :** There are text elements or images of text that do not meet the WCAG 2.0 required minimum color contrast ratio of 4.5:1 for standard text of 18pt (24px) or 14pt (19px) if bolded. Examples include:

Expiration date format
CVV format
![image](https://user-images.githubusercontent.com/85922880/165268056-a5fbc616-57ee-480b-a853-d3fdbc2ca374.png)

**✔️Behaviour After The Fix:** The text elements or images of text  meet the WCAG 2.0 required minimum color contrast ratio of 4.5:1 for standard text of 18pt (24px) or 14pt (19px) if bolded.
![image](https://user-images.githubusercontent.com/85922880/165268200-28be97d6-89f2-4fee-ac80-ebbcf41d7ef8.png)



## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3835: AC-2496::Contrast insufficient - light grey text (Checkout - Payment)