### PR TITLE
AC-3522::Product search result with items count is not being read by …

### DIFF
--- a/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.js
+++ b/packages/venia-ui/lib/components/FilterSidebar/filterSidebar.js
@@ -101,7 +101,6 @@ const FilterSidebar = props => {
             className={classes.root}
             ref={filterRef}
             data-cy="FilterSidebar-root"
-            aria-live="polite"
             aria-busy="false"
         >
             <div className={classes.body}>

--- a/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/gallery.spec.js.snap
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/gallery.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`renders if \`items\` is an array of objects 1`] = `
 <div
   aria-busy="false"
-  aria-live="polite"
   className="root"
 >
   <div
@@ -208,7 +207,6 @@ exports[`renders if \`items\` is an array of objects 1`] = `
 exports[`renders if \`items\` is an empty array 1`] = `
 <div
   aria-busy="false"
-  aria-live="polite"
   className="root"
 >
   <div

--- a/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/gallery.spec.js.snap
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/gallery.spec.js.snap
@@ -9,8 +9,6 @@ exports[`renders if \`items\` is an array of objects 1`] = `
     className="items"
   >
     <div
-      aria-busy="false"
-      aria-live="polite"
       className="root"
     >
       <div
@@ -105,8 +103,6 @@ exports[`renders if \`items\` is an array of objects 1`] = `
       </div>
     </div>
     <div
-      aria-busy="false"
-      aria-live="polite"
       className="root"
     >
       <div

--- a/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/item.spec.js.snap
+++ b/packages/venia-ui/lib/components/Gallery/__tests__/__snapshots__/item.spec.js.snap
@@ -61,8 +61,6 @@ exports[`renders a placeholder item while awaiting item 1`] = `
 
 exports[`renders correctly with valid item data 1`] = `
 <div
-  aria-busy="false"
-  aria-live="polite"
   className="root"
 >
   <a

--- a/packages/venia-ui/lib/components/Gallery/gallery.js
+++ b/packages/venia-ui/lib/components/Gallery/gallery.js
@@ -37,11 +37,7 @@ const Gallery = props => {
     );
 
     return (
-        <div
-            data-cy="Gallery-root"
-            className={classes.root}
-            aria-busy="false"
-        >
+        <div data-cy="Gallery-root" className={classes.root} aria-busy="false">
             <div className={classes.items}>{galleryItems}</div>
         </div>
     );

--- a/packages/venia-ui/lib/components/Gallery/gallery.js
+++ b/packages/venia-ui/lib/components/Gallery/gallery.js
@@ -40,7 +40,6 @@ const Gallery = props => {
         <div
             data-cy="Gallery-root"
             className={classes.root}
-            aria-live="polite"
             aria-busy="false"
         >
             <div className={classes.items}>{galleryItems}</div>

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -83,11 +83,7 @@ const GalleryItem = props => {
     // ) : null;
 
     return (
-        <div
-            data-cy="GalleryItem-root"
-            className={classes.root}
-            ref={itemRef}
-        >
+        <div data-cy="GalleryItem-root" className={classes.root} ref={itemRef}>
             <Link
                 onClick={handleLinkClick}
                 to={productLink}

--- a/packages/venia-ui/lib/components/Gallery/item.js
+++ b/packages/venia-ui/lib/components/Gallery/item.js
@@ -86,8 +86,6 @@ const GalleryItem = props => {
         <div
             data-cy="GalleryItem-root"
             className={classes.root}
-            aria-live="polite"
-            aria-busy="false"
             ref={itemRef}
         >
             <Link

--- a/packages/venia-ui/lib/components/ProductSort/__tests__/__snapshots__/productSort.spec.js.snap
+++ b/packages/venia-ui/lib/components/ProductSort/__tests__/__snapshots__/productSort.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`renders correctly 1`] = `
 <div
   aria-busy="false"
-  aria-live="polite"
 >
   <button
     disabled={false}

