### PR TITLE
Logo misses required alt property for image

### DIFF
--- a/packages/venia-ui/lib/components/Logo/logo.js
+++ b/packages/venia-ui/lib/components/Logo/logo.js
@@ -26,6 +26,7 @@ const Logo = props => {
             classes={{ image: classes.logo }}
             height={height}
             src={logo}
+            alt={title}
             title={title}
             width={width}
         />


### PR DESCRIPTION
In my installation, the Image component requires the `alt` property, but the `Logo` component does not render one.


### Resolved issues:
1. [x] resolves magento/pwa-studio#3937: Logo misses required alt property for image