### PR TITLE
PWA-2801: Reduce docker build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,24 @@
+**/*.git
+.github/
+**/.gitignore
+
+CHANGELOG.md
+pwa-devdocs/
+images/
+
+*.dockerfile
+docker/
+!docker/.env*
+
+**/.editorconfig
+
+docker-compose.yml
+
+scripts/
+!scripts/monorepo-introduction.js
+
+# mounted as a volume and used with cypress image, not pwa-studio build
+venia-integration-tests/
+
 packages/**/node_modules
 packages/**/dist


### PR DESCRIPTION
## Description

Reduces the context sent to the Docker daemon upon builds. 

Example, on related builds

```
+ docker build ...
Sending build context to Docker daemon  385.9MB
```

After (this build)

```
+ docker build ...
Sending build context to Docker daemon  12.79MB
```

Closes JIRA-[PWA-2801](https://jira.corp.magento.com/browse/PWA-2801).

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->


Docker builds continue to work (necessary files are copied in from the context) and we are able to deploy a running container. 

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->


#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

Docker build and deploys are successful. 

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
