### PR TITLE
AC-2789::Focus not set to newly visible content (pattern)

### DIFF
--- a/packages/venia-ui/lib/components/Navigation/navigation.js
+++ b/packages/venia-ui/lib/components/Navigation/navigation.js
@@ -10,6 +10,7 @@ import StoreSwitcher from '../Header/storeSwitcher';
 import LoadingIndicator from '../LoadingIndicator';
 import NavHeader from './navHeader';
 import defaultClasses from './navigation.module.css';
+import { FocusScope } from 'react-aria';
 
 const AuthModal = React.lazy(() => import('../AuthModal'));
 
@@ -52,35 +53,37 @@ const Navigation = props => {
     ) : null;
 
     return (
-        <aside className={rootClassName}>
-            <header className={classes.header}>
-                <NavHeader
-                    isTopLevel={isTopLevel}
-                    onBack={handleBack}
-                    view={view}
-                />
-            </header>
-            <div className={bodyClassName}>
-                <CategoryTree
-                    categoryId={categoryId}
-                    onNavigate={handleClose}
-                    setCategoryId={setCategoryId}
-                    updateCategories={catalogActions.updateCategories}
-                />
-            </div>
-            <div className={classes.footer}>
-                <div className={classes.switchers}>
-                    <StoreSwitcher />
-                    <CurrencySwitcher />
+        <FocusScope contain restoreFocus autoFocus>
+            <aside className={rootClassName}>
+                <header className={classes.header}>
+                    <NavHeader
+                        isTopLevel={isTopLevel}
+                        onBack={handleBack}
+                        view={view}
+                    />
+                </header>
+                <div className={bodyClassName}>
+                    <CategoryTree
+                        categoryId={categoryId}
+                        onNavigate={handleClose}
+                        setCategoryId={setCategoryId}
+                        updateCategories={catalogActions.updateCategories}
+                    />
                 </div>
-                <AuthBar
-                    disabled={hasModal}
-                    showMyAccount={showMyAccount}
-                    showSignIn={showSignIn}
-                />
-            </div>
-            <div className={modalClassName}>{authModal}</div>
-        </aside>
+                <div className={classes.footer}>
+                    <div className={classes.switchers}>
+                        <StoreSwitcher />
+                        <CurrencySwitcher />
+                    </div>
+                    <AuthBar
+                        disabled={hasModal}
+                        showMyAccount={showMyAccount}
+                        showSignIn={showSignIn}
+                    />
+                </div>
+                <div className={modalClassName}>{authModal}</div>
+            </aside>
+        </FocusScope>
     );
 };
 


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
Focus not set to newly visible content (pattern)

**Reproduction Steps**
Locations (representative sample):

**Global Header**
**Search Results**
1. At a tablet or mobile breakpoint (smaller than ~1020px) , press Tab to move through the content.
2. When keyboard focus is on the menu button, press Enter or Space to activate it.
3. Continue tabbing until menu items receive focus.

**Actual Behavior**
When the mobile menu (globally) or the filters sidebar (on Search Results page) is expanded using keyboard, focus is not moved to the newly expanded content. The newly visible content does not follow the button that expands it in the DOM, but instead is located at the bottom of the DOM. As a result, keyboard-only users must tab through all of the page content before being able to interact with their intended content.

**Expected Behavior**
Ensure focus is moved appropriately to new content when it becomes visible, or else ensure that the new content immediately follows the button that spawned it in the DOM.

## Related Issue

Closes [AC-2789](https://jira.corp.magento.com/browse/AC-2789).

## Verification Steps
**Pre-Conditions:**

1. Have Magento instance with sample data installed
2. Make sure to have pwa studio installed
3. Make sure to have a customer login for front end login

**Manual Steps executed:**

Login to venia > Activate your mobile mode > Navigate to main menu and enter to expand
Check the keyboard focus is on the main menu options after tabbing
 
**✖️ Behaviour Before The Fix :** The focus does not move appropriately to new content (main menu) when it becomes visible
![image](https://user-images.githubusercontent.com/85922880/165289054-18d97a6f-635c-4810-983d-56034437b637.png)
**✔️Behaviour After The Fix:** The focus is moved appropriately to new content (main menu) when it becomes visible
![image](https://user-images.githubusercontent.com/85922880/165289123-efdc0c51-8d5a-443a-b361-31e99ec6ddec.png)

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
