### PR TITLE
Fixed pagebuilder tab toggle issue

### DIFF
--- a/packages/pagebuilder/lib/ContentTypes/Tabs/tabs.module.css
+++ b/packages/pagebuilder/lib/ContentTypes/Tabs/tabs.module.css
@@ -125,7 +125,7 @@ ul.navigation::-webkit-scrollbar {
 
 .panel {
     min-height: inherit;
-    composes: !empty_hidden from global;
+    composes: empty_hidden from global;
 }
 
 .panelSelected {


### PR DESCRIPTION
## Description

This PR contains the fix for CSS issues in page builder tab content toggle.

Closes #PWA-3356
https://jira.corp.adobe.com/browse/PWA-3356

## Acceptance

### Verification Stakeholders

### Specification

## Verification Steps

Step 1: Create a static content (Either a page or static block) in Magento admin panel
Step 2: Use page builder to edit the content, drag and drop "Tab" inside a row
(Drag and drop the "Row" into the content area if it's not there already)
Step 3: Create multiple tabs to have toggle in storefront
Step 4: Save the content and check the tab(s) in storefront
(Configure the static block/page appropriately so that the content will be visible in storefront)

Current result:
Empty space will be visible on each tab switch

Fix result:
The tab content toggle will work and there won't be any empty space/in-active tab content displayed.

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

## Checklist

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
