### PR TITLE
Update htmlStringImgUrlConverter.js Sanetize DOM Text Interpreted As HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "caniuse-lite": "~1.0.30001335",
     "path-to-regexp": "^8.2.0",
     "qs": "^6.13.0",
-    "setimmediate": "^1.0.5"
+    "setimmediate": "^1.0.5",
+    "dompurify": "^2.3.8"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "~7.4.4",

--- a/packages/peregrine/lib/util/htmlStringImgUrlConverter.js
+++ b/packages/peregrine/lib/util/htmlStringImgUrlConverter.js
@@ -1,6 +1,6 @@
 import makeUrl from './makeUrl';
 import resolveLinkProps from './resolveLinkProps';
-
+import DOMPurify from 'dompurify';
 /**
  * Modifies html string images to use makeUrl as source and resolves links to use internal path.
  *
@@ -9,7 +9,7 @@ import resolveLinkProps from './resolveLinkProps';
  */
 const htmlStringImgUrlConverter = htmlString => {
     const temporaryElement = document.createElement('div');
-    temporaryElement.innerHTML = htmlString;
+    temporaryElement.innerHTML = DOMPurify.sanitize(htmlString);
     for (const imgElement of temporaryElement.getElementsByTagName('img')) {
         imgElement.src = makeUrl(imgElement.src, {
             type: 'image-wysiwyg',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,6 +8935,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^2.3.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
+  integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
+
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Sanitize HTML content using DOMPurify before returning it in richContent. This ensures safe rendering of potentially untrusted HTML, protecting against XSS attacks. The innerHTML of the first child node is sanitized before being returned, improving security.
