### PR TITLE
AC-2483::Contrast insufficient - custom blue focus indicator

### DIFF
--- a/packages/venia-ui/lib/components/AddressBookPage/addressBookPage.module.css
+++ b/packages/venia-ui/lib/components/AddressBookPage/addressBookPage.module.css
@@ -43,3 +43,6 @@
 
     composes: hover_border-brand-dark from global;
 }
+.addButton:focus {
+    box-shadow: -6px 6px rgb(var(--venia-global-color-blue-100));
+}


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Contrast insufficient - custom blue focus indicator

Environment
Adobe Magento - Venia

Context
Windows 10; Chrome 88;

Reproduction Steps
Locations (representative sample):

Global Header
Landing Page
Search Results
Product Detail Page
Shopping Bag Mini Cart
Shopping Bag
Checkout - Shipping Information
Checkout - Payment
- Checkout - Confirmation / Create an Account
Sign In
Account - Order History
1. Use a color contrast checker to compare foreground and background colors.

Actual Behavior
The visual focus indicator for buttons, links styled like buttons, or input fields throughout the site is provided by a box-shadow which does not meet the minimum 3:1 contrast ratio for a custom focus indicator. Users with low vision may have trouble identifying this focus indicator. Examples include:

Module 01a - Global Header:
Search input

Module 02 - Landing Page:
Various links styled like buttons, (e.g. "Shop Now" in hero carousel, "Shop Summer" on black background").

Module 03 - Search Results page:
"Filter", "Sort", "See Results" buttons
Checkboxes within filter menu

Module 04 - Product Detail page:
"Add to Cart" button
"Quantity" input field

Module 05a - Shopping Bag dialog/Mini Cart:
"Checkout" button

Module 05b - Shopping Bag:
Buttons, inputs

Module 06a - Checkout - Shipping Information:
Buttons, inputs

Module 06b - Checkout - Payment:
Radio Button

Module 06c - Checkout - Confirmation / Create an Account:
Buttons, inputs

Module 07 - Sign In:
Buttons, inputs

Module 08 - Order History:

Search by order number input & button
Buttons and links styled like buttons:
box-shadow: 6px 6px hsl(var(-brightBlue) / 0.3);
--brightBlue: 233 100% 056%;

The spread and blur of the box shadow combined with the transparency in the hsl color value results in a lower contrast ratio on the page than the assigned hsl value would otherwise provide.

The highest contrast ratio for this style was sampled at #BBC3FF on a #ffffff background, for a contrast ratio of 1.7:1. This contrast ratio falls lower where the focus style is applied on other background colors, such as light gray in the homepage hero carousel (shadow sampled at #BBC3FF on background #f3f3f3 – contrast ratio of ~1.7:1) and dark gray on homepage "Vacations meet fresh style" callout (shadow sampled at #1C2B6C on background #1B252C – contrast ratio of 1.2:1).

Inputs:
box-shadow: 6px 6px rgb(var(-venia-brand-color-1-100));
--venia-global-color-blue-100: 194 200 255;

Against a white background, this box shadow color was sampled at #c2c8ff, for a contrast ratio of 1.6:1.

Expected Behavior
Ensure that custom focus indicators provide a contrast ratio of at least 3:1 against the background color.

Refer to the Color Contrast Checker Tool for assistance: https://www.levelaccess.com/compliance-resource/color-contrast-checker

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes https://jira.corp.magento.com/browse/AC-2483

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

✔️ QA Passed
Pre-Conditions:

1. Have Magento instance with sample data installed

2. Make sure to have pwa studio installed

3. Make sure to have a customer login for front end login

 

Manual Steps executed:

Login to venia > Navigate to global header > Search input > "Filter", "Sort", "See Results" buttons
Navigate to Product Detail page >  "Add to Cart" button > "Quantity" input field
Navigate to  shopping Bag dialog/Mini Cart > "Checkout" button
Navigate to Shopping Bag > Buttons, inputs > Checkout - Shipping Information > Buttons, inputs
Navigate to Checkout - Payment > Radio Button > heckout - Confirmation / Create an Account > Buttons, inputs
Navigate to Sign In > Buttons, inputs > Order History > Search by order number input & button > address book > Communication > account information.
 

✖️ Behaviour Before The Fix : The custom focus indicators did not provide a contrast ratio of at least 3:1 against the background color.

![image](https://user-images.githubusercontent.com/97873570/165512329-3e9d4fbf-16f2-4f04-9ffa-41d16bf2bd0d.png)
![image](https://user-images.githubusercontent.com/97873570/165512365-f2e3fb3f-6158-407b-8db0-3b6ca7923c0c.png)


✔️Behaviour After The Fix: The custom focus indicators provide a contrast ratio of at least 3:1 against the background color.

![image](https://user-images.githubusercontent.com/97873570/165512390-fff76238-c334-4dd0-b317-e8eb0492d9d8.png)
![image](https://user-images.githubusercontent.com/97873570/165512409-82a3455a-fb6e-49c0-8c62-251648ce4e70.png)




## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3825: AC-2483::Contrast insufficient - custom blue focus indicator