### PR TITLE
PWA-2985: [bug]: Payment method always reverts to “Check / Money orde…

### DIFF
--- a/packages/peregrine/lib/hooks/useCustomerWishlistSkus/__tests__/useCustomerWishlistSkus.spec.js
+++ b/packages/peregrine/lib/hooks/useCustomerWishlistSkus/__tests__/useCustomerWishlistSkus.spec.js
@@ -49,6 +49,7 @@ test('pre-caches wishlist items', async () => {
         Object {
           "customerWishlistProducts": Array [
             "Dress",
+            "Shirt",
           ],
         }
     `);

--- a/packages/peregrine/lib/hooks/useCustomerWishlistSkus/__tests__/useCustomerWishlistSkus.spec.js
+++ b/packages/peregrine/lib/hooks/useCustomerWishlistSkus/__tests__/useCustomerWishlistSkus.spec.js
@@ -49,7 +49,6 @@ test('pre-caches wishlist items', async () => {
         Object {
           "customerWishlistProducts": Array [
             "Dress",
-            "Shirt",
           ],
         }
     `);

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/__snapshots__/usePaymentMethods.spec.js.snap
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/__snapshots__/usePaymentMethods.spec.js.snap
@@ -9,7 +9,7 @@ Object {
   ],
   "currentSelectedPaymentMethod": "currentSelectedPaymentMethod",
   "handlePaymentMethodSelection": [Function],
-  "initialSelectedMethod": "braintree",
+  "initialSelectedMethod": "availablePaymentMethod",
   "isLoading": false,
 }
 `;

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/__snapshots__/usePaymentMethods.spec.js.snap
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/__snapshots__/usePaymentMethods.spec.js.snap
@@ -8,7 +8,8 @@ Object {
     },
   ],
   "currentSelectedPaymentMethod": "currentSelectedPaymentMethod",
-  "initialSelectedMethod": "availablePaymentMethod",
+  "handlePaymentMethodSelection": [Function],
+  "initialSelectedMethod": "braintree",
   "isLoading": false,
 }
 `;

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/usePaymentMethods.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/usePaymentMethods.spec.js
@@ -18,14 +18,21 @@ jest.mock(
     }
 );
 
