### PR TITLE
fix error when getting product thumbnails by url key

### DIFF
--- a/packages/peregrine/lib/talons/OrderHistoryPage/orderRow.gql.js
+++ b/packages/peregrine/lib/talons/OrderHistoryPage/orderRow.gql.js
@@ -11,7 +11,7 @@ export const GET_CONFIGURABLE_THUMBNAIL_SOURCE = gql`
 `;
 
 export const GET_PRODUCT_THUMBNAILS_BY_URL_KEY = gql`
-    query GetProductThumbnailsByURLKey($urlKeys: [String!]!) {
+    query GetProductThumbnailsByURLKey($urlKeys: [String]!) {
         products(filter: { url_key: { in: $urlKeys } }) {
             # eslint-disable-next-line @graphql-eslint/require-id-when-available
             items {


### PR DESCRIPTION
## Description

TODO: Describe your changes in detail here.

## Related Issue

Closes #4307 .

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

1. Login in account
2. Place order with 1 product
3. Delete this product out of magento
4. Go to order history page
5. See no error anymore in console

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
