### PR TITLE
[Docs] Release notes for PWA Studio release 12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ _For older release notes, see_ [PWA Studio releases][].
 
 ## Highlights
 
-The 12.7.0 release of PWA Studio focuses on accessibility improvements and bug fixes.
+The 12.7.0 release of PWA Studio provides customers with a better product selection experience by showing which variations of a configurable product are out of stock. This addition prevents customers from selecting out of stock variations when configuring a product for purchase.
 
-### Features
+This release also adds and improves several keyboard and screen-reader accessibility features along with user session and permission bug fixes. Full details are described below.
 
-- **Out-of-stock for product variations** [3903][] — The out-of-stock setting can now be applied to configurable product variations, making it easier for customers to select variations.
+## New Features
+
+- **Out-of-stock for product variations** [3903][] — The out-of-stock setting can now be applied to configurable product variations, making it easier for customers to configure a product with the available variations.
 - **Tailwind theming documentation** [155][] — New instructions on how to install, configure, and use Tailwind with Venia to theme your own PWA Studio app. See [Tailwind Theming for PWA Studio apps](https://developer.adobe.com/commerce/pwa-studio/guides/theming/).
 - **Accessible Action menus** [3791][] — Action menu functions are now accessible by keyboard.
 - **Accessible Search results content** [3891][] —Screen reading of search results has been improved.
@@ -20,7 +22,7 @@ The 12.7.0 release of PWA Studio focuses on accessibility improvements and bug f
 - **Accessible Actionable UI elements** [3864][] — When actionable UI elements receive focus, a visible focus indicator is present.
 - **Accessible Logo component** [3936][] — The Logo component now renders the `alt` property.
 
-### Fixes
+## Bug Fixes
 
 - **Fixed selected payment method** [3969][] — The selected payment method now persists during the user session, when multiple payment methods are available.
 - **Fixed permission error** [3955][] — Fixed a permission error that occurred during the compilation process initiated by Docker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,24 @@ _For older release notes, see_ [PWA Studio releases][].
 
 The 12.7.0 release of PWA Studio focuses on accessibility improvements and bug fixes.
 
-### Additions
+### Features
 
-- New Feature: [3903][] — **Out-of-stock variations** — The out-of-stock setting can now be applied to configurable product variations, making it easier for customers to select variations.
-- Documentation: [155][] — **Tailwind theming documentation** — New instructions on how to install, configure, and use Tailwind with Venia to theme your own PWA Studio app. See [Tailwind Theming for PWA Studio apps](https://developer.adobe.com/commerce/pwa-studio/guides/theming/).
-- Accessibility: [3791][] — **Action menus** — Action menu functions are now accessible by keyboard.
-- Accessibility: [3891][] — **Search results content** — Screen reading of search results has been improved.
-- Accessibility: [3935][] — **Search results count** — Screen reader announces the total items found in the searched result.
-- Accessibility: [3792][] — **UI Control states** — Screen readers now announce the expanded and collapsed states of controls.
-- Accessibility: [3798][] — **Mega Menu** — The Mega Menu is now accessible by keyboard.
-- Accessibility: [3864][] — **Actionable UI elements** — When actionable UI elements receive focus, a visible focus indicator is present.
-- Accessibility: [3936][] — **Logo component** — The Logo component now renders the `alt` property.
+- **Out-of-stock for product variations** [3903][] — The out-of-stock setting can now be applied to configurable product variations, making it easier for customers to select variations.
+- **Tailwind theming documentation** [155][] — New instructions on how to install, configure, and use Tailwind with Venia to theme your own PWA Studio app. See [Tailwind Theming for PWA Studio apps](https://developer.adobe.com/commerce/pwa-studio/guides/theming/).
+- **Accessible Action menus** [3791][] — Action menu functions are now accessible by keyboard.
+- **Accessible Search results content** [3891][] —Screen reading of search results has been improved.
+- **Accessible Search results count** [3935][] — Screen reader announces the total items found in the searched result.
+- **Accessible UI Control states** [3792][] — Screen readers now announce the expanded and collapsed states of controls.
+- **Accessible Mega Menu** [3798][] — The Mega Menu is now accessible by keyboard.
+- **Accessible Actionable UI elements** [3864][] — When actionable UI elements receive focus, a visible focus indicator is present.
+- **Accessible Logo component** [3936][] — The Logo component now renders the `alt` property.
 
 ### Fixes
 
-- Bug: [3969][] — The selected payment method now persists during the user session, when multiple payment methods are available.
-- Bug: [3955][] — Fixed a permission error that occurred during the compilation process initiated by Docker.
-- Bug: [3648][] — Fixed a typo in the import name of a component.
-- Bug: [3942][] — Fixed console warnings for invalid DOM property names.
+- **Fixed selected payment method** [3969][] — The selected payment method now persists during the user session, when multiple payment methods are available.
+- **Fixed permission error** [3955][] — Fixed a permission error that occurred during the compilation process initiated by Docker.
+- **Fixed import typo** [3648][] — Fixed a typo for the import name of a component.
+- **Fixed console warnings** [3942][] — Fixed console warnings for invalid DOM property names.
 
 ## 12.7.0 Lighthouse scores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,32 +65,32 @@ See [Upgrading versions][] for more information about upgrading between PWA Stud
 [scaffolded project]: https://developer.adobe.com/commerce/pwa-studio/tutorials/
 [upgrading versions]: https://developer.adobe.com/commerce/pwa-studio/guides/upgrading-versions/
 
-### Update dependencies
+### Updated package dependencies
 
 Open your `package.json` file and update the PWA Studio package dependencies to the versions associated with this release.
-The following table lists the latest versions of each package as of 12.7.0.
+The following table lists the latest versions of each package as of 12.7.0. The **bolded** versions with an asterisk (*) are the packages that were updated from PWA Studio 12.6.0.
 
 **Note:**
 Your project may not depend on some packages listed in this table.
 
 | Package                             | Latest version |
 |-------------------------------------|----------------|
-| `babel-preset-peregrine`            | **1.2.2**      |
-| `create-pwa`                        | **2.3.3**      |
-| `experience-platform-connector`     | **1.0.2**      |
-| `upward-security-headers`           | **1.0.11**     |
-| `venia-sample-backends`             | 0.0.8      |
-| `venia-sample-eventing`             | **0.0.3**      |
-| `venia-sample-language-packs`       | **0.0.11**     |
-| `venia-sample-payments-checkmo`     | **0.0.9**      |
-| `pagebuilder`                       | **7.4.2**      |
-| `peregrine`                         | **12.6.0**     |
-| `pwa-buildpack`                     | **11.4.1**     |
-| `pwa-theme-venia`                   | **1.4.0**      |
+| `babel-preset-peregrine`            | **1.2.2***      |
+| `create-pwa`                        | **2.3.3***      |
+| `experience-platform-connector`     | **1.0.2***      |
+| `upward-security-headers`           | **1.0.11***     |
+| `venia-sample-backends`             | **0.0.9***      |
+| `venia-sample-eventing`             | **0.0.3***      |
+| `venia-sample-language-packs`       | **0.0.11***     |
+| `venia-sample-payments-checkmo`     | **0.0.9***      |
+| `pagebuilder`                       | **7.4.2***      |
+| `peregrine`                         | **12.6.0***     |
+| `pwa-buildpack`                     | **11.4.1***     |
+| `pwa-theme-venia`                   | **1.4.0***      |
 | `upward-js`                         | 5.3.2      |
 | `upward-spec`                       | 5.2.1      |
-| `venia-concept`                     | **12.7.0**     |
-| `venia-ui`                          | **9.7.0**      |
+| `venia-concept`                     | **12.7.0***     |
+| `venia-ui`                          | **9.7.0***      |
 | `magento2-pwa`                      | 0.3.0      |
 | `magento2-pwa-commerce`             | 0.0.2      |
 | `magento-venia-sample-data-modules` | 0.0.3      |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,35 @@
-# PWA Studio Release 12.6.0
+# PWA Studio Release 12.7.0
 
 **NOTE:**
-_This changelog only contains release notes for PWA Studio and Venia 12.6.0_.
+_This changelog only contains release notes for PWA Studio and Venia 12.7.0_.
 _For older release notes, see_ [PWA Studio releases][].
 
 ## Highlights
 
-The 12.6.0 release of PWA Studio focuses on accessibility improvements and bug fixes.
-  
--   Accessibility Improvements: Added autocomplete attributes to checkout shipping and payment forms — [3785][]  
--   Accessibility Improvements:: Open panels now have keyboard focus. — [3805][]   
--   Accessibility Improvements:: Navigation buttons for carousels now meet contrast requirements. — [3787][]  
--   Controls now have a descriptive accessible name. Visible \[label] elements are correctly associated with their inputs using the "for" attribute. — [3786][]  
--   Removes duplicate logic from QuoteGraphQlPwa module — [29][]  
--   Bug Fix: Failing cypress tests fixed — [3911][]  
--   Bug Fix - Braintree payment form Customer Name field values now appear normal. — [3912][]  
--   Bug Fix: Braintree npm package braintree-web-drop-in updated to latest version to fix csp related console errors. — [3912][]  
--   Accessibility Improvements: Keyboard focus no longer lands on hidden elements in Kebab menu — [3800][]   
--   Fixed a bug in mobile view where the Edit and Remove options in the kebab menu for a cart item on the cart page is non functional. - [3925][]
--   Fixed a console error when accessing different filters. - [30][]
+The 12.7.0 release of PWA Studio focuses on accessibility improvements and bug fixes.
 
-## 12.6.0 Lighthouse scores
+### Additions
 
-With each new release of PWA Studio, we perform Lighthouse audits of four Venia page types, each representing a different level of complexity. Shown below are the Lighthouse scores for the 12.6.0 release of these pages on desktop and mobile devices.
+- New Feature: [3903][] — **Out-of-stock variations** — The out-of-stock setting can now be applied to configurable product variations, making it easier for customers to select variations.
+- Documentation: [155][] — **Tailwind theming documentation** — New instructions on how to install, configure, and use Tailwind with Venia to theme your own PWA Studio app. See [Tailwind Theming for PWA Studio apps](https://developer.adobe.com/commerce/pwa-studio/guides/theming/).
+- Accessibility: [3791][] — **Action menus** — Action menu functions are now accessible by keyboard.
+- Accessibility: [3891][] — **Search results content** — Screen reading of search results has been improved.
+- Accessibility: [3935][] — **Search results count** — Screen reader announces the total items found in the searched result.
+- Accessibility: [3792][] — **UI Control states** — Screen readers now announce the expanded and collapsed states of controls.
+- Accessibility: [3798][] — **Mega Menu** — The Mega Menu is now accessible by keyboard.
+- Accessibility: [3864][] — **Actionable UI elements** — When actionable UI elements receive focus, a visible focus indicator is present.
+- Accessibility: [3936][] — **Logo component** — The Logo component now renders the `alt` property.
+
+### Fixes
+
+- Bug: [3969][] — The selected payment method now persists during the user session, when multiple payment methods are available.
+- Bug: [3955][] — Fixed a permission error that occurred during the compilation process initiated by Docker.
+- Bug: [3648][] — Fixed a typo in the import name of a component.
+- Bug: [3942][] — Fixed console warnings for invalid DOM property names.
+
+## 12.7.0 Lighthouse scores
+
+With each new release of PWA Studio, we perform Lighthouse audits of four Venia page types, each representing a different level of complexity. Shown below are the Lighthouse scores for the 12.7.0 release of these pages on desktop and mobile devices.
 
 ### Desktop scores
 
@@ -46,9 +53,13 @@ With each new release of PWA Studio, we perform Lighthouse audits of four Venia 
 | SEO | ![](images/score_100.svg) | ![](images/score_100.svg) | ![](images/score_100.svg) | ![](images/score_100.svg) |
 | PWA | ![](images/pwa_perfect.svg) | ![](images/pwa_imperfect.svg) | ![](images/pwa_imperfect.svg) | ![](images/pwa_perfect.svg) |
 
+## Known issue
+
+When a user logs out, that user's local storage session persists. As a result, the cart ID from the logged out user is retrieved and given to the _guest user_ on the computer. This causes the following error when the guest user tries to check out: `An error has occurred. Please check the input and try again.` To resolve this issue, try disabling graphql session sharing as described in the GraphQL documentation on session cookies here: https://devdocs.magento.com/guides/v2.4/graphql/authorization-tokens.html#session-cookies.
+
 ## Upgrading from a previous version
 
-Use the steps outlined in this section to update your [scaffolded project][] from 12.5.0 to 12.6.0.
+Use the steps outlined in this section to update your [scaffolded project][] from 12.6.0 to 12.7.0.
 See [Upgrading versions][] for more information about upgrading between PWA Studio versions.
 
 [scaffolded project]: https://developer.adobe.com/commerce/pwa-studio/tutorials/
@@ -57,46 +68,47 @@ See [Upgrading versions][] for more information about upgrading between PWA Stud
 ### Update dependencies
 
 Open your `package.json` file and update the PWA Studio package dependencies to the versions associated with this release.
-The following table lists the latest versions of each package as of 12.6.0.
+The following table lists the latest versions of each package as of 12.7.0.
 
 **Note:**
 Your project may not depend on some packages listed in this table.
 
 | Package                             | Latest version |
 |-------------------------------------|----------------|
-| `babel-preset-peregrine`            | **1.2.1**      |
-| `create-pwa`                        | **2.3.2**      |
-| `experience-platform-connector`     | **1.0.1**      |
-| `upward-security-headers`           | **1.0.10**     |
-| `venia-sample-backends`             | **0.0.8**      |
-| `venia-sample-eventing`             | **0.0.2**      |
-| `venia-sample-language-packs`       | **0.0.10**     |
-| `venia-sample-payments-checkmo`     | **0.0.8**      |
-| `pagebuilder`                       | **7.5.0**      |
-| `peregrine`                         | **12.5.0**     |
-| `pwa-buildpack`                     | **11.4.0**     |
+| `babel-preset-peregrine`            | **1.2.2**      |
+| `create-pwa`                        | **2.3.3**      |
+| `experience-platform-connector`     | **1.0.2**      |
+| `upward-security-headers`           | **1.0.11**     |
+| `venia-sample-backends`             | 0.0.8      |
+| `venia-sample-eventing`             | **0.0.3**      |
+| `venia-sample-language-packs`       | **0.0.11**     |
+| `venia-sample-payments-checkmo`     | **0.0.9**      |
+| `pagebuilder`                       | **7.4.2**      |
+| `peregrine`                         | **12.6.0**     |
+| `pwa-buildpack`                     | **11.4.1**     |
 | `pwa-theme-venia`                   | **1.4.0**      |
-| `upward-js`                         | **5.4.0**      |
-| `upward-spec`                       | **5.2.1**      |
-| `venia-concept`                     | **12.6.0**     |
-| `venia-ui`                          | **9.6.0**      |
-| `magento2-pwa`                      | **0.3.0**      |
-| `magento2-pwa-commerce`             | **0.0.2**      |
-| `magento-venia-sample-data-modules` | **0.0.3**      |
-| `magento-venia-sample-data-modules-ee`| **0.0.2**    |
-| `magento2-upward-connector`         | **2.0.1**      |
-| `upward-php`                        | **2.0.1**      |
-
-[3785]: https://github.com/magento/pwa-studio/pull/3785
-[3805]: https://github.com/magento/pwa-studio/pull/3805
-[3787]: https://github.com/magento/pwa-studio/pull/3787
-[3786]: https://github.com/magento/pwa-studio/pull/3786
-[29]: https://github.com/magento-commerce/magento2-pwa/pull/29
-[3911]: https://github.com/magento/pwa-studio/pull/3911
-[3912]: https://github.com/magento/pwa-studio/pull/3912
-[3800]: https://github.com/magento/pwa-studio/pull/3800
-[30]: https://github.com/magento-commerce/magento2-pwa/pull/30
-[3925]: https://github.com/magento/pwa-studio/pull/3925
-[29]: https://github.com/magento-commerce/magento2-pwa/pull/29
+| `upward-js`                         | 5.3.2      |
+| `upward-spec`                       | 5.2.1      |
+| `venia-concept`                     | **12.7.0**     |
+| `venia-ui`                          | **9.7.0**      |
+| `magento2-pwa`                      | 0.3.0      |
+| `magento2-pwa-commerce`             | 0.0.2      |
+| `magento-venia-sample-data-modules` | 0.0.3      |
+| `magento-venia-sample-data-modules-ee`| 0.0.2    |
+| `magento2-upward-connector`         | 2.0.1      |
+| `upward-php`                        | 2.0.1      |
 
 [PWA Studio releases]: https://github.com/magento/pwa-studio/releases
+[155]: https://github.com/AdobeDocs/commerce-pwa-studio/pull/155
+[3791]: https://github.com/magento/pwa-studio/pull/3791
+[3903]: https://github.com/magento/pwa-studio/pull/3903
+[3798]: https://github.com/magento/pwa-studio/pull/3798
+[3792]: https://github.com/magento/pwa-studio/pull/3792
+[3891]: https://github.com/magento/pwa-studio/pull/3891
+[3864]: https://github.com/magento/pwa-studio/pull/3864
+[3935]: https://github.com/magento/pwa-studio/pull/3935
+[3942]: https://github.com/magento/pwa-studio/pull/3942
+[3648]: https://github.com/magento/pwa-studio/pull/3648
+[3955]: https://github.com/magento/pwa-studio/pull/3955
+[3969]: https://github.com/magento/pwa-studio/pull/3969
+[3936]: https://github.com/magento/pwa-studio/pull/3936


### PR DESCRIPTION
## Description

Release notes for PWA Studio release 12.7

## Completion Blocker

We need to include the new Lighthouse scores. The included ones are from the 12.6 release.

## Related Issue

[PWA-3000](https://jira.corp.adobe.com/browse/PWA-3000)

Closes #PWA-3000.

## Acceptance

- @anthoula 
- @dpatil-magento 

### Verification Stakeholders

- @anthoula 
- @dpatil-magento 

## Verification Steps

Review CHANGELOG.md to ensure all 12.7 stories and bugs are added and described accurately.

## Checklist

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
