### PR TITLE
GraphQL cacheable requests always have "Authorization Bearer" header

### DIFF
--- a/packages/peregrine/lib/Apollo/links/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/peregrine/lib/Apollo/links/__tests__/__snapshots__/index.spec.js.snap
@@ -4,7 +4,6 @@ exports[`returns a map with expected keys and values 1`] = `
 Map {
   "MUTATION_QUEUE" => "mutationQueue",
   "RETRY" => "retry",
-  "AUTH" => "auth",
   "GQL_CACHE" => "gqlCache",
   "STORE" => "store",
   "ERROR" => "error",

--- a/packages/peregrine/lib/Apollo/links/__tests__/index.spec.js
+++ b/packages/peregrine/lib/Apollo/links/__tests__/index.spec.js
@@ -7,10 +7,10 @@ jest.mock('@apollo/client', () => ({
     __esModule: true,
     createHttpLink: jest.fn(() => 'http')
 }));
-jest.mock('@magento/peregrine/lib/Apollo/links/authLink', () => ({
-    __esModule: true,
-    default: jest.fn(() => 'auth')
-}));
+// jest.mock('@magento/peregrine/lib/Apollo/links/authLink', () => ({
+//     __esModule: true,
+//     default: jest.fn(() => 'auth')
+// }));
 jest.mock('@magento/peregrine/lib/Apollo/links/errorLink', () => ({
     __esModule: true,
     default: jest.fn(() => 'error')

--- a/packages/peregrine/lib/Apollo/links/authLink.js
+++ b/packages/peregrine/lib/Apollo/links/authLink.js
@@ -1,18 +1,18 @@
 import { setContext } from '@apollo/client/link/context';
-import { BrowserPersistence } from '@magento/peregrine/lib/util';
+// import { BrowserPersistence } from '@magento/peregrine/lib/util';
 
-const storage = new BrowserPersistence();
+// const storage = new BrowserPersistence();
 
 export default function createAuthLink() {
     return setContext((_, { headers }) => {
         // get the authentication token from local storage if it exists.
-        const token = storage.getItem('signin_token');
+        // const token = storage.getItem('signin_token');
 
         // return the headers to the context so httpLink can read them
         return {
             headers: {
                 ...headers,
-                authorization: token ? `Bearer ${token}` : ''
+                // authorization: token ? `Bearer ${token}` : ''
             }
         };
     });

--- a/packages/peregrine/lib/Apollo/links/authLink.js
+++ b/packages/peregrine/lib/Apollo/links/authLink.js
@@ -11,7 +11,7 @@ export default function createAuthLink() {
         // return the headers to the context so httpLink can read them
         return {
             headers: {
-                ...headers,
+                ...headers
                 // authorization: token ? `Bearer ${token}` : ''
             }
         };

--- a/packages/peregrine/lib/Apollo/links/index.js
+++ b/packages/peregrine/lib/Apollo/links/index.js
@@ -54,7 +54,7 @@ const getLinks = apiBase => {
     const links = new Map()
         .set('MUTATION_QUEUE', mutationQueueLink)
         .set('RETRY', retryLink)
-        .set('AUTH', authLink)
+        // .set('AUTH', authLink)
         .set('GQL_CACHE', gqlCacheLink)
         .set('STORE', storeLink)
         .set('ERROR', errorLink)

--- a/packages/peregrine/lib/Apollo/links/index.js
+++ b/packages/peregrine/lib/Apollo/links/index.js
@@ -54,7 +54,7 @@ const getLinks = apiBase => {
     const links = new Map()
         .set('MUTATION_QUEUE', mutationQueueLink)
         .set('RETRY', retryLink)
-        // .set('AUTH', authLink)
+        .set('AUTH', authLink)
         .set('GQL_CACHE', gqlCacheLink)
         .set('STORE', storeLink)
         .set('ERROR', errorLink)

--- a/packages/peregrine/lib/Apollo/links/index.js
+++ b/packages/peregrine/lib/Apollo/links/index.js
@@ -1,6 +1,6 @@
 import { createHttpLink } from '@apollo/client';
 
-import createAuthLink from '@magento/peregrine/lib/Apollo/links/authLink';
+// import createAuthLink from '@magento/peregrine/lib/Apollo/links/authLink';
 import createErrorLink from '@magento/peregrine/lib/Apollo/links/errorLink';
 import createGqlCacheLink from '@magento/peregrine/lib/Apollo/links/gqlCacheLink';
 import createMutationQueueLink from '@magento/peregrine/lib/Apollo/links/mutationQueueLink';
@@ -32,7 +32,7 @@ export const customFetchToShrinkQuery = (uri, options) => {
 };
 
 const getLinks = apiBase => {
-    const authLink = createAuthLink();
+    // const authLink = createAuthLink();
     const storeLink = createStoreLink();
     const errorLink = createErrorLink();
     const retryLink = createRetryLink();
@@ -54,7 +54,7 @@ const getLinks = apiBase => {
     const links = new Map()
         .set('MUTATION_QUEUE', mutationQueueLink)
         .set('RETRY', retryLink)
-        .set('AUTH', authLink)
+        // .set('AUTH', authLink)
         .set('GQL_CACHE', gqlCacheLink)
         .set('STORE', storeLink)
         .set('ERROR', errorLink)


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

 GraphQL cacheable requests always have "Authorization Bearer" header
Steps to test the behaviour :

1- sign up.in Venia.magento.com or any PWA store
2- login
3- check network tab on any page and search for GraphQL requests which should be cached such as CMSPages
4- check the request header you will not find Authorization Bearer header exist
5- Varnish will cache that request's response.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes #https://jira.corp.adobe.com/browse/PWA-3154

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