--- a/packages/venia-ui/lib/components/ProductSort/productSort.js
+++ b/packages/venia-ui/lib/components/ProductSort/productSort.js
@@ -162,7 +162,6 @@ const ProductSort = props => {
             ref={elementRef}
             className={classes.root}
             data-cy="ProductSort-root"
-            aria-live="polite"
             aria-busy="false"
         >
             <Button

--- a/packages/venia-ui/lib/components/SearchPage/__tests__/__snapshots__/searchPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/SearchPage/__tests__/__snapshots__/searchPage.spec.js.snap
@@ -14,6 +14,8 @@ exports[`Search Page Component error view does not render when data is present 1
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -21,8 +23,7 @@ exports[`Search Page Component error view does not render when data is present 1
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           0 items
@@ -85,6 +86,8 @@ exports[`Search Page Component error view renders when data is not present and n
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       />
       <div
@@ -129,6 +132,8 @@ exports[`Search Page Component filter button/modal does not render if there are 
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -136,8 +141,7 @@ exports[`Search Page Component filter button/modal does not render if there are 
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           0 items
@@ -208,6 +212,8 @@ exports[`Search Page Component filter button/modal renders when there are filter
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -215,8 +221,7 @@ exports[`Search Page Component filter button/modal renders when there are filter
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           0 items
@@ -294,6 +299,8 @@ exports[`Search Page Component loading indicator does not render when data is pr
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <Shimmer
@@ -363,6 +370,8 @@ exports[`Search Page Component loading indicator renders when data is not presen
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <Shimmer
@@ -433,6 +442,8 @@ exports[`Search Page Component search results does not render if data returned h
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <Shimmer
@@ -487,6 +498,8 @@ exports[`Search Page Component search results heading renders a generic message 
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -494,8 +507,7 @@ exports[`Search Page Component search results heading renders a generic message 
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           1 items
@@ -590,6 +602,8 @@ exports[`Search Page Component search results heading renders a specific message
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -604,8 +618,7 @@ exports[`Search Page Component search results heading renders a specific message
           }
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           1 items
@@ -700,6 +713,8 @@ exports[`Search Page Component search results renders if data has items 1`] = `
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <Shimmer
@@ -769,6 +784,8 @@ exports[`Search Page Component sort button/container does not render if total co
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -776,8 +793,7 @@ exports[`Search Page Component sort button/container does not render if total co
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           0 items
@@ -825,6 +841,8 @@ exports[`Search Page Component sort button/container renders when total count > 
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -832,8 +850,7 @@ exports[`Search Page Component sort button/container renders when total count > 
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           1 items
@@ -928,6 +945,8 @@ exports[`Search Page Component total count renders 0 items if data.products.tota
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -935,8 +954,7 @@ exports[`Search Page Component total count renders 0 items if data.products.tota
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           0 items
@@ -984,6 +1002,8 @@ exports[`Search Page Component total count renders results from data 1`] = `
       className="heading"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
         className="searchInfo"
       >
         <mock-FormattedMessage
@@ -991,8 +1011,7 @@ exports[`Search Page Component total count renders results from data 1`] = `
           id="searchPage.searchTermEmpty"
         />
         <span
-          aria-busy="true"
-          aria-live="assertive"
+          aria-live="polite"
           className="totalPages"
         >
           1 items

--- a/packages/venia-ui/lib/components/SearchPage/__tests__/__snapshots__/searchPage.spec.js.snap
+++ b/packages/venia-ui/lib/components/SearchPage/__tests__/__snapshots__/searchPage.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Search Page Component error view does not render when data is present 1
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           0 items
@@ -137,7 +137,7 @@ exports[`Search Page Component filter button/modal does not render if there are 
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           0 items
@@ -216,7 +216,7 @@ exports[`Search Page Component filter button/modal renders when there are filter
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           0 items
@@ -495,7 +495,7 @@ exports[`Search Page Component search results heading renders a generic message 
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           1 items
@@ -605,7 +605,7 @@ exports[`Search Page Component search results heading renders a specific message
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           1 items
@@ -777,7 +777,7 @@ exports[`Search Page Component sort button/container does not render if total co
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           0 items
@@ -833,7 +833,7 @@ exports[`Search Page Component sort button/container renders when total count > 
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           1 items
@@ -936,7 +936,7 @@ exports[`Search Page Component total count renders 0 items if data.products.tota
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           0 items
@@ -992,7 +992,7 @@ exports[`Search Page Component total count renders results from data 1`] = `
         />
         <span
           aria-busy="true"
-          aria-live="polite"
+          aria-live="assertive"
           className="totalPages"
         >
           1 items

--- a/packages/venia-ui/lib/components/SearchPage/searchPage.js
+++ b/packages/venia-ui/lib/components/SearchPage/searchPage.js
@@ -173,10 +173,7 @@ const SearchPage = props => {
 
     const itemCountHeading =
         data && !loading ? (
-            <span
-                aria-live="polite"
-                className={classes.totalPages}
-            >
+            <span aria-live="polite" className={classes.totalPages}>
                 {formatMessage(
                     {
                         id: 'searchPage.totalPages',
@@ -202,7 +199,11 @@ const SearchPage = props => {
             </div>
             <div className={classes.searchContent}>
                 <div className={classes.heading}>
-                    <div aria-live="polite" aria-atomic='true' className={classes.searchInfo}>
+                    <div
+                        aria-live="polite"
+                        aria-atomic="true"
+                        className={classes.searchInfo}
+                    >
                         {searchResultsHeading}
                         {itemCountHeading}
                     </div>

--- a/packages/venia-ui/lib/components/SearchPage/searchPage.js
+++ b/packages/venia-ui/lib/components/SearchPage/searchPage.js
@@ -174,7 +174,7 @@ const SearchPage = props => {
     const itemCountHeading =
         data && !loading ? (
             <span
-                aria-live="polite"
+                aria-live="assertive"
                 aria-busy="true"
                 className={classes.totalPages}
             >

--- a/packages/venia-ui/lib/components/SearchPage/searchPage.js
+++ b/packages/venia-ui/lib/components/SearchPage/searchPage.js
@@ -174,8 +174,7 @@ const SearchPage = props => {
     const itemCountHeading =
         data && !loading ? (
             <span
-                aria-live="assertive"
-                aria-busy="true"
+                aria-live="polite"
                 className={classes.totalPages}
             >
                 {formatMessage(
@@ -203,7 +202,7 @@ const SearchPage = props => {
             </div>
             <div className={classes.searchContent}>
                 <div className={classes.heading}>
-                    <div className={classes.searchInfo}>
+                    <div aria-live="polite" aria-atomic='true' className={classes.searchInfo}>
                         {searchResultsHeading}
                         {itemCountHeading}
                     </div>

--- a/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.js
+++ b/packages/venia-ui/lib/components/SortedByContainer/sortedByContainer.js
@@ -10,7 +10,7 @@ const SortedByContainer = props => {
     const classes = useStyle(defaultClasses, props.classes);
 
     return (
-        <div className={classes.root} aria-live="polite" aria-busy="true">
+        <div className={classes.root} aria-busy="true">
             <FormattedMessage
                 id={'searchPage.sortContainer'}
                 defaultMessage={'Items sorted by '}


### PR DESCRIPTION
## Description

product search result with items count is not being read by screen reader

Pre Conditions:

Have Venia setup working with Magento 2.4.5-alpha2 in the local.
Have sample data available in the instance
Have Google chrome screen reader extension enabled and working.
Steps to reproduce:

Keeping extension enabled, open the venia front end in the chrome browser.
Tab the focus to search button in the home page.
Press return key from the keyboard and input with the text that results with items found. (ex: carina)
Expected: Screen reader should announce the total items found in the searched result.

Actual: Randomly announcing the text from left side filters options sometimes or sort items dropdown, as such.



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes #[AC-3522](https://jira.corp.adobe.com/browse/AC-3522)
Closes #[PWA-2972](https://jira.corp.adobe.com/browse/PWA-2972)

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3938: AC-3522::Product search result with items count is not being read by …