### PR TITLE
Update configAggregator.js Sanetize DOM Text Interpreted As HTML 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "caniuse-lite": "~1.0.30001335",
     "path-to-regexp": "^8.2.0",
     "qs": "^6.13.0",
-    "setimmediate": "^1.0.5"
+    "setimmediate": "^1.0.5",
     "dompurify": "^2.3.8"
 
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "path-to-regexp": "^8.2.0",
     "qs": "^6.13.0",
     "setimmediate": "^1.0.5"
+    "dompurify": "^2.3.8"
+
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "~7.4.4",

--- a/packages/pagebuilder/lib/ContentTypes/Block/configAggregator.js
+++ b/packages/pagebuilder/lib/ContentTypes/Block/configAggregator.js
@@ -1,8 +1,16 @@
+import DOMPurify from 'dompurify';
 import { getAdvanced } from '../../utils';
 
 export default node => {
+    // Get the raw HTML content from the first child node
+    const rawHTML = node.childNodes[0] ? node.childNodes[0].innerHTML : '';
+
+    // Sanitize the raw HTML using DOMPurify
+    const sanitizedHTML = DOMPurify.sanitize(rawHTML);
+
     return {
-        richContent: node.childNodes[0] ? node.childNodes[0].innerHTML : '',
+        // Return the sanitized HTML content, along with the result from getAdvanced
+        richContent: sanitizedHTML,
         ...getAdvanced(node)
     };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,6 +8935,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^2.3.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
+  integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
+
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Sanitize HTML content using DOMPurify before returning it in richContent. This ensures safe rendering of potentially untrusted HTML, protecting against XSS attacks. The innerHTML of the first child node is sanitized before being returned, improving security.

