### PR TITLE
Remove all pwastudio.io documentation links

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,9 +2,9 @@
 
 Need help with something? Please use the following resources to get the help you need:
 
--   Documentation website - [PWA DevDocs]
--   Chat with us on **Slack** - [#pwa channel]
--   Send us an Email: pwa@magento.com
+- Documentation website - [PWA DevDocs]
+- Chat with us on **Slack** - [#pwa channel]
+- Send us an Email: pwa@magento.com
 
-[pwa devdocs]: https://pwastudio.io
+[pwa devdocs]: https://developer.adobe.com/commerce/pwa-studio/
 [#pwa channel]: https://magentocommeng.slack.com/messages/C71HNKYS2

--- a/packages/babel-preset-peregrine/README.md
+++ b/packages/babel-preset-peregrine/README.md
@@ -1,1 +1,1 @@
-Documentation for Magento PWA Studio packages is located at [https://pwastudio.io](https://pwastudio.io).
+Documentation for Magento PWA Studio packages is located at [https://developer.adobe.com/commerce/pwa-studio/](https://developer.adobe.com/commerce/pwa-studio/).

--- a/packages/graphql-cli-validate-magento-pwa-queries/lib/index.js
+++ b/packages/graphql-cli-validate-magento-pwa-queries/lib/index.js
@@ -22,7 +22,7 @@ const exitCodes = {
     FAILURE: 1
 };
 const DOCS_COMPAT_TABLE_PATH =
-    'https://pwastudio.io/technologies/magento-compatibility/';
+    'https://developer.adobe.com/commerce/pwa-studio/integrations/adobe-commerce/version-compatibility';
 const plugin = {
     COMMAND: 'validate-magento-pwa-queries',
     DESCRIPTION:

--- a/packages/peregrine/README.md
+++ b/packages/peregrine/README.md
@@ -1,1 +1,1 @@
-Documentation for Magento PWA Studio packages is located at [https://pwastudio.io](https://pwastudio.io).
+Documentation for Magento PWA Studio packages is located at [https://developer.adobe.com/commerce/pwa-studio/](https://developer.adobe.com/commerce/pwa-studio/).

--- a/packages/peregrine/docs/RestApi.md
+++ b/packages/peregrine/docs/RestApi.md
@@ -1,5 +1,5 @@
 # REST API Clients
 
-Documentation has been moved to the [REST API client][] topic in the PWA devdocs site.
+Documentation has been moved to the [Commerce REST API][] site.
 
-[REST API client]: https://pwastudio.io/peregrine/reference/rest-api-client/
+[Commerce REST API]: https://developer.adobe.com/commerce/webapi/rest/

--- a/packages/peregrine/docs/Router.md
+++ b/packages/peregrine/docs/Router.md
@@ -2,5 +2,4 @@
 
 Documentation content has been moved to the [Router][] topic in the PWA devdocs site.
 
-[Router]: https://pwastudio.io/peregrine/reference/router/
-
+[Router]: https://developer.adobe.com/commerce/pwa-studio/api/peregrine/components-and-utilities/Router/

--- a/packages/peregrine/lib/targets/HookInterceptorSet.js
+++ b/packages/peregrine/lib/targets/HookInterceptorSet.js
@@ -14,7 +14,7 @@ class HookInterceptorSet extends Trackable {
     /**
      * Direct access to the array of all generated hooks. Used for retrieving all the transform requests.
      * @type {TransformRequest[]}
-     * @see [TransformRequest]{@link https://pwastudio.io/pwa-buildpack/reference/transform-requests/#addTransform}
+     * @see [TransformRequest]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/transform-requests/}
      */
     get allModules() {
         return this._all;

--- a/packages/peregrine/lib/targets/peregrine-declare.js
+++ b/packages/peregrine/lib/targets/peregrine-declare.js
@@ -70,7 +70,7 @@ module.exports = targets => {
  *
  * Interceptors of `hooks` should call `wrapWith` on the individual hooks in
  * the provided [`HookInterceptorSet` object]{@link
- * http://pwastudio.io/peregrine/reference/targets/wrappable-talons}.
+ * https://developer.adobe.com/commerce/pwa-studio/tutorials/targets/modify-talon-results/}.
  *
  * @callback hookInterceptFunction
  * @param {HookInterceptorSet} hookInterceptors Registry of wrappable hook namespaces

--- a/packages/pwa-buildpack/README.md
+++ b/packages/pwa-buildpack/README.md
@@ -1,1 +1,1 @@
-Documentation for Magento PWA Studio packages is located at [https://pwastudio.io](https://pwastudio.io).
+Documentation for Magento PWA Studio packages is located at [https://developer.adobe.com/commerce/pwa-studio/](https://developer.adobe.com/commerce/pwa-studio/).

--- a/packages/pwa-buildpack/docs/MagentoResolver.md
+++ b/packages/pwa-buildpack/docs/MagentoResolver.md
@@ -2,4 +2,4 @@
 
 Documentation content has been moved to the [MagentoResolver][] page on the PWA devdocs site.
 
-[MagentoResolver]: https://pwastudio.io/pwa-buildpack/reference/magento-resolver/
+[MagentoResolver]: https://developer.adobe.com/commerce/pwa-studio/api/buildpack/webpack/magento-resolver/

--- a/packages/pwa-buildpack/docs/MagentoRootComponentsPlugin.md
+++ b/packages/pwa-buildpack/docs/MagentoRootComponentsPlugin.md
@@ -2,4 +2,4 @@
 
 Documentation content has been moved to the [MagentoRootComponentsPlugin] page in the PWA devdocs site.
 
-[MagentoRootComponentsPlugin]: https://pwastudio.io/pwa-buildpack/reference/root-components-plugin/
+[MagentoRootComponentsPlugin]: https://developer.adobe.com/commerce/pwa-studio/api/buildpack/webpack/magento-root-components-plugin/

--- a/packages/pwa-buildpack/docs/PWADevServer.md
+++ b/packages/pwa-buildpack/docs/PWADevServer.md
@@ -2,4 +2,4 @@
 
 Documentation content has been moved to the [PWADevServer][] page in the PWA devdocs site.
 
-[PWADevServer]: https://pwastudio.io/pwa-buildpack/reference/pwa-dev-server/
+[PWADevServer]: https://developer.adobe.com/commerce/pwa-studio/api/buildpack/webpack/dev-server/

--- a/packages/pwa-buildpack/docs/ServiceWorkerPlugin.md
+++ b/packages/pwa-buildpack/docs/ServiceWorkerPlugin.md
@@ -2,4 +2,4 @@
 
 Documentation content has been moved to the [ServiceWorkerPlugin][] page in the PWA devdocs site.
 
-[ServiceWorkerPlugin]: https://pwastudio.io/pwa-buildpack/reference/serviceworker-plugin/
+[ServiceWorkerPlugin]: https://developer.adobe.com/commerce/pwa-studio/api/buildpack/webpack/service-worker/

--- a/packages/pwa-buildpack/lib/BuildBus/TargetProvider.js
+++ b/packages/pwa-buildpack/lib/BuildBus/TargetProvider.js
@@ -10,7 +10,7 @@ const {
 } = require('./mapHooksToTargets');
 
 /**
- * Respond to a request from a [TargetProvider]{@link https://pwastudio.io/pwa-buildpack/reference/buildbus/targetprovider/}
+ * Respond to a request from a [TargetProvider]{@link https://developer.adobe.com/commerce/pwa-studio/guides/general-concepts/extensibility/#targetproviders}
  * to retrieve a different(external) TargetProvider.
  *
  * This callback pattern helps to loosely couple TargetProviders so
@@ -43,7 +43,7 @@ class TargetProvider extends Trackable {
      * @param {Object} dep - The package which owns this TargetProvider.
      * @param {string} dep.name - Name of the package which owns this.
      * @param {getExternalTargets} getExternalTargets - Function this TargetProvider will use to retrieve external packages when they are requested with `.of()`.
-     * Should usually be a delegate to BuildBus's [`getExternalTargets()`]{@link http://pwastudio.io/pwa-buildpack/reference/buildbus/targetprovider/#buildpackbuildbusgetexternaltargets--targetprovider}
+     * Should usually be a delegate to BuildBus's [`getExternalTargets()`]{@link https://developer.adobe.com/commerce/pwa-studio/guides/general-concepts/extensibility/#targetproviders}
      *
      * @memberof TargetProvider
      */

--- a/packages/pwa-buildpack/lib/BuildBus/declare-base.js
+++ b/packages/pwa-buildpack/lib/BuildBus/declare-base.js
@@ -21,16 +21,16 @@ module.exports = targets => {
         /**
          * Called to collect the definitions and documentation for project-wide
          * configuration values. Core environment variables are defined in the
-         * [`envVarDefinitions.json` file]{@link http://pwastudio.io/pwa-buildpack/reference/environment-variables/core-definitions/}.
+         * [`envVarDefinitions.json` file]{@link https://github.com/magento/pwa-studio/blob/develop/packages/pwa-buildpack/envVarDefinitions.json}.
          *
          * Intercept this target in your project to add new environment
          * variables, typed and documented. This integrates your extension
          * configuration with the project-wide environment variable system.
          *
-         * @see [Variable definition schema]{@link http://pwastudio.io/pwa-buildpack/reference/environment-variables/definitions-api/}
-         * @see [Core variable definitions]{@link http://pwastudio.io/pwa-buildpack/reference/environment-variables/core-definitions/}
+         * @see [Variable definition schema]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/definition-object/}
+         * @see[Core variable definitions]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/variables/}
          *
-         * @param {object} envVarDefinitions The [variable definitions object]{@link http://pwastudio.io/pwa-buildpack/reference/environment-variables/definitions-api/}.
+         * @param {object} envVarDefinitions The [variable definitions object]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/definition-object/}.
          * Modify in place.
          * @member {tapable.SyncHook}
          * @example <caption>Add config fields for your extension</caption>
@@ -111,7 +111,7 @@ module.exports = targets => {
          * Use a [specialFeatures intercept function]{@link specialFeaturesIntercept}
          * to add special build features for the modules used in your project.
          *
-         * @see [Special flags in `configureWebpack()`]{@link http://pwastudio.io/pwa-buildpack/reference/configure-webpack/#special-flags}
+         * @see [Special flags in `configureWebpack()`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/webpack/configure/#special-flags}
          *
          * @member {tapable.SyncHook}
          *
@@ -250,11 +250,11 @@ module.exports = targets => {
 /**
  * Callback to add a transform.
  *
- * @see [TransformRequest]{@link https://pwastudio.io/pwa-buildpack/reference/transform-requests/#addTransform}
+ * @see [TransformRequest]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/transform-requests/}
  *
  * @callback addTransform
  * @param {Buildpack/WebpackTools~TransformRequest} transformRequest -
- *   [Request]{@link https://pwastudio.io/pwa-buildpack/reference/transform-requests/#addTransform}
+ *   [Request]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/transform-requests/}
  * to apply a transform to a file provided by this dependency.
  */
 

--- a/packages/pwa-buildpack/lib/BuildBus/declare-base.js
+++ b/packages/pwa-buildpack/lib/BuildBus/declare-base.js
@@ -28,7 +28,7 @@ module.exports = targets => {
          * configuration with the project-wide environment variable system.
          *
          * @see [Variable definition schema]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/definition-object/}
-         * @see[Core variable definitions]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/variables/}
+         * @see [Core variable definitions]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/variables/}
          *
          * @param {object} envVarDefinitions The [variable definitions object]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/definition-object/}.
          * Modify in place.

--- a/packages/pwa-buildpack/lib/Utilities/getEnvVarDefinitions.js
+++ b/packages/pwa-buildpack/lib/Utilities/getEnvVarDefinitions.js
@@ -5,8 +5,8 @@ const debug = require('debug')('pwa-buildpack:getEnvVarDefinitions');
 
 /**
  * Get the list of environment definitions.
- * Calling this function will invoke the [`envVarDefinitions`]{@link http://pwastudio.io/pwa-buildpack/reference/buildbus/targets/#module_BuiltinTargets.envVarDefinitions}
- * target, passing the list of [built-in environment variables]{@link http://pwastudio.io/pwa-buildpack/reference/environment-variables/core-definitions/}
+ * Calling this function will invoke the [`envVarDefinitions`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/definition-object/}
+ * target, passing the list of [built-in environment variables]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/environment/variables/}
  * to all interceptors.
  * Any installed dependencies that intercept this target may add to or modify the list of environment variables.
  *
@@ -50,10 +50,10 @@ module.exports = getEnvVarDefinitions;
  * Defines the global settings of the project as a list of typed environment variables.
  * Includes a set of changes made to the environment variables in recent versions, to aid with migration and upgrades.
  *
- * `EnvVarDefinitions` are used by [`loadEnvironment()`]{@link http://pwastudio.io/pwa-buildpack/reference/buildpack-cli/load-env/#loadenvironmentdirorenv-logger}
+ * `EnvVarDefinitions` are used by [`loadEnvironment()`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/load-environment-file/}
  * to validate the currently defined values in the environment.
  *
- * `EnvVarDefinitions` are also used by [`createDotEnvFile()`]{@link http://pwastudio.io/pwa-buildpack/reference/buildpack-cli/create-env-file/#createdotenvfiledirectory-options}
+ * `EnvVarDefinitions` are also used by [`createDotEnvFile()`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/create-environment-file/}
  * to generate an extensively commented `.env` file for a project.
  *
  * @typedef {Object} EnvVarDefinitions
@@ -79,8 +79,8 @@ module.exports = getEnvVarDefinitions;
  * and/or an array of `choices` to limit the valid values.
  *
  * The recommended way to access the current environment values in build scripts and interceptors is through the
- * [Configuration]{@link http://pwastudio.io/pwa-buildpack/reference/buildpack-cli/load-env/#configuration-object}
- * object returned by [`loadEnvironment()`]{@link http://pwastudio.io/pwa-buildpack/reference/buildpack-cli/load-env/#loadenvironmentdirorenv-logger}.
+ * [Configuration]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/}
+ * object returned by [`loadEnvironment()`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/}.
  *
  * **Note:** Any build environment will have hundreds of environment variables _set_, most of which are unrelated to the build process.
  * Any environment variable during the build is accessible via `process.env` in NodeJS.

--- a/packages/pwa-buildpack/lib/Utilities/getEnvVarDefinitions.js
+++ b/packages/pwa-buildpack/lib/Utilities/getEnvVarDefinitions.js
@@ -79,8 +79,8 @@ module.exports = getEnvVarDefinitions;
  * and/or an array of `choices` to limit the valid values.
  *
  * The recommended way to access the current environment values in build scripts and interceptors is through the
- * [Configuration]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/}
- * object returned by [`loadEnvironment()`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/}.
+ * [Configuration object]{@link https://developer.adobe.com/commerce/pwa-studio/guides/general-concepts/configuration/#configuration-object}
+ * object returned by [`loadEnvironment()`]{@link https://developer.adobe.com/commerce/pwa-studio/api/buildpack/cli/load-environment-file/}.
  *
  * **Note:** Any build environment will have hundreds of environment variables _set_, most of which are unrelated to the build process.
  * Any environment variable during the build is accessible via `process.env` in NodeJS.

--- a/packages/venia-concept/README.md
+++ b/packages/venia-concept/README.md
@@ -1,1 +1,1 @@
-Documentation for Magento PWA Studio packages is located at [https://pwastudio.io](https://pwastudio.io).
+Documentation for Magento PWA Studio packages is located at [https://developer.adobe.com/commerce/pwa-studio/](https://developer.adobe.com/commerce/pwa-studio/).

--- a/packages/venia-concept/upward.yml
+++ b/packages/venia-concept/upward.yml
@@ -1,7 +1,7 @@
 # This is the UPWARD specification file for the Venia storefront.
 # It is used by an UPWARD server implementation, such as upward-js and
 # upward-php, to describe how the server responds to requests.
-# See: https://pwastudio.io/technologies/upward/
+# See: https://developer.adobe.com/commerce/pwa-studio/guides/packages/upward
 
 # The root properties of an UPWARD spec file are part of a global context
 # that includes request and environment data.

--- a/pwa-devdocs/README.md
+++ b/pwa-devdocs/README.md
@@ -79,7 +79,7 @@ This project is licensed under OSL-3.0 - see the [LICENSE.txt] file for details.
 [contribution guidelines]: https://magento.github.io/pwa-studio/technologies/contribute/
 [code of conduct]: https://github.com/magento/pwa-studio/blob/develop/.github/CODE_OF_CONDUCT.md
 [license.txt]: LICENSE.txt
-[documentation site]: https://pwastudio.io
+[documentation site]: https://developer.adobe.com/commerce/pwa-studio/
 [node.js]: https://nodejs.org
 [ruby]: https://www.ruby-lang.org/
 [bundler]: http://bundler.io/

--- a/pwa-devdocs/src/_includes/layout/header-scripts.html
+++ b/pwa-devdocs/src/_includes/layout/header-scripts.html
@@ -10,7 +10,7 @@
     {
       label: "PWA",
       name: "pwa-devdocs",
-      baseUrl: "https://pwastudio.io"
+      baseUrl: "https://developer.adobe.com/commerce/pwa-studio"
     },
     {
       label: "DevDocs",

--- a/pwa-devdocs/src/frequently-asked-questions/index.md
+++ b/pwa-devdocs/src/frequently-asked-questions/index.md
@@ -108,8 +108,6 @@ _**Note:** For testing, resize the viewport manually instead of using the native
 
 [prerender.io]: https://prerender.io/
 
-[pwa studio stats]: https://pwastudio-stats.com/
-
 [magento 2 upward connector module]: https://github.com/magento/magento2-upward-connector
 
 [windows subsystem for linux]: https://docs.microsoft.com/en-us/windows/wsl/install-win10

--- a/pwa-devdocs/src/technologies/overview/index.md
+++ b/pwa-devdocs/src/technologies/overview/index.md
@@ -69,9 +69,9 @@ This server also contains sample data for a fashion store to show the different 
 
 Other notable packages in PWA Studio include:
 
--   **[pwastudio.io][]** - Provides documentation to help guide developers towards creating a Magento PWA storefront
--   **[UPWARD][]** - A proxy-server concept that describes a highly configurable server that sits between the PWA storefront and backend services, such as Magento
--   **[PageBuilder][]** - PageBuilder extension for PWA Studio
+- **[PWA Studio docs][]** - Provides documentation to help guide developers towards creating a Magento PWA storefront
+- **[UPWARD][]** - A proxy-server concept that describes a highly configurable server that sits between the PWA storefront and backend services, such as Magento
+- **[PageBuilder][]** - PageBuilder extension for PWA Studio
 
 [tools and libraries]: {% link technologies/tools-libraries/index.md %}
 [pwa-buildpack]: {% link pwa-buildpack/index.md %}
@@ -83,9 +83,8 @@ Other notable packages in PWA Studio include:
 [set up a new storefront project]: <{%link tutorials/pwa-studio-fundamentals/project-setup/index.md %}>
 [pagebuilder]: <{%link pagebuilder/index.md %}>
 
-[pwastudio.io]: https://pwastudio.io
+[pwa studio docs]: https://developer.adobe.com/commerce/pwa-studio/
 [web.dev]: https://web.dev/progressive-web-apps/
 [developers.google.com]: https://developers.google.com/web/updates/2015/12/getting-started-pwa
 [developer.mozilla.org]: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps
 [rail]: https://web.dev/rail/
-

--- a/pwa-devdocs/src/tutorials/cloud-deploy/index.md
+++ b/pwa-devdocs/src/tutorials/cloud-deploy/index.md
@@ -226,9 +226,9 @@ variables, such as `CONFIG__DEFAULT__WEB__UPWARD__PATH` and `MAGENTO_BACKEND_URL
 [environment variables]: <{%link pwa-buildpack/reference/environment-variables/core-definitions/index.md %}>
 [project setup]: <{%link tutorials/pwa-studio-fundamentals/project-setup/index.md %}>
 
-[magento pwa studio]: http://pwastudio.io
+[magento pwa studio]: https://developer.adobe.com/commerce/pwa-studio/
 [`@magento/venia-concept`]: https://www.npmjs.com/package/@magento/venia-concept
-[venia storefront]: https://pwastudio.io/venia-pwa-concept/
+[venia storefront]: https://developer.adobe.com/commerce/pwa-studio/guides/storefront-architecture/
 [create a `package.json`]: https://docs.npmjs.com/cli/init
 
 [magento2-upward-connector]: https://github.com/magento/magento2-upward-connector


### PR DESCRIPTION
## Description

Replaced all links to `pwastudio.io` with the appropriate link+anchor in `developer.adobe.com/commerce/pwa-studio`.

## Related Issue

Jira issue [PWA-3011](https://jira.corp.adobe.com/browse/PWA-3011). 

Olena contacted Anthoula and I to update the old `pwastudio.io` link on the [peregrine npm registry page](https://www.npmjs.com/package/@magento/peregrine) as reported. I found more references on [other npm registry pages](https://www.npmjs.com/package/@magento/pwa-buildpack) and throughout the source-code documentation. So it was time to purge these old links permanently.

## Staged preview

[STAGED PREVIEW](https://developer-stage.adobe.com/commerce/pwa-studio) — for spot checks on removal of old pwastudio.io links. 

## Blockers / Contingencies

Someone with access to the `@magento` org account on the npm registry site needs to change the descriptions on the site to match the updates this PR makes to the README.md files of these packages:
- @magento/peregrine: https://www.npmjs.com/package/@magento/peregrine
- @magento/pwa-buildpack: https://www.npmjs.com/package/@magento/pwa-buildpack
- @magento/venia-concept: https://www.npmjs.com/package/@magento/venia-concept
- @magento/babel-preset-peregrine: https://www.npmjs.com/package/@magento/babel-preset-peregrine

OR — If we plan to update those packages for this release, make sure this PR is merged first so the descriptions on the npm pages will auto-update based on the README.md files of each package. 

Closes #PWA-3011.

## Acceptance
- @jcalcaben 
- @tkacheva 
- @anthoula 

### Verification Stakeholders

- @tkacheva 
- @anthoula 

## Verification Steps

Make sure the documentation links on the following npm registry pages resolve to the PWA Studio docs:
- @magento/peregrine: https://www.npmjs.com/package/@magento/peregrine
- @magento/pwa-buildpack: https://www.npmjs.com/package/@magento/pwa-buildpack
- @magento/venia-concept: https://www.npmjs.com/package/@magento/venia-concept
- @magento/babel-preset-peregrine: https://www.npmjs.com/package/@magento/babel-preset-peregrine

![IMG_6916](https://user-images.githubusercontent.com/1828494/196443946-d56d07bf-683e-4dc0-a5c2-7f1e84ed7193.jpg)
