### PR TITLE
PWA-2948::Console error on accessing different filters, venia page al…

### DIFF
--- a/packages/peregrine/lib/talons/SearchPage/useSearchPage.js
+++ b/packages/peregrine/lib/talons/SearchPage/useSearchPage.js
@@ -172,7 +172,7 @@ export const useSearchPage = (props = {}) => {
         const newFilters = {};
         const refinementData = [];
         filters.forEach((values, key) => {
-            key = (key == 'category_uid') ? 'category_id' : key;
+            key = key == 'category_uid' ? 'category_id' : key;
             const filterMapType = filterTypeMap.get(key);
             newFilters[key] = getFilterInput(values, filterMapType);
             refinementData.push({

--- a/packages/peregrine/lib/talons/SearchPage/useSearchPage.js
+++ b/packages/peregrine/lib/talons/SearchPage/useSearchPage.js
@@ -172,6 +172,7 @@ export const useSearchPage = (props = {}) => {
         const newFilters = {};
         const refinementData = [];
         filters.forEach((values, key) => {
+            key = (key == 'category_uid') ? 'category_id' : key;
             const filterMapType = filterTypeMap.get(key);
             newFilters[key] = getFilterInput(values, filterMapType);
             refinementData.push({


### PR DESCRIPTION


## Description
Steps to Reproduce

Go to https://develop.pwa-venia.com/search.html?query=Tops&page=1&price%5Bfilter%5D=100-200%2C100_200&category_uid%5Bfilter%5D=Tops%2C8
Expected - Filter should work

Actual - Error toast is displaying. Console error -

client.6ca431a9afdb603e0cfa.js:2697 Unhandled TypeError541 TypeError: Cannot read properties of null (reading 'items')
    at https://develop.pwa-venia.com/RootCmp_SEARCH__default.ec17b7754fcfb8113d40.js:141:841
    at Object.ci [as useMemo] (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:2486:47)
    at https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:1441:662
    at SearchPage (https://develop.pwa-venia.com/RootCmp_SEARCH__default.ec17b7754fcfb8113d40.js:141:391)
    at Ch (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:2429:150)
    at li (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:2518:28)
    at ho (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:3075:41)
    at bk (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:2902:126)
    at ak (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:2902:54)
    at Tj (https://develop.pwa-venia.com/vendors.646665da47d8ec0c465c.js:2900:35)
errorRecord @ client.6ca431a9afdb603e0cfa.js:2697
(anonymous) @ client.6ca431a9afdb603e0cfa.js:3096
useMemo @ vendors.646665da47d8ec0c465c.js:2490
(anonymous) @ vendors.646665da47d8ec0c465c.js:1441
useApp @ client.6ca431a9afdb603e0cfa.js:3096
App @ client.6ca431a9afdb603e0cfa.js:3101

## Related Issue


Closes [#PWA-2948.](https://jira.corp.magento.com/browse/PWA-2948)

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
