### PR TITLE
PWA-3117::[PWA] display number of items in cart instead of quantities…

### DIFF
--- a/packages/peregrine/lib/talons/Header/cartTriggerFragments.gql.js
+++ b/packages/peregrine/lib/talons/Header/cartTriggerFragments.gql.js
@@ -4,5 +4,6 @@ export const CartTriggerFragment = gql`
     fragment CartTriggerFragment on Cart {
         id
         total_quantity
+        total_summary_quantity_including_config
     }
 `;

--- a/packages/peregrine/lib/talons/Header/useCartTrigger.js
+++ b/packages/peregrine/lib/talons/Header/useCartTrigger.js
@@ -52,7 +52,7 @@ export const useCartTrigger = props => {
         errorPolicy: 'all'
     });
 
-    const itemCount = data?.cart?.total_quantity || 0;
+    const itemCount = data?.cart?.total_summary_quantity_including_config || 0;
 
     const handleTriggerClick = useCallback(() => {
         // Open the mini cart.

--- a/packages/peregrine/lib/talons/Header/useCartTrigger.js
+++ b/packages/peregrine/lib/talons/Header/useCartTrigger.js
@@ -53,7 +53,7 @@ export const useCartTrigger = props => {
     });
 
     const itemCount = data?.cart?.total_summary_quantity_including_config || 0;
-    
+
     const handleTriggerClick = useCallback(() => {
         // Open the mini cart.
         setMiniCartIsOpen(isOpen => !isOpen);

--- a/packages/peregrine/lib/talons/Header/useCartTrigger.js
+++ b/packages/peregrine/lib/talons/Header/useCartTrigger.js
@@ -53,7 +53,6 @@ export const useCartTrigger = props => {
     });
 
     const itemCount = data?.cart?.total_summary_quantity_including_config || 0;
-
     const handleTriggerClick = useCallback(() => {
         // Open the mini cart.
         setMiniCartIsOpen(isOpen => !isOpen);

--- a/packages/peregrine/lib/talons/Header/useCartTrigger.js
+++ b/packages/peregrine/lib/talons/Header/useCartTrigger.js
@@ -53,6 +53,7 @@ export const useCartTrigger = props => {
     });
 
     const itemCount = data?.cart?.total_summary_quantity_including_config || 0;
+    
     const handleTriggerClick = useCallback(() => {
         // Open the mini cart.
         setMiniCartIsOpen(isOpen => !isOpen);

--- a/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/cartTrigger.spec.js.snap
+++ b/packages/venia-ui/lib/components/Header/__tests__/__snapshots__/cartTrigger.spec.js.snap
@@ -5,7 +5,7 @@ Array [
   <div>
     <button
       aria-expanded={false}
-      aria-label="Toggle mini cart. You have 100 items in your cart."
+      aria-label="Toggle mini cart. You have 0 items in your cart."
       onClick={[Function]}
     >
       <span>
@@ -34,14 +34,11 @@ Array [
           />
         </svg>
       </span>
-      <span>
-        99+
-      </span>
     </button>
   </div>,
   <button
     aria-expanded={false}
-    aria-label="Toggle mini cart. You have 100 items in your cart."
+    aria-label="Toggle mini cart. You have 0 items in your cart."
     onClick={[Function]}
   >
     <span>
@@ -69,9 +66,6 @@ Array [
           d="M16 10a4 4 0 0 1-8 0"
         />
       </svg>
-    </span>
-    <span>
-      99+
     </span>
   </button>,
   <require('../MiniCart')
@@ -86,7 +80,7 @@ Array [
   <div>
     <button
       aria-expanded={false}
-      aria-label="Toggle mini cart. You have 10 items in your cart."
+      aria-label="Toggle mini cart. You have 0 items in your cart."
       onClick={[Function]}
     >
       <span>
@@ -115,14 +109,11 @@ Array [
           />
         </svg>
       </span>
-      <span>
-        10
-      </span>
     </button>
   </div>,
   <button
     aria-expanded={false}
-    aria-label="Toggle mini cart. You have 10 items in your cart."
+    aria-label="Toggle mini cart. You have 0 items in your cart."
     onClick={[Function]}
   >
     <span>
@@ -150,9 +141,6 @@ Array [
           d="M16 10a4 4 0 0 1-8 0"
         />
       </svg>
-    </span>
-    <span>
-      10
     </span>
   </button>,
   <require('../MiniCart')


### PR DESCRIPTION
Preconditions
Leave only Yes or No as the answer

Issue is reproducible on the latest mainline, without Sample Data: Yes
JIRA was checked for similar/duplicated issues: Yes
GitHub project was checked: Yes
[Merchdocs](https://docs.magento.com/user-guide/) and [Devdocs](https://devdocs.magento.com/) were checked: Yes
[Double Check List L3](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=CENG&title=Keywords+for+double+check+during+triage+process) was checked: Yes
Steps to reproduce

Install PWA studio with [ 2.4-develop ]

Check the [ Display Cart Summary ] configuration from [ Store > Configuration > Sales > Checkout > My Cart Link > Display Cart Summary ]. The default value should available as [ Display item quantities ]

Create a simple product from the backend

Add 5 quantities to cart from the above product. The minicart will display like below. Which is correct with the default [ Display Cart Summary ] configuration.

Change the [ Display Cart Summary ] configuration to [ Display number of items in cart ]

Remove items from the shopping cart and again add 5 quantities from the same product

Check the mini-cart product count

Actual results
Minicart still displays [ 5 ].

Expected results
When we set [ Display Cart Summary ] configuration to [ Display number of items in cart ], it should not display the item quantity. The value it should display is [ 1 ], which is the number of unique items in the cart.


Closes [#PWA-3117](https://jira.corp.adobe.com/browse/PWA-3117)

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
