### PR TITLE
DevContainer > Node 14 to 18 LTS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
 	"name": "PWA Studio",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-14",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+	"containerEnv": {
+		"NODE_OPTIONS": "--openssl-legacy-provider"
+	},
 	"forwardPorts": [10000],
 	"postCreateCommand": "yarn install --frozen-lockfile && yarn build && yarn workspace @magento/venia-concept run watch",
 	"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
 		"NODE_OPTIONS": "--openssl-legacy-provider"
 	},
 	"forwardPorts": [10000],
-	"postCreateCommand": "yarn install --frozen-lockfile && yarn build && yarn workspace @magento/venia-concept run watch",
+	"postCreateCommand": "yarn install --frozen-lockfile && yarn build",
+	"postStartCommand": "yarn workspace @magento/venia-concept run watch",
 	"extensions": [
 		"larsroettig.vscode-pwa-studio",
 		"GraphQL.vscode-graphql-syntax"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "develop"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "develop"
-    ]
-}


### PR DESCRIPTION
Node 14 is supported but not recommended, since it's not been maintained anymore.

[PWA Studio supports Node 18 LTS](https://developer.adobe.com/commerce/pwa-studio/tutorials/#check-node-and-yarn-versions), an actively supported version. Ref: https://endoflife.date/nodejs

![Screenshot 2023-09-20 135022](https://github.com/magento/pwa-studio/assets/610598/529ed941-c5dc-4521-b317-12f835f5fa31)
