### PR TITLE
fix: hardcoded ".html" URL suffix on Wishlist item product links

### DIFF
--- a/packages/peregrine/lib/talons/WishlistPage/__tests__/__snapshots__/useWishlist.spec.js.snap
+++ b/packages/peregrine/lib/talons/WishlistPage/__tests__/__snapshots__/useWishlist.spec.js.snap
@@ -9,6 +9,7 @@ Object {
   "isLoading": false,
   "isOpen": true,
   "items": Array [],
+  "storeConfig": null,
 }
 `;
 
@@ -21,6 +22,7 @@ Object {
   "isLoading": false,
   "isOpen": true,
   "items": Array [],
+  "storeConfig": null,
 }
 `;
 
@@ -37,5 +39,6 @@ Object {
       "name": "item1",
     },
   ],
+  "storeConfig": null,
 }
 `;

--- a/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlist.spec.js
+++ b/packages/peregrine/lib/talons/WishlistPage/__tests__/useWishlist.spec.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import { act } from 'react-test-renderer';
-import { useLazyQuery } from '@apollo/client';
+import { useLazyQuery, useQuery, gql } from '@apollo/client';
 
 import createTestInstance from '../../../util/createTestInstance';
 import { useWishlist } from '../useWishlist';
 
 jest.mock('../wishlist.gql', () => ({
     getCustomerWishlistItems: jest.fn().mockName('getCustomerWishlistItems')
+}));
+
+jest.mock('../wishlistConfig.gql', () => ({
+    getWishlistConfigQuery: jest.fn().mockName('getWishlistConfigQuery')
 }));
 
 jest.mock('@apollo/client', () => {
@@ -19,7 +23,9 @@ jest.mock('@apollo/client', () => {
     const queryFetcher = jest.fn().mockResolvedValue(true);
 
     return {
-        useLazyQuery: jest.fn().mockReturnValue([queryFetcher, queryConfig])
+        gql: jest.fn(strings => strings.join('')),
+        useLazyQuery: jest.fn().mockReturnValue([queryFetcher, queryConfig]),
+        useQuery: jest.fn().mockReturnValue({ data: undefined })
     };
 });
 

--- a/packages/peregrine/lib/talons/WishlistPage/useWishlist.js
+++ b/packages/peregrine/lib/talons/WishlistPage/useWishlist.js
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLazyQuery } from '@apollo/client';
+import { useLazyQuery, useQuery } from '@apollo/client';
 import mergeOperations from '../../util/shallowMerge';
 import defaultOperations from './wishlist.gql';
+import wishlistConfigOperations from './wishlistConfig.gql';
 
 /**
  * @function
@@ -12,7 +13,11 @@ import defaultOperations from './wishlist.gql';
  */
 export const useWishlist = (props = {}) => {
     const { id, itemsCount, isCollapsed } = props;
-    const operations = mergeOperations(defaultOperations, props.operations);
+    const operations = mergeOperations(
+        defaultOperations,
+        wishlistConfigOperations,
+        props.operations
+    );
 
     const [page, setPage] = useState(1);
     const [isOpen, setIsOpen] = useState(!isCollapsed);
@@ -31,7 +36,17 @@ export const useWishlist = (props = {}) => {
             }
         }
     );
+
     const { data, error, loading, fetchMore } = queryResult;
+
+    const { data: storeConfigData } = useQuery(
+        operations.getWishlistConfigQuery,
+        {
+            fetchPolicy: 'cache-and-network'
+        }
+    );
+
+    const storeConfig = storeConfigData ? storeConfigData.storeConfig : null;
 
     const handleContentToggle = () => {
         setIsOpen(currentValue => !currentValue);
@@ -126,7 +141,8 @@ export const useWishlist = (props = {}) => {
         error,
         isLoading: !!loading,
         isFetchingMore,
-        handleLoadMore
+        handleLoadMore,
+        storeConfig
     };
 };
 
@@ -145,4 +161,5 @@ export const useWishlist = (props = {}) => {
  * @property {Boolean} isLoading Boolean which represents if is in loading state
  * @property {Boolean} isFetchingMore Boolean which represents if is in loading more state
  * @property {Function} handleLoadMore Callback to load more items
+ * @property {Object} storeConfig Store configuration used by the wishlist (e.g. product_url_suffix)
  */

--- a/packages/peregrine/lib/talons/WishlistPage/wishlistConfig.gql.ce.js
+++ b/packages/peregrine/lib/talons/WishlistPage/wishlistConfig.gql.ce.js
@@ -6,6 +6,7 @@ export const GET_WISHLIST_CONFIG = gql`
         storeConfig {
             store_code
             magento_wishlist_general_is_enabled
+            product_url_suffix
         }
     }
 `;

--- a/packages/peregrine/lib/talons/WishlistPage/wishlistConfig.gql.ee.js
+++ b/packages/peregrine/lib/talons/WishlistPage/wishlistConfig.gql.ee.js
@@ -8,6 +8,7 @@ export const GET_WISHLIST_CONFIG = gql`
             magento_wishlist_general_is_enabled
             enable_multiple_wishlists
             maximum_number_of_wishlists
