### PR TITLE
Added code to display error message from grapqhl response in form

### DIFF
--- a/packages/peregrine/lib/talons/CreateAccount/createAccount.gql.js
+++ b/packages/peregrine/lib/talons/CreateAccount/createAccount.gql.js
@@ -24,6 +24,7 @@ export const CREATE_ACCOUNT = gql`
             # eslint-disable-next-line @graphql-eslint/require-id-when-available
             customer {
                 email
+                is_confirmed
             }
         }
     }

--- a/packages/peregrine/lib/talons/FormError/useFormError.js
+++ b/packages/peregrine/lib/talons/FormError/useFormError.js
@@ -14,7 +14,27 @@ export const useFormError = props => {
                   defaultMessage:
                       'An error has occurred. Please check the input and try again.'
               });
-        return deriveErrorMessage(errors, defaultErrorMessage);
+
+        const firstError = errors
+        .filter(error => error !== null||undefined)
+        .map(error => Array.isArray(error) ? error[0] : error)
+        .find(message => message);
+        var graphqlErrorMessage;
+
+        if (firstError) {
+            var category = firstError.graphQLErrors?.find(extensions => extensions).extensions?.category;
+            category = category ? category
+            .split('-')
+            .map((word, index) => index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1))
+            .join('') : null;
+            const errorId = category ? 'formError.'+category : 'formError.responseError';
+            graphqlErrorMessage = formatMessage({
+                id: errorId,
+                defaultMessage: firstError.message
+            });
+        }
+
+        return (graphqlErrorMessage) ? deriveErrorMessage(errors, graphqlErrorMessage) : deriveErrorMessage(errors, defaultErrorMessage);
     }, [errors, formatMessage, allowErrorMessages]);
 
     return {

--- a/packages/peregrine/lib/talons/FormError/useFormError.js
+++ b/packages/peregrine/lib/talons/FormError/useFormError.js
@@ -22,24 +22,8 @@ export const useFormError = props => {
         var graphqlErrorMessage;
 
         if (firstError) {
-            var category = firstError.graphQLErrors?.find(
-                extensions => extensions
-            ).extensions?.category;
-            category = category
-                ? category
-                      .split('-')
-                      .map((word, index) =>
-                          index === 0
-                              ? word
-                              : word.charAt(0).toUpperCase() + word.slice(1)
-                      )
-                      .join('')
-                : null;
-            const errorId = category
-                ? 'formError.' + category
-                : 'formError.responseError';
             graphqlErrorMessage = formatMessage({
-                id: errorId,
+                id: 'formError.responseError',
                 defaultMessage: firstError.message
             });
         }

--- a/packages/peregrine/lib/talons/FormError/useFormError.js
+++ b/packages/peregrine/lib/talons/FormError/useFormError.js
@@ -16,25 +16,37 @@ export const useFormError = props => {
               });
 
         const firstError = errors
-        .filter(error => error !== null||undefined)
-        .map(error => Array.isArray(error) ? error[0] : error)
-        .find(message => message);
+            .filter(error => error !== null || undefined)
+            .map(error => (Array.isArray(error) ? error[0] : error))
+            .find(message => message);
         var graphqlErrorMessage;
 
         if (firstError) {
-            var category = firstError.graphQLErrors?.find(extensions => extensions).extensions?.category;
-            category = category ? category
-            .split('-')
-            .map((word, index) => index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1))
-            .join('') : null;
-            const errorId = category ? 'formError.'+category : 'formError.responseError';
+            var category = firstError.graphQLErrors?.find(
+                extensions => extensions
+            ).extensions?.category;
+            category = category
+                ? category
+                      .split('-')
+                      .map((word, index) =>
+                          index === 0
+                              ? word
+                              : word.charAt(0).toUpperCase() + word.slice(1)
+                      )
+                      .join('')
+                : null;
+            const errorId = category
+                ? 'formError.' + category
+                : 'formError.responseError';
             graphqlErrorMessage = formatMessage({
                 id: errorId,
                 defaultMessage: firstError.message
             });
         }
 
-        return (graphqlErrorMessage) ? deriveErrorMessage(errors, graphqlErrorMessage) : deriveErrorMessage(errors, defaultErrorMessage);
+        return graphqlErrorMessage
+            ? deriveErrorMessage(errors, graphqlErrorMessage)
+            : deriveErrorMessage(errors, defaultErrorMessage);
     }, [errors, formatMessage, allowErrorMessages]);
 
     return {

--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -199,6 +199,7 @@
     "forgotPasswordPage.header": "Forgot Your Password?",
     "forgotPasswordPage.title": "Forgot Your Password?",
     "formError.errorMessage": "An error has occurred. Please check the input and try again.",
+    "formError.graphqlAuthenticationEmailNotConfirmed": "Your account is created, You must confirm your account. Please check your email for the confirmation link.",
     "formSubmissionSuccessful.recoverPasswordText": "Recover Password",
     "formSubmissionSuccessful.textMessage": "If there is an account associated with {email} you will receive an email with a link to change your password.",
     "galleryItem.unavailableProduct": "Currently unavailable for purchase.",

--- a/packages/venia-ui/i18n/en_US.json
+++ b/packages/venia-ui/i18n/en_US.json
@@ -199,7 +199,6 @@
     "forgotPasswordPage.header": "Forgot Your Password?",
     "forgotPasswordPage.title": "Forgot Your Password?",
     "formError.errorMessage": "An error has occurred. Please check the input and try again.",
-    "formError.graphqlAuthenticationEmailNotConfirmed": "Your account is created, You must confirm your account. Please check your email for the confirmation link.",
     "formSubmissionSuccessful.recoverPasswordText": "Recover Password",
     "formSubmissionSuccessful.textMessage": "If there is an account associated with {email} you will receive an email with a link to change your password.",
     "galleryItem.unavailableProduct": "Currently unavailable for purchase.",


### PR DESCRIPTION
## Description

This PR contains the fix for customer login flow when require email confirmation is enabled.
Appropriate error message response from the graphql on customer creation will be shown in the form

This change requires few changes in Magento backend code.
Backend PR:
https://github.com/magento-commerce/magento2-pwa/pull/61

Closes #PWA-3367
https://jira.corp.adobe.com/browse/PWA-3367

## Acceptance

### Verification Stakeholders

### Specification

## Verification Steps

Step 1: Enable customer email confirmation from Magento Admin panel -> Stores -> Customer -> Customer Configuration -> Create New Account Options -> Require Emails Confirmation -> Yes and save the config
Step 2: In PWA store view add a product to cart and the go to Checkout page -> Sign In-> Create an account or Header -> Sign in -> Create an account
Step 3: Enter all the necessary details for the new customer account (Email should not exist already in the website)
Step 4: Click create an account button

Current result:
General error is thrown instead of more relevant error
(Error: An error has occurred. Please check the input and try again.)

Fix result:
Actual message from Magento graphql will be shown.
(Your account is created, You must confirm your account. Please check your email for the confirmation link.)

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

## Checklist

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
