### PR TITLE
Prevent Cart Creation for Guest User and Add Functionality To Create …

### DIFF
--- a/packages/peregrine/lib/context/cart.js
+++ b/packages/peregrine/lib/context/cart.js
@@ -1,15 +1,14 @@
 import React, {
     createContext,
     useContext,
-    useEffect,
     useMemo,
     useCallback
 } from 'react';
 import { connect } from 'react-redux';
-import { useMutation } from '@apollo/client';
-import gql from 'graphql-tag';
+//import { useMutation } from '@apollo/client';
+//import gql from 'graphql-tag';
 
-import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
+//import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
 import actions from '../store/actions/cart/actions';
 import * as asyncActions from '../store/actions/cart/asyncActions';
 import bindActionCreators from '../util/bindActionCreators';
@@ -62,8 +61,8 @@ const CartContextProvider = props => {
         return [derivedCartState, cartApi];
     }, [cartApi, cartState, derivedDetails]);
 
-    const [fetchCartId] = useMutation(CREATE_CART_MUTATION);
-    const fetchCartDetails = useAwaitQuery(CART_DETAILS_QUERY);
+    //const [fetchCartId] = useMutation(CREATE_CART_MUTATION);
+    //const fetchCartDetails = useAwaitQuery(CART_DETAILS_QUERY);
 
     // Storage listener to force a state update if cartId changes from another browser tab.
     const storageListener = useCallback(() => {
@@ -77,13 +76,13 @@ const CartContextProvider = props => {
 
     useEventListener(globalThis, 'storage', storageListener);
 
-    useEffect(() => {
-        // cartApi.getCartDetails initializes the cart if there isn't one.
-        cartApi.getCartDetails({
-            fetchCartId,
-            fetchCartDetails
-        });
-    }, [cartApi, fetchCartDetails, fetchCartId]);
+    // useEffect(() => {
+    //     // cartApi.getCartDetails initializes the cart if there isn't one.
+    //     cartApi.getCartDetails({
+    //         fetchCartId,
+    //         fetchCartDetails
+    //     });
+    // }, [cartApi, fetchCartDetails, fetchCartId]);
 
     return (
         <CartContext.Provider value={contextValue}>
@@ -111,18 +110,18 @@ export const useCartContext = () => useContext(CartContext);
  * queries to talons/hooks. This is an exception to the rule because it would
  * be unecessarily complex to pass these queries to the context provider.
  */
-const CREATE_CART_MUTATION = gql`
-    mutation createCart {
-        cartId: createEmptyCart
-    }
-`;
+// const CREATE_CART_MUTATION = gql`
+//     mutation createCart {
+//         cartId: createEmptyCart
+//     }
+// `;
 
-const CART_DETAILS_QUERY = gql`
-    query checkUserIsAuthed($cartId: String!) {
-        cart(cart_id: $cartId) {
-            # The purpose of this query is to check that the user is authorized
-            # to query on the current cart. Just fetch "id" to keep it small.
-            id
-        }
-    }
-`;
+// const CART_DETAILS_QUERY = gql`
+//     query checkUserIsAuthed($cartId: String!) {
+//         cart(cart_id: $cartId) {
+//             # The purpose of this query is to check that the user is authorized
+//             # to query on the current cart. Just fetch "id" to keep it small.
+//             id
+//         }
+//     }
+// `;

--- a/packages/peregrine/lib/context/cart.js
+++ b/packages/peregrine/lib/context/cart.js
@@ -1,9 +1,4 @@
-import React, {
-    createContext,
-    useContext,
-    useMemo,
-    useCallback
-} from 'react';
+import React, { createContext, useContext, useMemo, useCallback } from 'react';
 import { connect } from 'react-redux';
 //import { useMutation } from '@apollo/client';
 //import gql from 'graphql-tag';

--- a/packages/peregrine/lib/talons/Gallery/__tests__/useAddToCartButton.spec.js
+++ b/packages/peregrine/lib/talons/Gallery/__tests__/useAddToCartButton.spec.js
@@ -1,21 +1,33 @@
 import React from 'react';
 import { useMutation } from '@apollo/client';
 import { useHistory } from 'react-router-dom';
+import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
+import { useCartContext } from '../../../context/cart';
 
 import createTestInstance from '../../../util/createTestInstance';
 import { useAddToCartButton } from '../useAddToCartButton';
 import { useEventingContext } from '../../../context/eventing';
+import { act } from 'react-test-renderer';
 
 jest.mock('@apollo/client', () => ({
-    useMutation: jest.fn().mockReturnValue([jest.fn()])
+    gql: jest.fn(),
+    useMutation: jest.fn(),
+    useApolloClient: jest.fn()
+}));
+
+jest.mock('@magento/peregrine/lib/hooks/useAwaitQuery', () => ({
+    useAwaitQuery: jest.fn()
 }));
 
 jest.mock('react-router-dom', () => ({
     useHistory: jest.fn().mockReturnValue({ push: jest.fn() })
 }));
 
+// Make sure useCartContext returns [state, api] so cartApi.getCartDetails exists
 jest.mock('../../../context/cart', () => ({
-    useCartContext: jest.fn().mockReturnValue([{ cartId: '1234' }])
+    useCartContext: jest
+        .fn()
+        .mockReturnValue([{ cartId: '1234' }, { getCartDetails: jest.fn() }])
 }));
 
 jest.mock('../addToCart.gql', () => ({ ADD_ITEM: 'Add Item GQL Mutation' }));
@@ -40,9 +52,39 @@ afterAll(() => {
     global.console.error = originalError;
 });
 
+beforeEach(() => {
+    // Provide safe defaults so hook renders without per-test overrides
+    useMutation.mockClear();
+    useMutation.mockReturnValue([jest.fn()]); // default single-function tuple
+
+    // Ensure useAwaitQuery is a mock function
+    if (useAwaitQuery && useAwaitQuery.mockClear) {
+        useAwaitQuery.mockClear();
+        useAwaitQuery.mockReturnValue(jest.fn());
+    }
+
+    // Ensure useCartContext returns both state and api (if tests want to override later)
+    if (useCartContext && useCartContext.mockClear) {
+        useCartContext.mockClear();
+        useCartContext.mockReturnValue([
+            { cartId: '1234' },
+            { getCartDetails: jest.fn() }
+        ]);
+    }
+
+    // Reset eventing mock
+    if (useEventingContext && useEventingContext.mockClear) {
+        useEventingContext.mockClear();
+        useEventingContext.mockReturnValue([{}, { dispatch: jest.fn() }]);
+    }
+
+    // Reset console spies
+    warn.mockClear();
+    error.mockClear();
+});
+
 const Component = props => {
     const talonProps = useAddToCartButton(props);
-
     return <i talonProps={talonProps} />;
 };
 
@@ -53,7 +95,6 @@ const getTalonProps = props => {
 
     const update = newProps => {
         tree.update(<Component {...{ ...props, ...newProps }} />);
-
         return root.findByType('i').props.talonProps;
     };
 
@@ -88,91 +129,66 @@ const defaultProps = {
 
 test('returns proper shape', () => {
     const { talonProps } = getTalonProps(defaultProps);
-
     expect(talonProps).toMatchSnapshot();
 });
 
 test('returns isDisabled true if product type is virtual', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            __typename: 'VirtualProduct'
-        }
+        item: { ...defaultProps.item, __typename: 'VirtualProduct' }
     });
-
     expect(talonProps.isDisabled).toBeTruthy();
 });
 
 test('returns isDisabled true if product type is downloadable', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            __typename: 'DownloadableProduct'
-        }
+        item: { ...defaultProps.item, __typename: 'DownloadableProduct' }
     });
