### PR TITLE
AC-2482::Screen readers not informed when new page view loads. (patte…

### DIFF
--- a/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
+++ b/packages/venia-ui/lib/RootComponents/Category/__tests__/__snapshots__/categoryContent.spec.js.snap
@@ -13,6 +13,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -110,6 +111,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -221,6 +223,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -332,6 +335,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -451,6 +455,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -501,6 +506,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -569,6 +575,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -666,6 +673,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div
@@ -716,6 +724,7 @@ Array [
       className="categoryHeader"
     >
       <h1
+        aria-live="polite"
         className="title"
       >
         <div

--- a/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
+++ b/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
@@ -155,7 +155,7 @@ const CategoryContent = props => {
             <StoreTitle>{categoryName}</StoreTitle>
             <article className={classes.root} data-cy="CategoryContent-root">
                 <div className={classes.categoryHeader}>
-                    <h1 className={classes.title}>
+                    <h1 aria-live='polite' className={classes.title}>
                         <div
                             className={classes.categoryTitle}
                             data-cy="CategoryContent-categoryTitle"

--- a/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
+++ b/packages/venia-ui/lib/RootComponents/Category/categoryContent.js
@@ -155,7 +155,7 @@ const CategoryContent = props => {
             <StoreTitle>{categoryName}</StoreTitle>
             <article className={classes.root} data-cy="CategoryContent-root">
                 <div className={classes.categoryHeader}>
-                    <h1 aria-live='polite' className={classes.title}>
+                    <h1 aria-live="polite" className={classes.title}>
                         <div
                             className={classes.categoryTitle}
                             data-cy="CategoryContent-categoryTitle"

--- a/packages/venia-ui/lib/components/AccountInformationPage/__tests__/__snapshots__/accountInformationPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/AccountInformationPage/__tests__/__snapshots__/accountInformationPage.spec.js.snap
@@ -6,6 +6,7 @@ exports[`renders form error 1`] = `
 >
   Account Information
   <h1
+    aria-live="polite"
     className="title"
   >
     <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/AccountInformationPage/accountInformationPage.js
+++ b/packages/venia-ui/lib/components/AccountInformationPage/accountInformationPage.js
@@ -127,7 +127,7 @@ const AccountInformationPage = props => {
                 })}
             </StoreTitle>
             <h1
-                aria-live='polite'
+                aria-live="polite"
                 className={classes.title}
                 data-cy="AccountInformationPage-title"
             >

--- a/packages/venia-ui/lib/components/AccountInformationPage/accountInformationPage.js
+++ b/packages/venia-ui/lib/components/AccountInformationPage/accountInformationPage.js
@@ -127,6 +127,7 @@ const AccountInformationPage = props => {
                 })}
             </StoreTitle>
             <h1
+                aria-live='polite'
                 className={classes.title}
                 data-cy="AccountInformationPage-title"
             >

--- a/packages/venia-ui/lib/components/AddressBookPage/__tests__/__snapshots__/addressBookPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/AddressBookPage/__tests__/__snapshots__/addressBookPage.spec.js.snap
@@ -6,6 +6,7 @@ exports[`renders correctly when there are existing addresses 1`] = `
 >
   Title
   <h1
+    aria-live="polite"
     className="heading"
   >
     Address Book
@@ -125,6 +126,7 @@ exports[`renders correctly when there are no existing addresses 1`] = `
 >
   Title
   <h1
+    aria-live="polite"
     className="heading"
   >
     Address Book
@@ -199,6 +201,7 @@ exports[`renders delete confirmation on address that is being deleted 1`] = `
 >
   Title
   <h1
+    aria-live="polite"
     className="heading"
   >
     Address Book

--- a/packages/venia-ui/lib/components/AddressBookPage/addressBookPage.js
+++ b/packages/venia-ui/lib/components/AddressBookPage/addressBookPage.js
@@ -93,7 +93,11 @@ const AddressBookPage = props => {
     return (
         <div className={classes.root}>
             <StoreTitle>{PAGE_TITLE}</StoreTitle>
-            <h1 aria-live='polite' className={classes.heading} data-cy="AddressBookPage-heading">
+            <h1
+                aria-live="polite"
+                className={classes.heading}
+                data-cy="AddressBookPage-heading"
+            >
                 {PAGE_TITLE}
             </h1>
             <div className={classes.content} data-cy="AddressBookPage-content">

--- a/packages/venia-ui/lib/components/AddressBookPage/addressBookPage.js
+++ b/packages/venia-ui/lib/components/AddressBookPage/addressBookPage.js
@@ -93,7 +93,7 @@ const AddressBookPage = props => {
     return (
         <div className={classes.root}>
             <StoreTitle>{PAGE_TITLE}</StoreTitle>
-            <h1 className={classes.heading} data-cy="AddressBookPage-heading">
+            <h1 aria-live='polite' className={classes.heading} data-cy="AddressBookPage-heading">
                 {PAGE_TITLE}
             </h1>
             <div className={classes.content} data-cy="AddressBookPage-content">

--- a/packages/venia-ui/lib/components/CartPage/__tests__/__snapshots__/cartPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/CartPage/__tests__/__snapshots__/cartPage.spec.js.snap
@@ -89,6 +89,7 @@ exports[`renders components if cart has items 1`] = `
     className="heading_container"
   >
     <h1
+      aria-live="polite"
       className="heading"
     >
       <mock-FormattedMessage
@@ -144,6 +145,7 @@ exports[`renders empty cart text (no adjustments, list or summary) if cart is em
     className="heading_container"
   >
     <h1
+      aria-live="polite"
       className="heading"
     >
       <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/CartPage/cartPage.js
+++ b/packages/venia-ui/lib/components/CartPage/cartPage.js
@@ -93,7 +93,11 @@ const CartPage = props => {
                 })}
             </StoreTitle>
             <div className={classes.heading_container}>
-                <h1 aria-live='polite' data-cy="CartPage-heading" className={classes.heading}>
+                <h1
+                    aria-live="polite"
+                    data-cy="CartPage-heading"
+                    className={classes.heading}
+                >
                     <FormattedMessage
                         id={'cartPage.heading'}
                         defaultMessage={'Cart'}

--- a/packages/venia-ui/lib/components/CartPage/cartPage.js
+++ b/packages/venia-ui/lib/components/CartPage/cartPage.js
@@ -93,7 +93,7 @@ const CartPage = props => {
                 })}
             </StoreTitle>
             <div className={classes.heading_container}>
-                <h1 data-cy="CartPage-heading" className={classes.heading}>
+                <h1 aria-live='polite' data-cy="CartPage-heading" className={classes.heading}>
                     <FormattedMessage
                         id={'cartPage.heading'}
                         defaultMessage={'Cart'}

--- a/packages/venia-ui/lib/components/CategoryTree/categoryLeaf.js
+++ b/packages/venia-ui/lib/components/CategoryTree/categoryLeaf.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import React from 'react';
 import { func, shape, string } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';

--- a/packages/venia-ui/lib/components/CategoryTree/categoryLeaf.js
+++ b/packages/venia-ui/lib/components/CategoryTree/categoryLeaf.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import React from 'react';
 import { func, shape, string } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';

--- a/packages/venia-ui/lib/components/CheckoutPage/AddressBook/__tests__/__snapshots__/addressBook.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/AddressBook/__tests__/__snapshots__/addressBook.spec.js.snap
@@ -32,6 +32,7 @@ Array [
     className="root_active"
   >
     <h1
+      aria-live="polite"
       className="headerText"
     >
       <mock-FormattedMessage
@@ -215,6 +216,7 @@ Array [
     className="root"
   >
     <h1
+      aria-live="polite"
       className="headerText"
     >
       <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/CheckoutPage/AddressBook/addressBook.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/AddressBook/addressBook.js
@@ -133,7 +133,7 @@ const AddressBook = props => {
     return (
         <Fragment>
             <div className={rootClass}>
-                <h1 aria-live='polite' className={classes.headerText}>
+                <h1 aria-live="polite" className={classes.headerText}>
                     <FormattedMessage
                         id={'addressBook.headerText'}
                         defaultMessage={'Change Shipping Information'}

--- a/packages/venia-ui/lib/components/CheckoutPage/AddressBook/addressBook.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/AddressBook/addressBook.js
@@ -133,7 +133,7 @@ const AddressBook = props => {
     return (
         <Fragment>
             <div className={rootClass}>
-                <h1 className={classes.headerText}>
+                <h1 aria-live='polite' className={classes.headerText}>
                     <FormattedMessage
                         id={'addressBook.headerText'}
                         defaultMessage={'Change Shipping Information'}

--- a/packages/venia-ui/lib/components/CheckoutPage/GuestSignIn/__tests__/__snapshots__/guestSignIn.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/GuestSignIn/__tests__/__snapshots__/guestSignIn.spec.js.snap
@@ -5,6 +5,7 @@ exports[`renders CreateAccount component 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="header"
   >
     <mock-FormattedMessage
@@ -59,6 +60,7 @@ exports[`renders ForgotPassword component 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="header"
   >
     <mock-FormattedMessage
@@ -112,6 +114,7 @@ exports[`renders SignIn component 2`] = `
   className="root_hidden"
 >
   <h1
+    aria-live="polite"
     className="header"
   >
     <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/CheckoutPage/GuestSignIn/guestSignIn.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/GuestSignIn/guestSignIn.js
@@ -54,7 +54,7 @@ const GuestSignIn = props => {
 
     return (
         <div className={rootClass}>
-            <h1 className={classes.header}>
+            <h1 aria-live='polite' className={classes.header}>
                 <FormattedMessage
                     id="checkoutPage.guestSignIn.header"
                     defaultMessage="Account Sign-in"

--- a/packages/venia-ui/lib/components/CheckoutPage/GuestSignIn/guestSignIn.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/GuestSignIn/guestSignIn.js
@@ -54,7 +54,7 @@ const GuestSignIn = props => {
 
     return (
         <div className={rootClass}>
-            <h1 aria-live='polite' className={classes.header}>
+            <h1 aria-live="polite" className={classes.header}>
                 <FormattedMessage
                     id="checkoutPage.guestSignIn.header"
                     defaultMessage="Account Sign-in"

--- a/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/__tests__/__snapshots__/orderSummary.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/__tests__/__snapshots__/orderSummary.spec.js.snap
@@ -5,6 +5,7 @@ exports[`renders order summary 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="title"
   >
     <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/orderSummary.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/orderSummary.js
@@ -9,7 +9,7 @@ const OrderSummary = props => {
     const classes = useStyle(defaultClasses, props.classes);
     return (
         <div data-cy="OrderSummary-root" className={classes.root}>
-            <h1 className={classes.title}>
+            <h1 aria-live='polite' className={classes.title}>
                 <FormattedMessage
                     id={'checkoutPage.orderSummary'}
                     defaultMessage={'Order Summary'}

--- a/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/orderSummary.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/OrderSummary/orderSummary.js
@@ -9,7 +9,7 @@ const OrderSummary = props => {
     const classes = useStyle(defaultClasses, props.classes);
     return (
         <div data-cy="OrderSummary-root" className={classes.root}>
-            <h1 aria-live='polite' className={classes.title}>
+            <h1 aria-live="polite" className={classes.title}>
                 <FormattedMessage
                     id={'checkoutPage.orderSummary'}
                     defaultMessage={'Order Summary'}

--- a/packages/venia-ui/lib/components/CheckoutPage/__tests__/__snapshots__/checkoutPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/CheckoutPage/__tests__/__snapshots__/checkoutPage.spec.js.snap
@@ -770,6 +770,7 @@ exports[`CheckoutPage renders empty cart 1`] = `
       className="heading_container"
     >
       <h1
+        aria-live="polite"
         className="heading"
       >
         Guest Checkout

--- a/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
@@ -137,6 +137,7 @@ const CheckoutPage = props => {
             <div className={classes.empty_cart_container}>
                 <div className={classes.heading_container}>
                     <h1
+                        aria-live='polite'
                         className={classes.heading}
                         data-cy="ChekoutPage-heading"
                     >

--- a/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/checkoutPage.js
@@ -137,7 +137,7 @@ const CheckoutPage = props => {
             <div className={classes.empty_cart_container}>
                 <div className={classes.heading_container}>
                     <h1
-                        aria-live='polite'
+                        aria-live="polite"
                         className={classes.heading}
                         data-cy="ChekoutPage-heading"
                     >

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/__tests__/__snapshots__/resetPassword.spec.js.snap
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/__tests__/__snapshots__/resetPassword.spec.js.snap
@@ -5,7 +5,9 @@ exports[`should render error message if token is falsy 1`] = `
   <mock-StoreTitle>
     Reset Password
   </mock-StoreTitle>
-  <h1>
+  <h1
+    aria-live="polite"
+  >
     <mock-FormattedMessage
       defaultMessage="Reset Password"
       id="resetPassword.header"
@@ -27,7 +29,9 @@ exports[`should render formErrors 1`] = `
   <mock-StoreTitle>
     Reset Password
   </mock-StoreTitle>
-  <h1>
+  <h1
+    aria-live="polite"
+  >
     <mock-FormattedMessage
       defaultMessage="Reset Password"
       id="resetPassword.header"
@@ -174,7 +178,9 @@ exports[`should render properly 1`] = `
   <mock-StoreTitle>
     Reset Password
   </mock-StoreTitle>
-  <h1>
+  <h1
+    aria-live="polite"
+  >
     <mock-FormattedMessage
       defaultMessage="Reset Password"
       id="resetPassword.header"
@@ -321,7 +327,9 @@ exports[`should render success message if hasCompleted is true 1`] = `
   <mock-StoreTitle>
     Reset Password
   </mock-StoreTitle>
-  <h1>
+  <h1
+    aria-live="polite"
+  >
     <mock-FormattedMessage
       defaultMessage="Reset Password"
       id="resetPassword.header"

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
@@ -113,7 +113,7 @@ const ResetPassword = props => {
                     defaultMessage: 'Reset Password'
                 })}
             </StoreTitle>
-            <h1 aria-live='polite' className={classes.header}>
+            <h1 aria-live="polite" className={classes.header}>
                 <FormattedMessage
                     id="resetPassword.header"
                     defaultMessage="Reset Password"

--- a/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
+++ b/packages/venia-ui/lib/components/MyAccount/ResetPassword/resetPassword.js
@@ -113,7 +113,7 @@ const ResetPassword = props => {
                     defaultMessage: 'Reset Password'
                 })}
             </StoreTitle>
-            <h1 className={classes.header}>
+            <h1 aria-live='polite' className={classes.header}>
                 <FormattedMessage
                     id="resetPassword.header"
                     defaultMessage="Reset Password"

--- a/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/__snapshots__/orderHistoryPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/__tests__/__snapshots__/orderHistoryPage.spec.js.snap
@@ -7,6 +7,7 @@ exports[`renders correctly with data 1`] = `
   >
     Title
     <h1
+      aria-live="polite"
       className="heading"
     >
       Order History
@@ -207,6 +208,7 @@ exports[`renders correctly without data 1`] = `
   >
     Title
     <h1
+      aria-live="polite"
       className="heading"
     >
       Order History
@@ -383,6 +385,7 @@ exports[`renders invalid order id message if order id is wrong 1`] = `
   >
     Title
     <h1
+      aria-live="polite"
       className="heading"
     >
       Order History
@@ -570,6 +573,7 @@ exports[`renders loading indicator 1`] = `
   >
     Title
     <h1
+      aria-live="polite"
       className="heading"
     >
       Order History
@@ -780,6 +784,7 @@ exports[`renders no orders message is orders is empty 1`] = `
   >
     Title
     <h1
+      aria-live="polite"
       className="heading"
     >
       Order History

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
@@ -160,7 +160,9 @@ const OrderHistoryPage = props => {
         <OrderHistoryContextProvider>
             <div className={classes.root}>
                 <StoreTitle>{PAGE_TITLE}</StoreTitle>
-                <h1 aria-live='polite' className={classes.heading}>{PAGE_TITLE}</h1>
+                <h1 aria-live="polite" className={classes.heading}>
+                    {PAGE_TITLE}
+                </h1>
                 <div className={classes.filterRow}>
                     <span className={classes.pageInfo}>{pageInfoLabel}</span>
                     <Form className={classes.search} onSubmit={handleSubmit}>

--- a/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
+++ b/packages/venia-ui/lib/components/OrderHistoryPage/orderHistoryPage.js
@@ -160,7 +160,7 @@ const OrderHistoryPage = props => {
         <OrderHistoryContextProvider>
             <div className={classes.root}>
                 <StoreTitle>{PAGE_TITLE}</StoreTitle>
-                <h1 className={classes.heading}>{PAGE_TITLE}</h1>
+                <h1 aria-live='polite' className={classes.heading}>{PAGE_TITLE}</h1>
                 <div className={classes.filterRow}>
                     <span className={classes.pageInfo}>{pageInfoLabel}</span>
                     <Form className={classes.search} onSubmit={handleSubmit}>

--- a/packages/venia-ui/lib/components/ProductFullDetail/__tests__/__snapshots__/productFullDetail.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductFullDetail/__tests__/__snapshots__/productFullDetail.spec.js.snap
@@ -11,6 +11,7 @@ exports[`it disables the add to cart button when the talon indicates 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -171,6 +172,7 @@ exports[`it does not render options if the product is not a ConfigurableProduct 
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -301,6 +303,7 @@ exports[`it renders an error for an invalid cart 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -465,6 +468,7 @@ exports[`it renders an error for an invalid user token when adding to cart 1`] =
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -634,6 +638,7 @@ Array [
       className="title"
     >
       <h1
+        aria-live="polite"
         className="productName"
       >
         Flux Capacitor
@@ -795,6 +800,7 @@ exports[`it renders correctly 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -955,6 +961,7 @@ exports[`it renders field level errors for quantity - message 1 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -1115,6 +1122,7 @@ exports[`it renders field level errors for quantity - message 2 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -1275,6 +1283,7 @@ exports[`it renders field level errors for quantity - message 3 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -1435,6 +1444,7 @@ exports[`it renders form level errors 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -1599,6 +1609,7 @@ exports[`it renders message with unsupported product type 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -1772,6 +1783,7 @@ exports[`out of stock disabled CTA button is rendered if out of stock 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor
@@ -1902,6 +1914,7 @@ exports[`renders a WishlistButton with props 1`] = `
     className="title"
   >
     <h1
+      aria-live="polite"
       className="productName"
     >
       Flux Capacitor

--- a/packages/venia-ui/lib/components/ProductFullDetail/productFullDetail.js
+++ b/packages/venia-ui/lib/components/ProductFullDetail/productFullDetail.js
@@ -173,6 +173,7 @@ const ProductFullDetail = props => {
             >
                 <section className={classes.title}>
                     <h1
+                        aria-live='polite'
                         className={classes.productName}
                         data-cy="ProductFullDetail-productName"
                     >

--- a/packages/venia-ui/lib/components/ProductFullDetail/productFullDetail.js
+++ b/packages/venia-ui/lib/components/ProductFullDetail/productFullDetail.js
@@ -173,7 +173,7 @@ const ProductFullDetail = props => {
             >
                 <section className={classes.title}>
                     <h1
-                        aria-live='polite'
+                        aria-live="polite"
                         className={classes.productName}
                         data-cy="ProductFullDetail-productName"
                     >

--- a/packages/venia-ui/lib/components/SavedPaymentsPage/__tests__/__snapshots__/savedPaymentsPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/SavedPaymentsPage/__tests__/__snapshots__/savedPaymentsPage.spec.js.snap
@@ -6,6 +6,7 @@ exports[`renders correctly when there are existing saved payments 1`] = `
 >
   Title
   <h1
+    aria-live="polite"
     className="heading"
   >
     Saved Payments
@@ -37,6 +38,7 @@ exports[`renders correctly when there are no existing saved payments 1`] = `
 >
   Title
   <h1
+    aria-live="polite"
     className="heading"
   >
     Saved Payments

--- a/packages/venia-ui/lib/components/SavedPaymentsPage/savedPaymentsPage.js
+++ b/packages/venia-ui/lib/components/SavedPaymentsPage/savedPaymentsPage.js
@@ -55,7 +55,7 @@ const SavedPaymentsPage = props => {
     return (
         <div className={classes.root}>
             <StoreTitle>{title}</StoreTitle>
-            <h1 className={classes.heading}>{title}</h1>
+            <h1 aria-live='polite' className={classes.heading}>{title}</h1>
             <div className={classes.content}>{savedPaymentElements}</div>
             <div className={classes.noPayments}>{noSavedPayments}</div>
         </div>

--- a/packages/venia-ui/lib/components/SavedPaymentsPage/savedPaymentsPage.js
+++ b/packages/venia-ui/lib/components/SavedPaymentsPage/savedPaymentsPage.js
@@ -55,7 +55,9 @@ const SavedPaymentsPage = props => {
     return (
         <div className={classes.root}>
             <StoreTitle>{title}</StoreTitle>
-            <h1 aria-live='polite' className={classes.heading}>{title}</h1>
+            <h1 aria-live="polite" className={classes.heading}>
+                {title}
+            </h1>
             <div className={classes.content}>{savedPaymentElements}</div>
             <div className={classes.noPayments}>{noSavedPayments}</div>
         </div>

--- a/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlistPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlistPage.spec.js.snap
@@ -5,6 +5,7 @@ exports[`empty single wishlist 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="heading"
   >
     <mock-FormattedMessage
@@ -29,6 +30,7 @@ exports[`renders a single wishlist without visibility toggle 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="heading"
   >
     <mock-FormattedMessage
@@ -61,6 +63,7 @@ exports[`renders disabled feature error 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="heading"
   >
     <mock-FormattedMessage
@@ -91,6 +94,7 @@ exports[`renders general fetch error 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="heading"
   >
     <mock-FormattedMessage
@@ -203,6 +207,7 @@ exports[`renders wishlist data 1`] = `
   className="root"
 >
   <h1
+    aria-live="polite"
     className="heading"
   >
     <mock-FormattedMessage

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistPage.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistPage.js
@@ -81,7 +81,7 @@ const WishlistPage = props => {
 
     return (
         <div className={classes.root} data-cy="Wishlist-root">
-            <h1 className={classes.heading} data-cy="WishlistPage-heading">
+            <h1 aria-live='polite' className={classes.heading} data-cy="WishlistPage-heading">
                 <FormattedMessage
                     values={{ count: wishlists.length }}
                     id={'wishlistPage.headingText'}

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistPage.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistPage.js
@@ -81,7 +81,11 @@ const WishlistPage = props => {
 
     return (
         <div className={classes.root} data-cy="Wishlist-root">
-            <h1 aria-live='polite' className={classes.heading} data-cy="WishlistPage-heading">
+            <h1
+                aria-live="polite"
+                className={classes.heading}
+                data-cy="WishlistPage-heading"
+            >
                 <FormattedMessage
                     values={{ count: wishlists.length }}
                     id={'wishlistPage.headingText'}


### PR DESCRIPTION
…rn: No announcement for new page view)

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Screen readers not informed when new page view loads.

Environment
Adobe Magento - Venia

Context
Windows 10; Chrome 88; JAWS 2021

Reproduction Steps
Locations (representative sample):

Global Header
Landing Page
Search Results
Product Detail Page
Shopping Bag Mini Cart
Shopping Bag
Checkout - Shipping Information
- Checkout - Confirmation / Create an Account
Sign In
1. Press Tab to move through the content and activate one of the following:

navigation link
Sign In button
Create an Account button
Place Order button
Actual Behavior
When a new page view is rendered, screen reader users are not informed. Although the page title changes, this title change is not announced.

Expected Behavior
Ensure that screen reader users are informed when the page content has changed. This can be accomplished either by providing a live region that is updated when the page title changes (i.e. an element such as a <div> with aria-live="polite") , or by setting focus to the < h1 > of the page.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes https://jira.corp.magento.com/browse/AC-2482

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3824: AC-2482::Screen readers not informed when new page view loads. (patte…