### PR TITLE
docs: correct peregrine reference to PWA docs

### DIFF
--- a/packages/peregrine/README.md
+++ b/packages/peregrine/README.md
@@ -1,1 +1,1 @@
-Documentation for Magento PWA Studio packages is located at [https://pwastudio.io](https://pwastudio.io).
+Documentation for Magento PWA Studio packages is located at [https://developer.adobe.com/commerce/pwa-studio/](https://developer.adobe.com/commerce/pwa-studio/).


### PR DESCRIPTION
## Description

Changed docs reference from `pwastudio.io` to `developer.adobe.com/commerce/pwa-studio`.

## Related Issue

No issue. Olena contacted me to fix.

Closes #NoIssue.

## Acceptance

- @tkacheva 
- @anthoula 

### Verification Stakeholders

- @tkacheva 
- @anthoula 

## Verification Steps

Navigate to https://www.npmjs.com/package/@magento/peregrine and click on the docs link in the peregrine package description. The link should take you to the home page of the PWA Studio docs.
