### PR TITLE
AC-2486::contrast insufficient - medium grey text (Search Results)

### DIFF
--- a/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.module.css
+++ b/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.module.css
@@ -2,8 +2,6 @@
     composes: pb-xs from global;
     composes: text-center from global;
     composes: text-sm from global;
-    composes: text-subtle from global;
-
     composes: lg_hidden from global;
 }
 


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Contrast insufficient - medium grey text

Environment
Adobe Magento - Venia

Context
Windows 10; Chrome 88;

Reproduction Steps
search "short" - [NODE][body>div:nth-of-type(1)>*:nth-child(1)>*:nth-child(3)]

1. Use a color contrast checker to compare foreground and background colors.

Actual Behavior
There are text elements or images of text that do not meet the WCAG 2.0 required minimum color contrast ratio of 4.5:1 for standard text of 18pt (24px) or 14pt (19px) if bolded. Examples include:

"nn items"
"Items sorted by Best Match"

Foreground:#767B7F
Background:#FFFFFF
The contrast ratio is: 4.3:1

Sufficient contrast ensures that people with low vision or color deficiencies, users viewing the page without color, and users of monochrome screens can see the page content.

Expected Behavior
All text and images of text should provide the following minimum contrast ratios:

For standard text less than 18pt (24px) or less than 14pt (19px) if bolded must have a luminosity contrast ratio of 4.5:1 or more.
For larger text 18pt (24px) or larger or 14pt (19px) if bolded must have a luminosity contrast ratio of 3:1 or more.
Refer to the Color Contrast Checker Tool for assistance:
https://www.levelaccess.com/compliance-resource/color-contrast-checker/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes https://jira.corp.magento.com/browse/AC-2486

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

✔️ QA Passed
Pre-Conditions:

1. Have Magento instance with sample data installed

2. Make sure to have pwa studio installed

3. Make sure to have a customer login for front end login

 

Manual Steps executed:

Login to venia > inspect element and chosde mobile view
navigate to filter and sort button 
observe the  color contrast checker to compare foreground and background colors for the text appearing after sorting or filtering eg "nn items"
"Items sorted by Best Match"
 

✖️ Behaviour Before The Fix : text that do not meet the WCAG 2.0 required minimum color contrast ratio of 4.5:1 for standard text of 18pt (24px) or 14pt (19px) if bolded

![image](https://user-images.githubusercontent.com/97873570/165511419-3b07b5a1-de9a-4d7e-9333-f606c329a96e.png)

✔️Behaviour After The Fix: text that do not meet the WCAG 2.0 required minimum color contrast ratio of 4.5:1 for standard text of 18pt (24px) or 14pt (19px) if bolded

![image](https://user-images.githubusercontent.com/97873570/165511575-24e7e658-b797-455f-9de3-9ccd7495329e.png)

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3826: AC-2486::contrast insufficient - medium grey text (Search Results)