### PR TITLE
AC-2490::Contrast insufficient - product image selected state indicat…

### DIFF
--- a/packages/venia-ui/lib/tokens.module.css
+++ b/packages/venia-ui/lib/tokens.module.css
@@ -8,7 +8,7 @@
 
     /* color */
     --venia-global-color-blue-100: 194 200 255;
-    --venia-global-color-blue-400: 61 132 255;
+    --venia-global-color-blue-400: 71 139 255;
     /* --venia-global-color-blue-500: 51 109 255; */
     /* --venia-global-color-blue-600: 41 84 255; */
     --venia-global-color-blue-700: 31 57 255;


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
Contrast insufficient - product image selected state indicator (Product Detail Page)

**Reproduction Steps**
select "Blouses & Shirts" > select "Susanna Draped Tank" - [NODE][body>div:nth-of-type(1)>*:nth-child(1)>*:nth-child(3)]

1. Use a color contrast checker to compare foreground and background colors.

**Actual Behavior**
When a product image button is selected, the selection indicator does not meet the required contrast ratio of 3:1.

The style is provided by a box-shadow:
box-shadow: 0 0 10px 0 rgb(var(--venia-global-color-teal));
{}venia-global-color-teal: var({-}-venia-global-color-blue-400);
--venia-global-color-blue-400: 61 132 255;

This style results in a sampled hex color against a white background of #B5D0FF, with a contrast ratio of 1.6:1.

When sufficient contrast ratios are not met, users with low vision may have trouble identifying user interface components.

**Expected Behavior**
Ensure that visual indicators of state provide a contrast ratio of at least 3:1 against the background color. Refer to the Color Contrast Checker Tool for assistance: https://www.levelaccess.com/compliance-resource/color-contrast-checker

## Related Issue
Closes https://jira.corp.magento.com/browse/AC-2490.

## Verification Steps
**Pre-Conditions:**

1. Have Magento instance with sample data installed
2. Make sure to have pwa studio installed
3. Make sure to have a customer login for front end login

**Manual Steps executed:**

Login to venia > navigate to product detail page 
navigate to serach button and serach any product 
observe the Use a color contrast checker to compare foreground and background colors
 

**✖️ Behaviour Before The Fix :** 
When a product image button is selected, the selection indicator does not meet the required contrast ratio of 3:1.

**✔️Behaviour After The Fix:** the selection indicator does  meet the required contrast ratio of 3:1.

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3834: AC-2490::Contrast insufficient - product image selected state indicat…