+            product_url_suffix
         }
     }
 `;

--- a/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlistItem.spec.js.snap
+++ b/packages/venia-ui/lib/components/WishlistPage/__tests__/__snapshots__/wishlistItem.spec.js.snap
@@ -14,7 +14,7 @@ exports[`it renders a configurable wishlist item 1`] = `
 >
   <a
     className="name"
-    href="undefined.html"
+    href="/shoggoth-shirt.test_suffix"
   >
     <div
       className="root container"
@@ -136,7 +136,7 @@ exports[`it renders a simple wishlist item 1`] = `
 >
   <a
     className="name"
-    href="undefined.html"
+    href="/shoggoth-shirt.test_suffix"
   >
     <div
       className="root container"

--- a/packages/venia-ui/lib/components/WishlistPage/__tests__/wishlistItem.spec.js
+++ b/packages/venia-ui/lib/components/WishlistPage/__tests__/wishlistItem.spec.js
@@ -28,6 +28,7 @@ const baseProps = {
     item: {
         product: {
             name: 'Shoggoth Shirt',
+            url_key: 'shoggoth-shirt',
             price_range: {
                 maximum_price: {
                     final_price: {
@@ -38,6 +39,9 @@ const baseProps = {
             },
             stock_status: 'IN_STOCK'
         }
+    },
+    storeConfig: {
+        product_url_suffix: '.test_suffix'
     }
 };
 
@@ -78,6 +82,7 @@ test('it renders a configurable wishlist item', () => {
     });
 
     const configurableProps = {
+        ...baseProps,
         item: {
             ...baseProps.item,
             configurable_options: [

--- a/packages/venia-ui/lib/components/WishlistPage/wishlist.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlist.js
@@ -31,7 +31,8 @@ const Wishlist = props => {
         items,
         isLoading,
         isFetchingMore,
-        handleLoadMore
+        handleLoadMore,
+        storeConfig
     } = talonProps;
 
     const classes = useStyle(defaultClasses, props.classes);
@@ -77,7 +78,11 @@ const Wishlist = props => {
 
     const contentMessageElement = itemsCount ? (
         <Fragment>
-            <WishlistItems items={items} wishlistId={id} />
+            <WishlistItems
+                items={items}
+                wishlistId={id}
+                storeConfig={storeConfig}
+            />
             {loadMoreButton}
         </Fragment>
     ) : (

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistItem.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistItem.js
@@ -3,6 +3,7 @@ import { Trash2 } from 'react-feather';
 import { useIntl } from 'react-intl';
 import { useToasts } from '@magento/peregrine';
 import { useWishlistItem } from '@magento/peregrine/lib/talons/WishlistPage/useWishlistItem';
+import resourceUrl from '@magento/peregrine/lib/util/makeUrl';
 
 import { useStyle } from '../../classify';
 import Icon from '../Icon';
@@ -12,7 +13,7 @@ import Price from '../Price';
 import defaultClasses from './wishlistItem.module.css';
 
 const WishlistItem = props => {
-    const { item } = props;
+    const { item, storeConfig } = props;
 
     const { configurable_options: configurableOptions = [], product } = item;
     const {
@@ -103,10 +104,16 @@ const WishlistItem = props => {
         </button>
     ) : null;
 
+    const productUrlSuffix = storeConfig && storeConfig.product_url_suffix;
+
+    const productLink = resourceUrl(
+        `/${product.url_key}${productUrlSuffix || ''}`
+    );
+
     return (
         <div className={rootClass} data-cy="wishlistItem-root">
             <a
-                href={product.url_key + '.html'}
+                href={productLink}
                 className={classes.name}
                 data-cy="wishlistItem-productLink"
             >

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistItems.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistItems.js
@@ -7,7 +7,7 @@ import WishlistItem from './wishlistItem';
 import AddToCartDialog from '../AddToCartDialog';
 
 const WishlistItems = props => {
-    const { items, wishlistId } = props;
+    const { items, wishlistId, storeConfig } = props;
 
     const talonProps = useWishlistItems();
     const {
@@ -26,6 +26,7 @@ const WishlistItems = props => {
                     item={item}
                     onOpenAddToCartDialog={handleOpenAddToCartDialog}
                     wishlistId={wishlistId}
+                    storeConfig={storeConfig}
                 />
             );
         });

--- a/packages/venia-ui/lib/components/WishlistPage/wishlistItems.js
+++ b/packages/venia-ui/lib/components/WishlistPage/wishlistItems.js
@@ -30,7 +30,7 @@ const WishlistItems = props => {
                 />
             );
         });
-    }, [handleOpenAddToCartDialog, items, wishlistId]);
+    }, [handleOpenAddToCartDialog, items, wishlistId, storeConfig]);
 
     return (
         <Fragment>


### PR DESCRIPTION
## Description

Wishlist item product links were built by concatenating url_key with a hardcoded .html suffix, ignoring the product_url_suffix value set in Magento's store configuration (Stores → Configuration → Catalog → Search Engine Optimization). On stores using a suffix other than .html (or no suffix), every wishlist item link resolved to a 404. The fix reads product_url_suffix from storeConfig and uses it when constructing the product URL, consistent with how product links are built elsewhere in the storefront.

## Related Issue

Closes #4618

## Acceptance

<!-- The people and processes this pull request needs before it is merged. -->
<!-- These fields are not required when opening the pull request, but they -->
<!-- should be populated after code review. -->

### Verification Stakeholders

<!-- People who must verify that this solves the attached issue. -->

### Specification

<!-- Changes to `upward-spec` and/or `upward-js` packages must be reviewed -->
<!-- by `UPWARD-PHP` maintainers to ensure continued compatibility -->

## Verification Steps

<!-- During code review and QA we will try to ensure there are no bugs introduced by this change -->
<!-- So, we request that you add a detailed test plan on what needs to be checked before this PR gets merged -->
<!-- Feel free to update this after submitting the PR as you discover new scenarios -->
<!-- As part of review/QA we may also add or update the test plan if necessary-->

#### Test scenario(s) for direct fix/feature

1. In the Magento admin set the Product URL Suffix (Stores → Configuration → Catalog → Search Engine Optimization) to something other than .html (e.g. empty string or .htm) and flush caches.
2. Sign in as a customer and navigate to My Wish List (/wishlist).
3. Verify that each wishlist item's product link uses the configured suffix and navigates to the correct product detail page.

#### Test scenario(s) for any existing impacted features/areas

With the default .html suffix configured, verify that wishlist item links still resolve correctly to the product detail page.

#### Test scenario(s) for any Magento Backend Supported Configurations

1. Repeat the above scenarios with both Adobe Commerce (EE) and Magento Open Source (CE) store configurations.
2. Repeat with an empty product URL suffix (no suffix at all).

#### Is Browser/Device testing needed?

<!-- Example: -->
<!-- Yes, browser testing is needed as X UI component may be impacted on <browser> -->
<!-- Yes, device testing is needed as X UI component may be impacted on <mobile|desktop|etc> -->

#### Any ad-hoc/edge case scenarios that need to be considered?

<!-- Example: -->
<!-- Apply all filters to get 0 results and then remove filters to see respective products -->

## Screenshots / Screen Captures (if appropriate)

## Breaking Changes (if any)

<!-- If there are any breaking changes in this PR, please describe them here-->
<!-- For example: -->
<!-- * Removed Foo prop fro component Bar -->

## Checklist

<!--- Go over all the following points, and make sure you've done anything necessary -->

-   I have added tests to cover my changes, if necessary.
-   I have added translations for new strings, if necessary.
-   I have updated the documentation accordingly, if necessary.
