### PR TITLE
AC-2785::Custom dropdown controls lack appropriate name and state inf…

### DIFF
--- a/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/currencySwitcher.spec.js.snap
+++ b/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/currencySwitcher.spec.js.snap
@@ -5,6 +5,7 @@ exports[`does not render CurrencySwitcher when there is only one available store
   className="root"
 >
   <button
+    aria-expanded={false}
     aria-label="EUR"
     className="trigger"
     onClick={[MockFunction]}
@@ -27,9 +28,12 @@ exports[`does not render CurrencySwitcher when there is only one available store
   <div
     className="menu"
   >
-    <ul>
+    <ul
+      role="listbox"
+    >
       <li
         className="menuItem"
+        role="option"
       >
         <button
           className="root"
@@ -58,6 +62,7 @@ exports[`does not render CurrencySwitcher when there is only one available store
       </li>
       <li
         className="menuItem"
+        role="option"
       >
         <button
           className="root"
@@ -114,6 +119,7 @@ exports[`renders the correct tree 1`] = `
   className="root"
 >
   <button
+    aria-expanded={false}
     aria-label="EUR"
     className="trigger"
     onClick={[MockFunction]}
@@ -136,9 +142,12 @@ exports[`renders the correct tree 1`] = `
   <div
     className="menu"
   >
-    <ul>
+    <ul
+      role="listbox"
+    >
       <li
         className="menuItem"
+        role="option"
       >
         <button
           className="root"
@@ -167,6 +176,7 @@ exports[`renders the correct tree 1`] = `
       </li>
       <li
         className="menuItem"
+        role="option"
       >
         <button
           className="root"

--- a/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/currencySwitcher.spec.js.snap
+++ b/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/currencySwitcher.spec.js.snap
@@ -32,6 +32,7 @@ exports[`does not render CurrencySwitcher when there is only one available store
       role="listbox"
     >
       <li
+        aria-selected="EUR"
         className="menuItem"
         role="option"
       >
@@ -61,6 +62,7 @@ exports[`does not render CurrencySwitcher when there is only one available store
         </button>
       </li>
       <li
+        aria-selected="EUR"
         className="menuItem"
         role="option"
       >
@@ -146,6 +148,7 @@ exports[`renders the correct tree 1`] = `
       role="listbox"
     >
       <li
+        aria-selected="EUR"
         className="menuItem"
         role="option"
       >
@@ -175,6 +178,7 @@ exports[`renders the correct tree 1`] = `
         </button>
       </li>
       <li
+        aria-selected="EUR"
         className="menuItem"
         role="option"
       >

--- a/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/storeSwitcher.spec.js.snap
+++ b/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/storeSwitcher.spec.js.snap
@@ -7,6 +7,7 @@ exports[`does not render group name when there is only one group 1`] = `
   className="root"
 >
   <button
+    aria-expanded={false}
     aria-label="Store 2"
     className="trigger"
     onClick={[MockFunction]}
@@ -21,9 +22,11 @@ exports[`does not render group name when there is only one group 1`] = `
     >
       <ul
         className="groupList"
+        role="listbox"
       >
         <li
           className="menuItem"
+          role="option"
         >
           <button
             className="root"
@@ -43,6 +46,7 @@ exports[`does not render group name when there is only one group 1`] = `
         </li>
         <li
           className="menuItem"
+          role="option"
         >
           <button
             className="root"
@@ -91,6 +95,7 @@ exports[`renders the correct tree 1`] = `
   className="root"
 >
   <button
+    aria-expanded={false}
     aria-label="Store 2"
     className="trigger"
     onClick={[MockFunction]}
@@ -105,9 +110,11 @@ exports[`renders the correct tree 1`] = `
     >
       <ul
         className="groupList"
+        role="listbox"
       >
         <li
           className="menuItem"
+          role="option"
         >
           <button
             className="root"
@@ -127,6 +134,7 @@ exports[`renders the correct tree 1`] = `
         </li>
         <li
           className="menuItem"
+          role="option"
         >
           <button
             className="root"
@@ -167,9 +175,11 @@ exports[`renders the correct tree 1`] = `
       </ul>
       <ul
         className="groupList"
+        role="listbox"
       >
         <li
           className="menuItem"
+          role="option"
         >
           <button
             className="root"
@@ -189,6 +199,7 @@ exports[`renders the correct tree 1`] = `
         </li>
         <li
           className="menuItem"
+          role="option"
         >
           <button
             className="root"

--- a/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/storeSwitcher.spec.js.snap
+++ b/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/storeSwitcher.spec.js.snap
@@ -25,6 +25,7 @@ exports[`does not render group name when there is only one group 1`] = `
         role="listbox"
       >
         <li
+          aria-selected="Store 2"
           className="menuItem"
           role="option"
         >
@@ -45,6 +46,7 @@ exports[`does not render group name when there is only one group 1`] = `
           </button>
         </li>
         <li
+          aria-selected="Store 2"
           className="menuItem"
           role="option"
         >
@@ -113,6 +115,7 @@ exports[`renders the correct tree 1`] = `
         role="listbox"
       >
         <li
+          aria-selected="Store 2"
           className="menuItem"
           role="option"
         >
@@ -133,6 +136,7 @@ exports[`renders the correct tree 1`] = `
           </button>
         </li>
         <li
+          aria-selected="Store 2"
           className="menuItem"
           role="option"
         >
@@ -178,6 +182,7 @@ exports[`renders the correct tree 1`] = `
         role="listbox"
       >
         <li
+          aria-selected="Store 2"
           className="menuItem"
           role="option"
         >
@@ -198,6 +203,7 @@ exports[`renders the correct tree 1`] = `
           </button>
         </li>
         <li
+          aria-selected="Store 2"
           className="menuItem"
           role="option"
         >

--- a/packages/venia-ui/lib/components/Header/currencySwitcher.js
+++ b/packages/venia-ui/lib/components/Header/currencySwitcher.js
@@ -33,7 +33,7 @@ const CurrencySwitcher = props => {
 
     const currencies = availableCurrencies.map(code => {
         return (
-            <li key={code} className={classes.menuItem}>
+            <li role="option" key={code} className={classes.menuItem}>
                 <SwitcherItem
                     active={code === currentCurrencyCode}
                     onClick={handleSwitchCurrency}
@@ -58,6 +58,7 @@ const CurrencySwitcher = props => {
                 aria-label={currentCurrencyCode}
                 onClick={handleTriggerClick}
                 ref={currencyMenuTriggerRef}
+                aria-expanded={currencyMenuIsOpen}
             >
                 <span className={classes.label}>
                     <CurrencySymbol
@@ -69,7 +70,7 @@ const CurrencySwitcher = props => {
                 </span>
             </button>
             <div ref={currencyMenuRef} className={menuClassName}>
-                <ul>{currencies}</ul>
+                <ul role="listbox">{currencies}</ul>
             </div>
         </div>
     );

--- a/packages/venia-ui/lib/components/Header/currencySwitcher.js
+++ b/packages/venia-ui/lib/components/Header/currencySwitcher.js
@@ -33,7 +33,7 @@ const CurrencySwitcher = props => {
 
     const currencies = availableCurrencies.map(code => {
         return (
-            <li role="option" key={code} className={classes.menuItem}>
+            <li role="option" aria-selected={currentCurrencyCode} key={code} className={classes.menuItem}>
                 <SwitcherItem
                     active={code === currentCurrencyCode}
                     onClick={handleSwitchCurrency}

--- a/packages/venia-ui/lib/components/Header/currencySwitcher.js
+++ b/packages/venia-ui/lib/components/Header/currencySwitcher.js
@@ -33,7 +33,12 @@ const CurrencySwitcher = props => {
 
     const currencies = availableCurrencies.map(code => {
         return (
-            <li role="option" aria-selected={currentCurrencyCode} key={code} className={classes.menuItem}>
+            <li
+                role="option"
+                aria-selected={currentCurrencyCode}
+                key={code}
+                className={classes.menuItem}
+            >
                 <SwitcherItem
                     active={code === currentCurrencyCode}
                     onClick={handleSwitchCurrency}

--- a/packages/venia-ui/lib/components/Header/storeSwitcher.js
+++ b/packages/venia-ui/lib/components/Header/storeSwitcher.js
@@ -42,6 +42,7 @@ const StoreSwitcher = props => {
             }
             stores.push(
                 <li
+                    role="option"
                     key={code}
                     className={classes.menuItem}
                     data-cy="StoreSwitcher-view"
@@ -59,6 +60,7 @@ const StoreSwitcher = props => {
 
         groups.push(
             <ul
+                role="listbox"
                 className={classes.groupList}
                 key={key}
                 data-cy="StoreSwitcher-group"
@@ -84,6 +86,7 @@ const StoreSwitcher = props => {
                 onClick={handleTriggerClick}
                 ref={storeMenuTriggerRef}
                 data-cy="StoreSwitcher-trigger"
+                aria-expanded={storeMenuIsOpen}
             >
                 {triggerLabel}
             </button>

--- a/packages/venia-ui/lib/components/Header/storeSwitcher.js
+++ b/packages/venia-ui/lib/components/Header/storeSwitcher.js
@@ -42,6 +42,7 @@ const StoreSwitcher = props => {
             }
             stores.push(
                 <li
+                    aria-selected={currentStoreName}
                     role="option"
                     key={code}
                     className={classes.menuItem}


### PR DESCRIPTION
…ormation.

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Custom dropdown controls lack appropriate name and state information.

Environment
Adobe Magento - Venia

Context
Windows; Chrome 88; JAWS 2021

Reproduction Steps
[NODE][body>div:nth-of-type(1)>*:nth-child(1)>*:nth-child(2)]

1. With JAWS operating, press Tab to move through the content.

Actual Behavior
Buttons that trigger dropdowns do not provide information to indicate that there is an expandable dropdown associated or whether the dropdown is currently expanded. The name of these buttons do not identify the purpose of the control, but instead identifies the currently selected value. Examples include:

"Default Store View"
"$ USD"

When controls do not provide name, role and/or state, screen reader users will not know their purpose and current state.

Expected Behavior
Ensure that these controls provide accessible names and indicate their expanded or collapsed state.

Consider whether these controls can be implemented as listboxes. See the WAI-ARIA Authoring Practices design pattern for Listbox (https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox), referencing the Collapsible Dropdown Listbox Example (https://www.w3.org/TR/wai-aria-practices-1.1/examples/listbox/listbox-collapsible.html).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes [AC-2785.](https://jira.corp.magento.com/browse/AC-2785)

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3821: AC-2785::Custom dropdown controls lack appropriate name and state inf…