### PR TITLE
PWA-3108::When the button forget password is pressed, there's no mess…

### DIFF
--- a/packages/peregrine/lib/talons/SignIn/useSignIn.js
+++ b/packages/peregrine/lib/talons/SignIn/useSignIn.js
@@ -29,6 +29,7 @@ export const useSignIn = props => {
 
     const apolloClient = useApolloClient();
     const [isSigningIn, setIsSigningIn] = useState(false);
+    const [forgetPasswordFlag,setForgetPasswordFlag] = useState(false);
 
     const [
         { cartId },
@@ -148,13 +149,21 @@ export const useSignIn = props => {
 
     const handleForgotPassword = useCallback(() => {
         const { current: formApi } = formApiRef;
-
         if (formApi) {
             setDefaultUsername(formApi.getValue('email'));
         }
-
         showForgotPassword();
+        setForgetPasswordFlag(true);
     }, [setDefaultUsername, showForgotPassword]);
+
+    const forgotPasswordHandleEnterKeyPress = useCallback(() => {
+        event => {
+            if (event.key === 'Enter') {
+                handleForgotPassword();
+            }
+        };
+        setForgetPasswordFlag(true);
+    }, [handleForgotPassword]);
 
     const handleCreateAccount = useCallback(() => {
         const { current: formApi } = formApiRef;
@@ -193,6 +202,8 @@ export const useSignIn = props => {
 
     return {
         errors,
+        forgetPasswordFlag,
+        forgotPasswordHandleEnterKeyPress,
         handleCreateAccount,
         handleEnterKeyPress,
         signinHandleEnterKeyPress,

--- a/packages/venia-ui/lib/components/SignIn/signIn.js
+++ b/packages/venia-ui/lib/components/SignIn/signIn.js
@@ -35,6 +35,8 @@ const SignIn = props => {
 
     const {
         errors,
+        forgetPasswordFlag,
+        forgotPasswordHandleEnterKeyPress,
         handleCreateAccount,
         handleEnterKeyPress,
         signinHandleEnterKeyPress,
@@ -107,12 +109,16 @@ const SignIn = props => {
                         classes={forgotPasswordClasses}
                         type="button"
                         onClick={handleForgotPassword}
+                        onKeyDown={forgotPasswordHandleEnterKeyPress}
                         data-cy="SignIn-forgotPasswordButton"
                     >
-                        <FormattedMessage
+                        {forgetPasswordFlag ? <FormattedMessage
+                            id={'forgotPassword.recoverPasswordText'}
+                            defaultMessage={'Forgot Password?'}
+                        />  : <FormattedMessage
                             id={'signIn.forgotPasswordText'}
                             defaultMessage={'Forgot Password?'}
-                        />
+                        /> }
                     </LinkButton>
                 </div>
                 <GoogleRecaptcha {...recaptchaWidgetProps} />


### PR DESCRIPTION
…age to convey the information that the content has been refreshed for screen reader users

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

When the button "forget password" is pressed, there's no message to convey the information that the content has been refreshed for screen reader users.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes #https://jira.corp.adobe.com/browse/PWA-3108.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
