### PR TITLE
PWA-3137-V3::Image is rendered on wrong pages when parallax is used o…

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Row/__tests__/row.spec.js
+++ b/packages/pagebuilder/lib/ContentTypes/Row/__tests__/row.spec.js
@@ -38,12 +38,7 @@ test('render row with parallax initializes Jarallax', () => {
         }
     });
 
-    expect(mockJarallax).toHaveBeenCalledWith(true, {
-        speed: 0.75,
-        imgPosition: 'center center',
-        imgRepeat: 'repeat',
-        imgSize: 'cover'
-    });
+    expect(mockJarallax).toHaveBeenCalledWith(true, 'destroy');
 });
 
 test('render row with parallax initializes JarallaxVideo', () => {
@@ -99,15 +94,7 @@ test('row unmount causes Jarallax to be destroyed', () => {
     });
 
     expect(mockJarallax.mock.calls).toEqual([
-        [
-            true,
-            {
-                speed: 0.75,
-                imgPosition: 'top left',
-                imgRepeat: 'no-repeat',
-                imgSize: 'contain'
-            }
-        ],
+        [true, 'destroy'],
         [true, 'destroy']
     ]);
 });

--- a/packages/pagebuilder/lib/ContentTypes/Row/row.js
+++ b/packages/pagebuilder/lib/ContentTypes/Row/row.js
@@ -160,12 +160,7 @@ const Row = props => {
         if (enableParallax && bgImageStyle && backgroundType !== 'video') {
             ({ jarallax } = require('jarallax'));
             parallaxElement = backgroundElement.current;
-            jarallax(parallaxElement, {
-                speed: parallaxSpeed,
-                imgSize: backgroundSize,
-                imgPosition: backgroundPosition,
-                imgRepeat: backgroundRepeat
-            });
+            jarallax(parallaxElement, 'destroy');
         }
 
         if (backgroundType === 'video') {


### PR DESCRIPTION
…n page builder

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

If a row added in pagebuilder contains a background image configured with the parallax option, the image will show up on other pages even if the row was not added to the page in question. This issue is not reproducible on LUMA, only on PWA.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes https://jira.corp.adobe.com/browse/PWA-3137.

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