+const mockSetPaymentMethodOnCartMutation = jest.fn();
+
 jest.mock('@apollo/client', () => {
     return {
+        useMutation: jest.fn(() => [
+            mockSetPaymentMethodOnCartMutation,
+            { loading: true }
+        ]),
         useQuery: jest.fn().mockReturnValue({
             data: {
                 cart: {
                     available_payment_methods: [
                         { code: 'availablePaymentMethod' }
-                    ]
+                    ],
+                    selected_payment_method: { code: 'braintree' }
                 }
             },
             loading: false
@@ -34,8 +41,17 @@ jest.mock('@apollo/client', () => {
 });
 
 jest.mock('../paymentMethods.gql', () => ({
-    getPaymentMethodsQuery: 'paymentMethodsQuery'
+    getPaymentMethodsQuery: 'paymentMethodsQuery',
+    setPaymentMethodOnCartMutation: 'setPaymentMethod'
 }));
+
+const getPaymentMethodsQuery = 'getPaymentMethodsQuery';
+const setPaymentMethodOnCartMutation = 'setPaymentMethodOnCartMutation';
+
+const operations = {
+    getPaymentMethodsQuery,
+    setPaymentMethodOnCartMutation
+};
 
 const Component = props => {
     const talonProps = usePaymentMethods(props);
@@ -58,7 +74,9 @@ const getTalonProps = props => {
 };
 
 it('returns the correct shape', () => {
-    const { talonProps } = getTalonProps();
+    const { talonProps } = getTalonProps({
+        operations
+    });
 
     expect(talonProps).toMatchSnapshot();
 });

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/usePaymentMethods.spec.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/__tests__/usePaymentMethods.spec.js
@@ -89,3 +89,38 @@ it('returns an empty array for availablePaymentMethods when there is no data', (
     expect(talonProps.availablePaymentMethods).toEqual([]);
     expect(talonProps.initialSelectedMethod).toBeNull();
 });
+
+it('default payment is selected when there is one available payment method', () => {
+    useQuery.mockReturnValueOnce({
+        data: {
+            cart: {
+                available_payment_methods: [{ code: 'availablePaymentMethod' }],
+                selected_payment_method: { code: null }
+            }
+        }
+    });
+
+    const { talonProps } = getTalonProps();
+
+    expect(talonProps.availablePaymentMethods.length).toEqual(1);
+    expect(talonProps.initialSelectedMethod).toEqual('availablePaymentMethod');
+});
+
+it('default payment is not selected when there is more than one available payment method', () => {
+    useQuery.mockReturnValueOnce({
+        data: {
+            cart: {
+                available_payment_methods: [
+                    { code: 'availablePaymentMethod1' },
+                    { code: 'availablePaymentMethod2' }
+                ],
+                selected_payment_method: { code: null }
+            }
+        }
+    });
+
+    const { talonProps } = getTalonProps();
+
+    expect(talonProps.availablePaymentMethods.length).toEqual(2);
+    expect(talonProps.initialSelectedMethod).toBeNull();
+});

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/paymentMethods.gql.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/paymentMethods.gql.js
@@ -8,10 +8,33 @@ export const GET_PAYMENT_METHODS = gql`
                 code
                 title
             }
+            selected_payment_method {
+                code
+            }
+        }
+    }
+`;
+
+export const SET_PAYMENT_METHOD_ON_CART = gql`
+    mutation setPaymentMethodOnCart(
+        $cartId: String!
+        $paymentMethod: PaymentMethodInput!
+    ) {
+        setPaymentMethodOnCart(
+            input: { cart_id: $cartId, payment_method: $paymentMethod }
+        ) {
+            cart {
+                id
+                selected_payment_method {
+                    code
+                    title
+                }
+            }
         }
     }
 `;
 
 export default {
-    getPaymentMethodsQuery: GET_PAYMENT_METHODS
+    getPaymentMethodsQuery: GET_PAYMENT_METHODS,
+    setPaymentMethodOnCartMutation: SET_PAYMENT_METHOD_ON_CART
 };

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/usePaymentMethods.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/usePaymentMethods.js
@@ -1,4 +1,5 @@
-import { useQuery } from '@apollo/client';
+import { useCallback } from 'react';
+import { useMutation, useQuery } from '@apollo/client';
 import useFieldState from '@magento/peregrine/lib/hooks/hook-wrappers/useInformedFieldStateWrapper';
 import DEFAULT_OPERATIONS from './paymentMethods.gql';
 import mergeOperations from '@magento/peregrine/lib/util/shallowMerge';
@@ -7,7 +8,12 @@ import { useCartContext } from '../../../context/cart';
 
 export const usePaymentMethods = props => {
     const operations = mergeOperations(DEFAULT_OPERATIONS, props.operations);
-    const { getPaymentMethodsQuery } = operations;
+    const {
+        getPaymentMethodsQuery,
+        setPaymentMethodOnCartMutation
+    } = operations;
+
+    const [setPaymentMethod] = useMutation(setPaymentMethodOnCartMutation);
 
     const [{ cartId }] = useCartContext();
 
@@ -24,12 +30,32 @@ export const usePaymentMethods = props => {
         (data && data.cart.available_payment_methods) || [];
 
     const initialSelectedMethod =
-        (availablePaymentMethods.length && availablePaymentMethods[0].code) ||
-        null;
+        (data && data.cart.selected_payment_method.code) || null;
+
+    const handlePaymentMethodSelection = useCallback(
+        element => {
+            const value = element.target.value;
+
+            setPaymentMethod({
+                variables: {
+                    cartId,
+                    paymentMethod: {
+                        code: value,
+                        braintree: {
+                            payment_method_nonce: value,
+                            is_active_payment_token_enabler: false
+                        }
+                    }
+                }
+            });
+        },
+        [cartId, setPaymentMethod]
+    );
 
     return {
         availablePaymentMethods,
         currentSelectedPaymentMethod,
+        handlePaymentMethodSelection,
         initialSelectedMethod,
         isLoading: loading
     };

--- a/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/usePaymentMethods.js
+++ b/packages/peregrine/lib/talons/CheckoutPage/PaymentInformation/usePaymentMethods.js
@@ -29,8 +29,18 @@ export const usePaymentMethods = props => {
     const availablePaymentMethods =
         (data && data.cart.available_payment_methods) || [];
 
-    const initialSelectedMethod =
+    // If there is one payment method, select it by default.
+    // If more than one, none should be selected by default.
+    const defaultPaymentCode =
+        (availablePaymentMethods.length && availablePaymentMethods[0].code) ||
+        null;
+    const selectedPaymentCode =
         (data && data.cart.selected_payment_method.code) || null;
+
+    const initialSelectedMethod =
+        availablePaymentMethods.length > 1
+            ? selectedPaymentCode
+            : defaultPaymentCode;
 
     const handlePaymentMethodSelection = useCallback(
         element => {

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.js
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.js
@@ -28,6 +28,7 @@ const PaymentMethods = props => {
     const {
         availablePaymentMethods,
         currentSelectedPaymentMethod,
+        handlePaymentMethodSelection,
         initialSelectedMethod,
         isLoading
     } = talonProps;
@@ -65,6 +66,7 @@ const PaymentMethods = props => {
                             label: classes.radio_label
                         }}
                         checked={isSelected}
+                        onChange={handlePaymentMethodSelection}
                     />
                     {renderedComponent}
                 </div>

--- a/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.module.css
+++ b/packages/venia-ui/lib/components/CheckoutPage/PaymentInformation/paymentMethods.module.css
@@ -1,7 +1,7 @@
 .root {
     composes: grid from global;
     composes: p-md from global;
-    composes: pb-xs from global;
+    composes: pb-s from global;
 }
 
 .radio_group {
@@ -14,8 +14,6 @@
     composes: border-subtle from global;
     composes: pb-xs from global;
     composes: pt-xs from global;
-
-    composes: last_pt-0 from global;
 }
 
 /* TODO @TW: cannot compose */


### PR DESCRIPTION
…r” when there is an error with the transaction



<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

- Set selected payment method mutation upon onChange event
- Set initialSelectedMethod to selected_payment_method data
- Update test coverage & snapshots

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes #[PWA-2985](https://jira.corp.adobe.com/browse/PWA-2985).

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
