### PR TITLE
Update index.js sanetize DOM Text Interpreted As HTML 

### DIFF
--- a/venia-integration-tests/src/fixtures/googleMapApi/index.js
+++ b/venia-integration-tests/src/fixtures/googleMapApi/index.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 export const createGoogleMapApi = currentMapApi => {
     return {
         maps: {
@@ -85,7 +86,7 @@ export const createGoogleMapApi = currentMapApi => {
 
                 open(map) {
                     map.infoWindowContainer.style.maxWidth = this.maxWidth;
-                    map.infoWindowContainer.innerHTML = this.content;
+                    map.infoWindowContainer.innerHTML = DOMPurify.sanitize(this.content);
                 }
 
                 close() {


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Sanitize HTML content using DOMPurify before returning it in richContent. This ensures safe rendering of potentially untrusted HTML, protecting against XSS attacks. The innerHTML of the first child node is sanitized before being returned, improving security.