### PR TITLE
Bug#pwa 3055 Homepage slider creates unexpected GET-requests

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/__snapshots__/banner.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/__snapshots__/banner.spec.js.snap
@@ -305,7 +305,7 @@ exports[`renders a configured collage-left Banner component on mobile 1`] = `
         Object {
           "backgroundAttachment": "scroll",
           "backgroundColor": "blue",
-          "backgroundImage": "url(null)",
+          "backgroundImage": "url()",
           "backgroundPosition": "center center",
           "backgroundRepeat": "no-repeat",
           "backgroundSize": "cover",

--- a/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/__snapshots__/banner.spec.js.snap
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/__tests__/__snapshots__/banner.spec.js.snap
@@ -303,12 +303,7 @@ exports[`renders a configured collage-left Banner component on mobile 1`] = `
       className="wrapper"
       style={
         Object {
-          "backgroundAttachment": "scroll",
           "backgroundColor": "blue",
-          "backgroundImage": "url()",
-          "backgroundPosition": "center center",
-          "backgroundRepeat": "no-repeat",
-          "backgroundSize": "cover",
           "border": "solid",
           "borderColor": "rgb(0,0,0)",
           "borderRadius": "15px",

--- a/packages/pagebuilder/lib/ContentTypes/Banner/banner.js
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/banner.js
@@ -31,7 +31,7 @@ const Banner = props => {
     const viewportElement = useRef(null);
     const classes = useStyle(defaultClasses, props.classes);
     const [hovered, setHovered] = useState(false);
-    const [bgImageStyle, setBgImageStyle] = useState('');
+    const [bgImageStyle, setBgImageStyle] = useState(null);
     const toggleHover = () => setHovered(!hovered);
     const intersectionObserver = useIntersectionObserver();
     const {
@@ -160,7 +160,7 @@ const Banner = props => {
     ]);
     /* eslint-enable react-hooks/exhaustive-deps */
 
-    if (image) {
+    if (image && bgImageStyle) {
         wrapperStyles.backgroundImage = `url(${bgImageStyle})`;
         wrapperStyles.backgroundSize = backgroundSize;
         wrapperStyles.backgroundPosition = backgroundPosition;

--- a/packages/pagebuilder/lib/ContentTypes/Banner/banner.js
+++ b/packages/pagebuilder/lib/ContentTypes/Banner/banner.js
@@ -31,7 +31,7 @@ const Banner = props => {
     const viewportElement = useRef(null);
     const classes = useStyle(defaultClasses, props.classes);
     const [hovered, setHovered] = useState(false);
-    const [bgImageStyle, setBgImageStyle] = useState(null);
+    const [bgImageStyle, setBgImageStyle] = useState('');
     const toggleHover = () => setHovered(!hovered);
     const intersectionObserver = useIntersectionObserver();
     const {


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

To reproduce

Steps to reproduce the behavior:

Go to [venia.](https://venia.magento.com/) with dev console open
Open "Network" tab and filter by "null"
Review "Network" tab results
Expected behavior

No requests with "/null"

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes [#PWA-3055.](https://jira.corp.adobe.com/browse/PWA-3055)

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
