### PR TITLE
BUG#AC-2499::When focusing on 'Venia' image while using screen reader…

### DIFF
--- a/packages/venia-ui/lib/components/Footer/__tests__/__snapshots__/footer.spec.js.snap
+++ b/packages/venia-ui/lib/components/Footer/__tests__/__snapshots__/footer.spec.js.snap
@@ -205,6 +205,7 @@ exports[`footer renders copyright 1`] = `
       foo
     </p>
     <a
+      aria-label="Venia"
       className="logoContainer"
       href="/"
       onClick={[Function]}

--- a/packages/venia-ui/lib/components/Footer/footer.js
+++ b/packages/venia-ui/lib/components/Footer/footer.js
@@ -108,7 +108,11 @@ const Footer = props => {
                     </li>
                 </ul>
                 <p className={classes.copyright}>{copyrightText || null}</p>
-                <Link to={resourceUrl('/')} aria-label={title} className={classes.logoContainer}>
+                <Link
+                    to={resourceUrl('/')}
+                    aria-label={title}
+                    className={classes.logoContainer}
+                >
                     <Logo classes={{ logo: classes.logo }} />
                 </Link>
             </div>

--- a/packages/venia-ui/lib/components/Footer/footer.js
+++ b/packages/venia-ui/lib/components/Footer/footer.js
@@ -11,6 +11,7 @@ import { useStyle } from '../../classify';
 import defaultClasses from './footer.module.css';
 import { DEFAULT_LINKS, LOREM_IPSUM } from './sampleData';
 import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
+import { useIntl } from 'react-intl';
 
 const Footer = props => {
     const { links } = props;
@@ -18,7 +19,7 @@ const Footer = props => {
     const talonProps = useFooter();
 
     const { copyrightText } = talonProps;
-    const { formatMessage } = FormattedMessage();
+    const { formatMessage } = useIntl();
     const title = formatMessage({ id: 'logo.title', defaultMessage: 'Venia' });
 
     const linkGroups = Array.from(links, ([groupKey, linkProps]) => {
@@ -108,11 +109,7 @@ const Footer = props => {
                     </li>
                 </ul>
                 <p className={classes.copyright}>{copyrightText || null}</p>
-                <Link
-                    to={resourceUrl('/')}
-                    aria-label={title}
-                    className={classes.logoContainer}
-                >
+                <Link to={resourceUrl('/')} aria-label={title} className={classes.logoContainer}>
                     <Logo classes={{ logo: classes.logo }} />
                 </Link>
             </div>

--- a/packages/venia-ui/lib/components/Footer/footer.js
+++ b/packages/venia-ui/lib/components/Footer/footer.js
@@ -11,7 +11,6 @@ import { useStyle } from '../../classify';
 import defaultClasses from './footer.module.css';
 import { DEFAULT_LINKS, LOREM_IPSUM } from './sampleData';
 import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
-import { useIntl } from 'react-intl';
 
 const Footer = props => {
     const { links } = props;
@@ -19,7 +18,7 @@ const Footer = props => {
     const talonProps = useFooter();
 
     const { copyrightText } = talonProps;
-    const { formatMessage } = useIntl();
+    const { formatMessage } = FormattedMessage();
     const title = formatMessage({ id: 'logo.title', defaultMessage: 'Venia' });
 
     const linkGroups = Array.from(links, ([groupKey, linkProps]) => {
@@ -109,7 +108,11 @@ const Footer = props => {
                     </li>
                 </ul>
                 <p className={classes.copyright}>{copyrightText || null}</p>
-                <Link to={resourceUrl('/')} aria-label={title} className={classes.logoContainer}>
+                <Link
+                    to={resourceUrl('/')}
+                    aria-label={title}
+                    className={classes.logoContainer}
+                >
                     <Logo classes={{ logo: classes.logo }} />
                 </Link>
             </div>

--- a/packages/venia-ui/lib/components/Footer/footer.js
+++ b/packages/venia-ui/lib/components/Footer/footer.js
@@ -11,6 +11,7 @@ import { useStyle } from '../../classify';
 import defaultClasses from './footer.module.css';
 import { DEFAULT_LINKS, LOREM_IPSUM } from './sampleData';
 import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
+import { useIntl } from 'react-intl';
 
 const Footer = props => {
     const { links } = props;
@@ -18,6 +19,8 @@ const Footer = props => {
     const talonProps = useFooter();
 
     const { copyrightText } = talonProps;
+    const { formatMessage } = useIntl();
+    const title = formatMessage({ id: 'logo.title', defaultMessage: 'Venia' });
 
     const linkGroups = Array.from(links, ([groupKey, linkProps]) => {
         const linkElements = Array.from(linkProps, ([text, pathInfo]) => {
@@ -106,7 +109,7 @@ const Footer = props => {
                     </li>
                 </ul>
                 <p className={classes.copyright}>{copyrightText || null}</p>
-                <Link to={resourceUrl('/')} className={classes.logoContainer}>
+                <Link to={resourceUrl('/')} aria-label={title} className={classes.logoContainer}>
                     <Logo classes={{ logo: classes.logo }} />
                 </Link>
             </div>

--- a/packages/venia-ui/lib/components/Footer/footer.js
+++ b/packages/venia-ui/lib/components/Footer/footer.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Facebook, Instagram, Twitter } from 'react-feather';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { shape, string } from 'prop-types';
 import { useFooter } from '@magento/peregrine/lib/talons/Footer/useFooter';
@@ -11,7 +11,6 @@ import { useStyle } from '../../classify';
 import defaultClasses from './footer.module.css';
 import { DEFAULT_LINKS, LOREM_IPSUM } from './sampleData';
 import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
-import { useIntl } from 'react-intl';
 
 const Footer = props => {
     const { links } = props;

--- a/packages/venia-ui/lib/components/Header/header.js
+++ b/packages/venia-ui/lib/components/Header/header.js
@@ -17,6 +17,7 @@ import StoreSwitcher from './storeSwitcher';
 import CurrencySwitcher from './currencySwitcher';
 import MegaMenu from '../MegaMenu';
 import PageLoadingIndicator from '../PageLoadingIndicator';
+import { useIntl } from 'react-intl';
 
 const SearchBar = React.lazy(() => import('../SearchBar'));
 
@@ -51,6 +52,9 @@ const Header = props => {
         </Suspense>
     ) : null;
 
+    const { formatMessage } = useIntl();
+    const title = formatMessage({ id: 'logo.title', defaultMessage: 'Venia' });
+
     return (
         <Fragment>
             <div className={classes.switchersContainer}>
@@ -69,6 +73,7 @@ const Header = props => {
                         isOnline={isOnline}
                     />
                     <Link
+                        aria-label={title}
                         to={resourceUrl('/')}
                         className={classes.logoContainer}
                         data-cy="Header-logoContainer"

--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -23,7 +23,6 @@ const Logo = props => {
 
     return (
         <Image
-            alt={title}
             classes={{ image: classes.logo }}
             height={height}
             src={logo}


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

When focusing on "Venia" image while using screen reader "Venia Venia" is announced.

Environment
Adobe Magento - Venia

Context
Windows 10; Chrome 88; JAWS 2021

Reproduction Steps
Locations (representative sample):

Global Header
Global Footer
 
1. With JAWS operating, press Tab to move through the content.

Actual Behavior
When focusing on "Venia" image while using screen reader "Venia Venia" is announced. Information provided is too verbose for screen readers.

Module 01a - Global Header
Module 01b - Global Footer

Code Reference:
<a href="/default/">
<div class="image-root-Qpm image-container-_fN">

</div>
</a>

Expected Behavior
Ensure that information is communicated properly to screen reader users. In this case, "Venia" should be announced once.

Consider removing unnecessary title attributes from both images, using null alt text for both images (alt=""), and then adding visually-hidden text within the <a> element to form a concise accessible name for the link. (See sample markup/css below.)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes https://jira.corp.magento.com/browse/AC-2499

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

✔️ QA Passed
 

Pre-Conditions:

1. Have Magento instance with sample data installed

2. Make sure to have pwa studio installed

3. Make sure to have a customer login for front end login

 

Manual Steps executed:

Login to venia > Navigate to global header venia using screen reader > navigate to global footer venia using screen reader

 

✖️ Behaviour Before The Fix : When focusing on "Venia" header anf footer image while using screen reader "Venia Venia" is announced. 

✔️Behaviour After The Fix: Venia" is  announced only once using screen reader.



#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3828: BUG#AC-2499::When focusing on 'Venia' image while using screen reader…