-
     expect(talonProps.isDisabled).toBeTruthy();
 });
 
 test('returns isDisabled true if product type is grouped', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            __typename: 'GroupedProduct'
-        }
+        item: { ...defaultProps.item, __typename: 'GroupedProduct' }
     });
-
     expect(talonProps.isDisabled).toBeTruthy();
 });
 
 test('returns isDisabled true if product type is bundle', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            __typename: 'BundleProduct'
-        }
+        item: { ...defaultProps.item, __typename: 'BundleProduct' }
     });
-
     expect(talonProps.isDisabled).toBeTruthy();
 });
 
 test('returns isDisabled false if product type is simple', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            __typename: 'SimpleProduct'
-        }
+        item: { ...defaultProps.item, __typename: 'SimpleProduct' }
     });
-
     expect(talonProps.isDisabled).toBeFalsy();
 });
 
 test('returns isInStock true if stock_status is IN_STOCK', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            stock_status: 'IN_STOCK'
-        }
+        item: { ...defaultProps.item, stock_status: 'IN_STOCK' }
     });
-
     expect(talonProps.isInStock).toBeTruthy();
 });
 
 test('returns isInStock false if stock_status is not IN_STOCK', () => {
     const { talonProps } = getTalonProps({
-        item: {
-            ...defaultProps.item,
-            stock_status: 'OUT_STOCK'
-        }
+        item: { ...defaultProps.item, stock_status: 'OUT_STOCK' }
     });
-
     expect(talonProps.isInStock).toBeFalsy();
 });
 
 describe('testing handleAddToCart', () => {
     test('should add to cart if item is a simple product', async () => {
-        const addToCartMutation = jest.fn();
-        useMutation.mockReturnValueOnce([addToCartMutation]);
+        const fetchCartIdMock = jest.fn(); // for CREATE_CART_MUTATION (first useMutation)
+        const addToCartMutation = jest.fn(); // for ADD_ITEM (second useMutation)
+
+        useMutation
+            .mockReturnValueOnce([fetchCartIdMock])
+            .mockReturnValueOnce([addToCartMutation]);
 
         const { talonProps } = getTalonProps({
             item: {
@@ -182,7 +198,9 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
         expect(addToCartMutation).toHaveBeenCalled();
         expect(addToCartMutation.mock.calls[0]).toMatchInlineSnapshot(`
@@ -209,10 +227,7 @@ describe('testing handleAddToCart', () => {
 
     test('should navigate to PDP page if item is a configurable product', async () => {
         const push = jest.fn();
-        const history = {
-            push
-        };
-        useHistory.mockReturnValueOnce(history);
+        useHistory.mockReturnValueOnce({ push });
 
         const { talonProps } = getTalonProps({
             item: {
@@ -224,7 +239,9 @@ describe('testing handleAddToCart', () => {
             urlSuffix: '.suffix'
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
         expect(push).toHaveBeenCalledWith('/configurable_product.suffix');
     });
@@ -238,14 +255,13 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
-        expect(warn).toHaveBeenCalled();
-        expect(warn.mock.calls[0]).toMatchInlineSnapshot(`
-            Array [
-              "Unsupported product type unable to handle.",
-            ]
-        `);
+        expect(warn).toHaveBeenCalledWith(
+            'Unsupported product type unable to handle.'
+        );
     });
 
     test('should console warn if item is a grouped product', async () => {
@@ -257,14 +273,13 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
-        expect(warn).toHaveBeenCalled();
-        expect(warn.mock.calls[0]).toMatchInlineSnapshot(`
-            Array [
-              "Unsupported product type unable to handle.",
-            ]
-        `);
+        expect(warn).toHaveBeenCalledWith(
+            'Unsupported product type unable to handle.'
+        );
     });
 
     test('should console warn if item is a virtual product', async () => {
@@ -276,14 +291,13 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
-        expect(warn).toHaveBeenCalled();
-        expect(warn.mock.calls[0]).toMatchInlineSnapshot(`
-            Array [
-              "Unsupported product type unable to handle.",
-            ]
-        `);
+        expect(warn).toHaveBeenCalledWith(
+            'Unsupported product type unable to handle.'
+        );
     });
 
     test('should console warn if item is a downloadable product', async () => {
@@ -295,20 +309,23 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
-        expect(warn).toHaveBeenCalled();
-        expect(warn.mock.calls[0]).toMatchInlineSnapshot(`
-            Array [
-              "Unsupported product type unable to handle.",
-            ]
-        `);
+        expect(warn).toHaveBeenCalledWith(
+            'Unsupported product type unable to handle.'
+        );
     });
 
     test('should console error if the mutation fails', async () => {
+        const fetchCartIdMock = jest.fn();
         const errorMessage = 'Something went wrong';
         const addToCartMutation = jest.fn().mockRejectedValueOnce(errorMessage);
-        useMutation.mockReturnValueOnce([addToCartMutation]);
+
+        useMutation
+            .mockReturnValueOnce([fetchCartIdMock])
+            .mockReturnValueOnce([addToCartMutation]);
 
         const { talonProps } = getTalonProps({
             item: {
@@ -318,20 +335,23 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
-        expect(error).toHaveBeenCalledWith(errorMessage);
+        expect(error).toHaveBeenLastCalledWith(errorMessage);
     });
 
     test('should dispatch event', async () => {
         const mockDispatch = jest.fn();
+        useEventingContext.mockReturnValue([{}, { dispatch: mockDispatch }]);
 
-        useEventingContext.mockReturnValue([
-            {},
-            {
-                dispatch: mockDispatch
-            }
-        ]);
+        const fetchCartIdMock = jest.fn();
+        const addToCartMutation = jest.fn();
+
+        useMutation
+            .mockReturnValueOnce([fetchCartIdMock])
+            .mockReturnValueOnce([addToCartMutation]);
 
         const { talonProps } = getTalonProps({
             item: {
@@ -341,10 +361,11 @@ describe('testing handleAddToCart', () => {
             }
         });
 
-        await talonProps.handleAddToCart();
+        await act(async () => {
+            await talonProps.handleAddToCart();
+        });
 
-        expect(mockDispatch).toBeCalledTimes(1);
-
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
         expect(mockDispatch.mock.calls[0][0]).toMatchSnapshot();
     });
 });

--- a/packages/peregrine/lib/talons/Gallery/useAddToCartButton.js
+++ b/packages/peregrine/lib/talons/Gallery/useAddToCartButton.js
@@ -1,11 +1,13 @@
 import { useCallback, useState } from 'react';
-import { useMutation } from '@apollo/client';
+import { useMutation, gql } from '@apollo/client';
 import { useHistory } from 'react-router-dom';
 
 import { useCartContext } from '../../context/cart';
 import { useEventingContext } from '../../context/eventing';
 import resourceUrl from '../../util/makeUrl';
 import operations from './addToCart.gql';
+import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
+import BrowserPersistence from '../../util/simplePersistence';
 
 /**
  * @param {String} props.item.uid - uid of item
@@ -29,12 +31,32 @@ const UNSUPPORTED_PRODUCT_TYPES = [
     'DownloadableProduct'
 ];
 
+const CREATE_CART_MUTATION = gql`
+    mutation createCart {
+        cartId: createEmptyCart
+    }
+`;
+
+const CART_DETAILS_QUERY = gql`
+    query checkUserIsAuthed($cartId: String!) {
+        cart(cart_id: $cartId) {
+            id
+        }
+    }
+`;
+
 export const useAddToCartButton = props => {
     const { item, urlSuffix } = props;
 
     const [, { dispatch }] = useEventingContext();
 
     const [isLoading, setIsLoading] = useState(false);
+
+    const [cartState, cartApi] = useCartContext();
+    const { cartId } = cartState;
+
+    const [fetchCartId] = useMutation(CREATE_CART_MUTATION);
+    const fetchCartDetails = useAwaitQuery(CART_DETAILS_QUERY);
 
     const isInStock = item.stock_status === 'IN_STOCK';
 
@@ -52,9 +74,29 @@ export const useAddToCartButton = props => {
 
     const history = useHistory();
 
-    const [{ cartId }] = useCartContext();
+    //const [{ cartId }] = useCartContext();
 
     const [addToCart] = useMutation(operations.ADD_ITEM);
+
+    // helper: ensure we have a valid cartId before adding
+    const ensureCartId = useCallback(async () => {
+        console.log('ensureCartId is called');
+        let newCartId = cartId;
+        if (!newCartId) {
+            console.log('No cart ID found, creating a new cart...');
+            await cartApi.getCartDetails({
+                fetchCartId,
+                fetchCartDetails
+            });
+
+            newCartId = new BrowserPersistence().getItem('cartId');
+
+            if (!newCartId) {
+                throw new Error('Failed to create a new cart');
+            }
+        }
+        return newCartId;
+    }, [cartId, cartApi, fetchCartId, fetchCartDetails]);
 
     const handleAddToCart = useCallback(async () => {
         try {
@@ -62,11 +104,33 @@ export const useAddToCartButton = props => {
                 setIsLoading(true);
 
                 const quantity = 1;
+                let newCartId;
+                // let newCartId = cartId;
+                // if (!cartId) {
+                //     console.log("cart ID is not defined hence calling cart creation");
+                //     // Create cart and update cart context + localStorage
+                //     await cartApi.getCartDetails({
+                //         fetchCartId,
+                //         fetchCartDetails
+                //     });
+
+                //     // Get updated cartId from storage or context after creation
+                //     newCartId = new BrowserPersistence().getItem('cartId');
+
+                //     if (!newCartId) {
+                //         throw new Error('Failed to create a new cart');
+                //     }
+
+                //     // Now you can safely use newCartId instead of cartId
+                // }
 
                 if (item.uid) {
+                    // ensure cart right before addToCart
+                    newCartId = await ensureCartId();
+
                     await addToCart({
                         variables: {
-                            cartId,
+                            cartId: newCartId,
                             cartItem: {
                                 quantity,
                                 entered_options: [
@@ -80,9 +144,12 @@ export const useAddToCartButton = props => {
                         }
                     });
                 } else {
+                    // ensure cart right before addToCart
+                    newCartId = await ensureCartId();
+
                     await addToCart({
                         variables: {
-                            cartId,
+                            cartId: newCartId,
                             cartItem: {
                                 quantity,
                                 sku: item.sku
@@ -94,7 +161,7 @@ export const useAddToCartButton = props => {
                 dispatch({
                     type: 'CART_ADD_ITEM',
                     payload: {
-                        cartId,
+                        cartId: newCartId,
                         sku: item.sku,
                         name: item.name,
                         pricing: {
@@ -130,7 +197,15 @@ export const useAddToCartButton = props => {
         } catch (error) {
             console.error(error);
         }
-    }, [productType, addToCart, cartId, item, dispatch, history, urlSuffix]);
+    }, [
+        productType,
+        addToCart,
+        item,
+        dispatch,
+        history,
+        urlSuffix,
+        ensureCartId
+    ]);
 
     return {
         handleAddToCart,

--- a/packages/peregrine/lib/talons/ProductFullDetail/__tests__/useProductFullDetail.spec.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/__tests__/useProductFullDetail.spec.js
@@ -25,7 +25,8 @@ jest.mock('@apollo/client', () => ({
         },
         loading: false,
         error: false
-    }))
+    })),
+    useApolloClient: jest.fn()
 }));
 
 jest.mock('@magento/peregrine/lib/context/user', () => {

--- a/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
+++ b/packages/peregrine/lib/talons/ProductFullDetail/useProductFullDetail.js
@@ -1,6 +1,6 @@
 import { useCallback, useState, useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { useMutation, useQuery } from '@apollo/client';
+import { useMutation, useQuery, gql } from '@apollo/client';
 import { useCartContext } from '@magento/peregrine/lib/context/cart';
 import { useUserContext } from '@magento/peregrine/lib/context/user';
 
@@ -13,6 +13,8 @@ import mergeOperations from '../../util/shallowMerge';
 import defaultOperations from './productFullDetail.gql';
 import { useEventingContext } from '../../context/eventing';
 import { getOutOfStockVariants } from '@magento/peregrine/lib/util/getOutOfStockVariants';
+import { useAwaitQuery } from '@magento/peregrine/lib/hooks/useAwaitQuery';
+import BrowserPersistence from '../../util/simplePersistence';
 
 const INITIAL_OPTION_CODES = new Map();
 const INITIAL_OPTION_SELECTIONS = new Map();
@@ -257,7 +259,9 @@ export const useProductFullDetail = props => {
 
     const isSupportedProductType = isSupported(productType);
 
-    const [{ cartId }] = useCartContext();
+    //const [{ cartId }] = useCartContext();
+    const [cartState, cartApi] = useCartContext();
+    const { cartId } = cartState;
     const [{ isSignedIn }] = useUserContext();
     const { formatMessage } = useIntl();
 
@@ -411,6 +415,42 @@ export const useProductFullDetail = props => {
         return selectedOptions;
     }, [attributeIdToValuesMap, optionSelections]);
 
+    // ===== Cart creation wiring (same approach as useAddToCartButton.js) =====
+    const CREATE_CART_MUTATION = gql`
+        mutation createCart {
+            cartId: createEmptyCart
+        }
+    `;
+
+    const CART_DETAILS_QUERY = gql`
+        query checkUserIsAuthed($cartId: String!) {
+            cart(cart_id: $cartId) {
+                id
+            }
+        }
+    `;
+
+    const [fetchCartId] = useMutation(CREATE_CART_MUTATION);
+    const fetchCartDetails = useAwaitQuery(CART_DETAILS_QUERY);
+
+    const ensureCartId = useCallback(async () => {
+        let newCartId = cartId;
+        if (!newCartId) {
+            await cartApi.getCartDetails({
+                fetchCartId,
+                fetchCartDetails
+            });
+
+            newCartId = new BrowserPersistence().getItem('cartId');
+            if (!newCartId) {
+                throw new Error('Failed to create a new cart');
+            }
+        }
+        return newCartId;
+    }, [cartId, cartApi, fetchCartId, fetchCartDetails]);
+
+    // =======================================================================
+
     const handleAddToCart = useCallback(
         async formValues => {
             const { quantity } = formValues;
@@ -435,7 +475,7 @@ export const useProductFullDetail = props => {
 
                 if (isSupportedProductType) {
                     const variables = {
-                        cartId,
+                        cartId, // will be replaced by ensured cart id below
                         parentSku: payload.parentSku,
                         product: payload.item,
                         quantity: payload.quantity,
@@ -484,6 +524,10 @@ export const useProductFullDetail = props => {
                 }
 
                 try {
+                    //Ensure cart exists *right before* mutation runs
+                    const ensuredCartId = await ensureCartId();
+                    variables.cartId = ensuredCartId;
+
                     await addProductToCart({ variables });
 
                     const selectedOptionsLabels =
@@ -498,7 +542,7 @@ export const useProductFullDetail = props => {
                     dispatch({
                         type: 'CART_ADD_ITEM',
                         payload: {
-                            cartId,
+                            cartId: ensuredCartId,
                             sku: product.sku,
                             name: product.name,
                             pricing: product.price,
@@ -527,7 +571,8 @@ export const useProductFullDetail = props => {
             product,
             productPrice,
             productType,
-            selectedOptionsArray
+            selectedOptionsArray,
+            ensureCartId
         ]
     );
 


### PR DESCRIPTION
…Cart only when Guest User Adds Product to Cart

<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento/pwa-studio/blob/main/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

Worked on preventing the cart creation when a guest user lands on any of the webpage.
Worked to create the cart only when a product is added to cart. 

TODO: Describe your changes in detail here.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->

Closes #[PWA-3550](https://jira.corp.adobe.com/browse/PWA-3550).

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

<!-- Examples: -->
<!-- 1. Verify user is able to apply filters on category page -->
<!-- 2. Verify user is able to apply filters on search page -->

#### Test scenario(s) for any existing impacted features/areas

<!-- Examples: -->
<!-- Verify user is able to sort data after applying filters on category page -->
<!-- Verify user is able to sort data after applying filters on search page -->

#### Test scenario(s) for any Magento Backend Supported Configurations

<!-- Examples: -->

<!-- Update default Sort value in backend and repeat above scenarios -->

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
