### PR TITLE
AC-2786::Shopping bag button does not programmatically communicate st…

### DIFF
--- a/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/cartTrigger.spec.js.snap
+++ b/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/cartTrigger.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Cart counter displays 99+ when items quantity is more than 99 1`] = `
 Array [
   <div>
     <button
+      aria-expanded={false}
       aria-label="Toggle mini cart. You have 100 items in your cart."
       onClick={[Function]}
     >
@@ -39,6 +40,7 @@ Array [
     </button>
   </div>,
   <button
+    aria-expanded={false}
     aria-label="Toggle mini cart. You have 100 items in your cart."
     onClick={[Function]}
   >
@@ -83,6 +85,7 @@ exports[`Cart icon svg has fill and correct value when cart contains items 1`] =
 Array [
   <div>
     <button
+      aria-expanded={false}
       aria-label="Toggle mini cart. You have 10 items in your cart."
       onClick={[Function]}
     >
@@ -118,6 +121,7 @@ Array [
     </button>
   </div>,
   <button
+    aria-expanded={false}
     aria-label="Toggle mini cart. You have 10 items in your cart."
     onClick={[Function]}
   >
@@ -164,6 +168,7 @@ exports[`No counter when cart is empty 1`] = `
 Array [
   <div>
     <button
+      aria-expanded={false}
       aria-label="Toggle mini cart. You have 0 items in your cart."
       onClick={[Function]}
     >
@@ -196,6 +201,7 @@ Array [
     </button>
   </div>,
   <button
+    aria-expanded={false}
     aria-label="Toggle mini cart. You have 0 items in your cart."
     onClick={[Function]}
   >

--- a/packages/venia-ui/lib/components/Header/cartTrigger.js
+++ b/packages/venia-ui/lib/components/Header/cartTrigger.js
@@ -56,6 +56,7 @@ const CartTrigger = props => {
         <Fragment>
             <div className={triggerClassName} ref={miniCartTriggerRef}>
                 <button
+                    aria-expanded={miniCartIsOpen}
                     aria-label={buttonAriaLabel}
                     className={classes.trigger}
                     onClick={handleTriggerClick}
@@ -66,6 +67,7 @@ const CartTrigger = props => {
                 </button>
             </div>
             <button
+                aria-expanded={miniCartIsOpen}
                 aria-label={buttonAriaLabel}
                 className={classes.link}
                 onClick={handleLinkClick}


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
Shopping bag button does not programmatically communicate state. (Global Header)

**Reproduction Steps**
[NODE][body>div:nth-of-type(1)>*:nth-child(1)>*:nth-child(2)]

1. With JAWS operating and items in your "Bag", press Tab to move through the content.
2. When keyboard focus is on "Bag", press Enter or Space to activate it.

**Actual Behavior**
The Shopping bag button does not provide a programmatic or textual indication of its state. Screen reader users are not informed that the button will expand other content, or whether the associated content is expanded or collapsed.

**Expected Behavior**
Ensure that controls convey their state programmatically or in text. State can be conveyed programmatically with the aria-expanded attribute.

See the WAI-ARIA Authoring Practices design pattern for Disclosure: https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure

## Related Issue
Closes https://jira.corp.magento.com/browse/AC-2786

## Verification Steps
**Pre-Conditions:**

1. Have Magento instance with sample data installed
2. Make sure to have pwa studio installed
3. Make sure to have a customer login for front end login

**Manual Steps executed:**

Login to venia > activate your screen reader
Navigate to global header accessories or other
Add items to your bag > Navigate to shopping bag 
check if the screen reader is properly announcing the behaviour of the bag i.e bag expanded or bag collapsed 

**✖️ Behaviour Before The Fix :** The Shopping bag button does not provide a programmatic or textual indication of its state. Screen reader users are not informed that the button will expand other content, or whether the associated content is expanded or collapsed..

**✔️Behaviour After The Fix:** The Shopping bag button provide a programmatic or textual indication of its state. Screen reader users are  informed that the button will expand other content, or  the associated content is expanded or collapsed..

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3830: AC-2786::Shopping bag button does not programmatically communicate st…